### PR TITLE
Update homepage meta to be a bit clearer

### DIFF
--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-{% block page_title %}Enter your postcode{% endblock page_title %}
-{% block og_title %}Enter your postcode{% endblock og_title %}
+{% block base_title %}Who Can I Vote For?{% endblock base_title %}
+{% block og_title %}Who Can I Vote For?{% endblock og_title %}
 
 
 {% block content %}


### PR DESCRIPTION
The og:title is the most prominent bit of information in the facebook
share, so I’m not really sure about 912fc244.