### PR TITLE
Add short intros for candidates, use as meta description.

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -5,11 +5,10 @@
 
 
 {% block og_image %}{% if object.photo_url %}{{ object.photo_url }}{% endif %}{% endblock og_image %}
-
-
 {% block og_title %}{{ object.name }}{% endblock og_title %}
 {% block page_title %}{{ object.name }}{% endblock page_title %}
-{% block og_description %}Standing for '{{ object.posts.all.0.label }}' in {{ object.posts.all.0.election.name }}{% endblock og_description %}
+{% block page_description %}{{ object.text_intro }}. Get the latest information on this candidate at WhoCanIVoteFor?{% endblock page_description %}
+{% block og_description %}{{ object.text_intro }}. Get the latest information on this candidate at WhoCanIVoteFor?{% endblock og_description %}
 
 {% block content %}
   <div class="card person_banner">
@@ -19,17 +18,11 @@
       <img src="{{ object.photo_url }}" class="person_photo" alt="profile photo of {{ object.name }}">
     {% endif %}
 
-    {% if object.current_posts %}
-      {% if object.current_posts.0.party.party_name == "Independent" %}
-      <p>Standing in the <a href="{{ object.current_posts.0.election.get_absolute_url }}">{{ object.current_posts.0.election.name }}</a> as an independent candidate.
-      {% else %}
-      <p>Standing in the <a href="{{ object.current_posts.0.election.get_absolute_url }}">{{ object.current_posts.0.election.name }}</a> for the
-      <a href="{{ object.current_posts.0.party.get_absolute_url }}">{{ object.current_posts.0.party.party_name }}</a></p>
-      {% endif %}
-    {% endif %}
+    <p>
+    {{ object.intro|safe }}. Learn more below.
+    </p>
 
   </div>
-
 
   {% if object.statement_to_voters %}
   <div class="card">

--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -11,7 +11,7 @@
     </title>
     <link rel="canonical" href="{{ CANONICAL_URL }}{{ request.path }}" />
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="WhoCanIVoteFor"/>
-    <meta name="description" content="Who can I vote for - find out the latest information about about elections, candidates and polling stations near you." />
+    <meta name="description" content="{% block page_description %}Find out about elections, candidates and polling stations with Democracy Club's WhoCanIVoteFor?{% endblock page_description %}" />
     <meta property="og:site_name" content="WhoCanIVoteFor?" />
     <meta property="og:url" content="{{ CANONICAL_URL }}{{ request.path }}" />
     <meta property="fb:app_id" content="262795130596272" />
@@ -20,7 +20,7 @@
     <meta property="og:image" content="{{ CANONICAL_URL }}{% block og_image %}{% static "dc_theme/images/logo-large.png" %}{% endblock og_image %}" />
     <meta property="og:image:width" content="{{ site_logo_width }}">
     <meta property="og:title" content="{% block og_title %}WhoCanIVoteFor?{% endblock og_title %}" />
-    <meta property="og:description" content="{% block og_description %}Find out about elections, candidates and polling stations with Democracy Club's WhoCanIVoteFor tool.{% endblock og_description %}" />
+    <meta property="og:description" content="{% block og_description %}Find out about elections, candidates and polling stations with Democracy Club's WhoCanIVoteFor?{% endblock og_description %}" />
     {% block page_meta %}{% endblock page_meta %}
 
 


### PR DESCRIPTION
Fixes #149 - provide a friendly information intro for people who arrive without
much context from Google. Also use the same text as the meta description, so it
displays as a snippet in search results.

Text agreed with Joe and now includes details of the area, which isn't there at
the moment. Also now has a friendly intro for candidates from past elections, which
is blank at the moment.

<img width="929" alt="screen shot 2017-05-24 at 13 45 01" src="https://cloud.githubusercontent.com/assets/78156/26403746/3db12d7e-4087-11e7-8f62-7c3160ee783f.png">
<img width="933" alt="screen shot 2017-05-24 at 13 45 53" src="https://cloud.githubusercontent.com/assets/78156/26403766/5285ed16-4087-11e7-8667-c81e25fd6153.png">


The text is identical in the intro sentence and in the meta description, I've just
stripped out HTML tags in the meta tag.

We should probably use the same block for both the meta description and the
og:description consistently across the app: this is a bigger change so have
ticketed in #159.