### PR TITLE
fixes problems with wheredoivote

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -12,21 +12,9 @@
     </p>
   {% else %}
     {% if polling_station.custom_finder %}
-
-    <!-- hacky fix if custom_finder is a url to election office/council website rather than an object -->
-      {% if not polling_station.custom_finder.base_url %}
         <p>You can find your polling station by
         <a href="{{ polling_station.custom_finder }}">
         following this link</a>.
-      {% elif polling_station.custom_finder.can_pass_postcode %}
-        <p>You can find your polling station by
-        <a href="{{ polling_station.custom_finder.base_url}}{{polling_station.custom_finder.encoded_postcode}}">
-        following this link</a>.
-      {% else %}
-        <p>You can find your polling station by
-          <a href="{{ polling_station.custom_finder.base_url }}">following this link and entering your postcode</a>.
-        </p>
-    {% endif %}
     {% else %}
       <p>You should get a "poll card" through the post telling you where to vote.</p>
       <p>If you haven't got one, or aren't sure where to vote, you should call

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -12,15 +12,21 @@
     </p>
   {% else %}
     {% if polling_station.custom_finder %}
-      {% if polling_station.custom_finder.can_pass_postcode %}
+
+    <!-- hacky fix if custom_finder is a url to election office/council website rather than an object -->
+      {% if not polling_station.custom_finder.base_url %}
+        <p>You can find your polling station by
+        <a href="{{ polling_station.custom_finder }}">
+        following this link</a>.
+      {% elif polling_station.custom_finder.can_pass_postcode %}
         <p>You can find your polling station by
         <a href="{{ polling_station.custom_finder.base_url}}{{polling_station.custom_finder.encoded_postcode}}">
-        following this link</a>
+        following this link</a>.
       {% else %}
         <p>You can find your polling station by
-          <a href="{{ polling_station.custom_finder.base_url}}">following this link and entering your postcode</a>
+          <a href="{{ polling_station.custom_finder.base_url }}">following this link and entering your postcode</a>.
         </p>
-      {% endif %}
+    {% endif %}
     {% else %}
       <p>You should get a "poll card" through the post telling you where to vote.</p>
       <p>If you haven't got one, or aren't sure where to vote, you should call

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -132,11 +132,8 @@
   {% endfor %}
 {% endfor %}
 
-
-{% if polling_station.polling_station_known or polling_station.custom_finder%}
 {# Add this at the top of the page if it's known, or at the bottom if it's not #}
 {% include "elections/includes/_polling_place.html" %}
-{% endif %}
 
 <div class="card">
   {% include "notifications/includes/election_notification_form.html" %}


### PR DESCRIPTION
This should fix two issues with `_polling_place` cards for `postcode_view` I think this might have been due to changes made at some point to wheredoivote api @symroe?

1. Where a postcode did not have a known polling station, currently no card shows e.g. https://whocanivotefor.co.uk/elections/sa126hf/ because `polling_place.custom_finder` is `null`. The changes to `postcode_view.html` fixes this.

2. Where a postcode does not have a known polling station but `custom_finder` is a url _string_ (rather than the expected _object_), the current  results in the postcode_view giving no link to the third party site e.g. https://whocanivotefor.co.uk/elections/BT546RQ/. The changes to `_polling_place.html` fixes this. (Ok, it's a bit hacky in that it doesn't test for a url but it works.)

Tested that still working where there is full information for a polling station e.g https://whocanivotefor.co.uk/elections/sa126yr/. There may be more situations (?) but I don't know about them.