### PR TITLE
Perhaps one link to Wikipedia per page is enough.

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -88,14 +88,6 @@
           </a>
         </dd>
         {% endif %}
-        {% if object.wikipedia_url %}
-        <dt>Wikipedia</dt>
-        <dd>
-          <a href="{{ object.wikipedia_url }}" title="{{ object.name }}'s Wikipedia page">
-            {{ object.wikipedia_url }}
-          </a>
-        </dd>
-        {% endif %}
 
         <dt>Google</dt>
         <dd><a href='https://www.google.co.uk/search?q=%22{{object.name}}%22+candidate' target="_blank">


### PR DESCRIPTION
As pointed out by @andylolz - given there is an entire Wikipedia card, perhaps there is limited use in then displaying the wikipedia URL?