### PR TITLE
remove extraneous closing brace from meta description

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -1,1 +1,1 @@
-{% autoescape off %}See all {{ person_posts|length }} candidates in {{ object.post.label }} in the {{ object.election.name }} on {{ object.election.election_date }}: {% for pp in person_posts %}{{ pp.person.name|safe }} ({{ pp.party.party_name }}) {% endfor %}{% endautoescape %}}
+{% autoescape off %}See all {{ person_posts|length }} candidates in {{ object.post.label }} in the {{ object.election.name }} on {{ object.election.election_date }}: {% for pp in person_posts %}{{ pp.person.name|safe }} ({{ pp.party.party_name }}) {% endfor %}{% endautoescape %}


### PR DESCRIPTION
fixes

![screenshot at 2017-11-29 14 39 33](https://user-images.githubusercontent.com/6025893/33380517-4d6551fc-d513-11e7-95f3-2e8ea04ea3d7.png)
