### PR TITLE
Menus should not be on two lines by accident.

### DIFF
--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -46,7 +46,7 @@
 {% block site_footer %}
 <footer class="footer">
   <div class="row">
-    <div class="small-12 medium-6 columns">
+    <div class="small-12 medium-7 columns">
       <p class="footer-links">
         <a href="{% url 'home_view' %}">Home</a>
         <a href="{% url 'about_view' %}">About</a>


### PR DESCRIPTION
(Same goes for the orphaning of 'democracy' which is embarrassing for everyone given this is a _democracy_ club project.)

Before:
![screen shot 2016-04-30 at 17 09 37](https://cloud.githubusercontent.com/assets/17229/14937185/4b81f8ec-0ef7-11e6-90df-a65b701ed770.png)

After:


![screen shot 2016-04-30 at 17 09 55](https://cloud.githubusercontent.com/assets/17229/14937189/60dd0006-0ef7-11e6-9bc9-f8b069621b21.png)