### PR TITLE
Lose the ref to 2016 on the homepage

### DIFF
--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -8,7 +8,7 @@
 <section class="columns large-6 large-centered">
   <div style="margin-top:2rem;">
     {% block pre_post_code_copy %}
-      <p style="font-size: 1.4rem;">Everyone in the UK had an election on 5 May 2016.</p>
+      <p style="font-size: 1.4rem;">Decisions are made by those who show up.</p>
       <p>Find out about the elections in your area by entering your postcode below.</p>
     {% endblock %}
   </div>

--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -8,8 +8,7 @@
 <section class="columns large-6 large-centered">
   <div style="margin-top:2rem;">
     {% block pre_post_code_copy %}
-      <p style="font-size: 1.4rem;">Decisions are made by those who show up.</p>
-      <p>Find out about the elections in your area by entering your postcode below.</p>
+      <p>Find out about elections in your area by entering your postcode below.</p>
     {% endblock %}
   </div>
 


### PR DESCRIPTION
This is one suggestion...there might be other things that are better!

Or maybe just remove that line entirely...