### PR TITLE
Remind NI voters to bring ID and how to find out more info

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -1,4 +1,5 @@
 {# TODO this is a mess! Clean it up somehow #}
+{% load postcode_tags %}
 <div class="card" id="polling_place">
 
   <h2>Where to vote</h2>
@@ -18,12 +19,21 @@
     {% else %}
       <p>You should get a "poll card" through the post telling you where to vote.</p>
       <p>If you haven't got one, or aren't sure where to vote, you should call
-      {% if polling_station.council %}
+      {% if postcode|ni_postcode %}
+        the Electoral Office
+        {% if polling_station.council%}
+          on <a href="tel:{{ polling_station.council.phone }}">
+        {{ polling_station.council.phone }}</a>.</p>
+        {% endif %}
+      {% elif polling_station.council %}
         {{ polling_station.council.name }} on <a href="tel:{{ polling_station.council.phone }}">
         {{ polling_station.council.phone }}</a></p>
       {% else %}
         your local council.</p>
       {% endif %}
+    {% endif %}
+    {% if postcode|ni_postcode %}
+      <p>You will need photographic identification.</p>
     {% endif %}
   {% endif %}
 

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -33,8 +33,15 @@
       {% endif %}
     {% endif %}
     {% if postcode|ni_postcode %}
-      <p>You will need photographic identification.</p>
+        <p>You will need photographic identification.</p>
     {% endif %}
+  {% endif %}
+  {% if postcode|ni_postcode %}
+      <p><a href="http://www.eoni.org.uk/Vote/Voting-at-a-polling-place" target="_top">
+      Read more about voting in Northern Ireland</a>.</p>
+    {% else %}
+      <a href="https://www.gov.uk/voting-in-the-uk/polling-stations" target="_top">
+      Read more about voting in Great Britain</a>.</p>
   {% endif %}
 
   {% if not polling_station.custom_finder and polling_station.polling_station_known %}

--- a/wcivf/apps/elections/templatetags/postcode_tags.py
+++ b/wcivf/apps/elections/templatetags/postcode_tags.py
@@ -1,0 +1,11 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+import re
+
+register = template.Library()
+
+@register.filter(name='ni_postcode')
+@stringfilter
+def ni_postcode(postcode):
+    if re.match('^BT.*', postcode):
+        return True


### PR DESCRIPTION
1. remind anyone with a 'BT' (Northern Ireland) regional postcode to bring their photo identification

2. add a link to the official 'more information on voting' (which is specific to either NI or GB)

a lá [WDIV/#928](https://github.com/DemocracyClub/UK-Polling-Stations/pull/928)