### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 after_success:
   - coveralls
 before_cache:
-    - rm -f .tox/py34-django110/log/*.log
+    - rm -f .tox/py34-django111/log/*.log
     - rm -f .cache/pip/log/*.log
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ sudo: false
 language: python
 python:
   - '3.4'
+  - '3.5'
 addons:
-  postgresql: '9.3'
+  postgresql: '9.5'
   apt:
     packages:
-      - postgresql-9.3-postgis-2.3
+      - postgresql-9.5-postgis-2.3
 services:
   - redis-server
 cache:
@@ -18,7 +19,7 @@ cache:
     - $HOME/.tox/
     - .tox
 install:
-  - pip install tox coveralls
+  - pip install tox tox-travis coveralls
 before_script:
   - psql -U postgres -c "create extension postgis"
 script:
@@ -27,6 +28,7 @@ after_success:
   - coveralls
 before_cache:
     - rm -f .tox/py34-django111/log/*.log
+    - rm -f .tox/py35-django111/log/*.log
     - rm -f .cache/pip/log/*.log
 notifications:
   slack:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,11 +1,11 @@
-Django>=1.10,<1.11
+Django>=1.11,<2.0
 
 six
 psycopg2==2.6.1
 requests==2.9.1
 django-model-utils==2.4
 django-markdown-deux
-django-localflavor==1.2
+django-localflavor==2.0
 django-extensions
 djangorestframework==3.6.3
 django-redis

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 Django>=1.11,<2.0
 
 six
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 requests==2.9.1
 django-model-utils==2.4
 django-markdown-deux

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Ensure you add to .travis.yml if you add here
 # envlist = {py27,py34}-django{18,19,110}
-envlist = py34-django110
+envlist = py34-django111
 skipsdist = True
 
 
@@ -14,9 +14,9 @@ deps = -r{toxinidir}/requirements/testing.txt
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 commands =
+    python manage.py --version
     python manage.py check
     pytest --flake
     pytest
     pytest --cov-report= --cov=wcivf
     # pytest --pep8
-

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,5 @@ commands =
     python manage.py --version
     python manage.py check
     pytest --flake
-    pytest
     pytest --cov-report= --cov=wcivf
     # pytest --pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,19 @@
 [tox]
 # Ensure you add to .travis.yml if you add here
 # envlist = {py27,py34}-django{18,19,110}
-envlist = py34-django111
+envlist = py{34,35}-django111
 skipsdist = True
 
-
+[tox:travis]
+3.4 = py34
+3.5 = py35
 
 [testenv]
 # usedevelop = true
 # whitelist_externals =
 #     psql
+passenv = *
 deps = -r{toxinidir}/requirements/testing.txt
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 commands =
     python manage.py --version


### PR DESCRIPTION
As far as I can tell, there doesn't seem to be anything we need to change to do this beyond package updates. The tests pass and I can't find anything in the

* core user journeys
* admin interface or
* [scheduled management commands](https://github.com/DemocracyClub/who_deploy/blob/master/crontab.yml)

that throws a deprecation warning or stops working after the upgrade so this _should_ be good to go.

Making the jump to 2.0 looks like it is going to involve more friction due to changes to the middleware interface and FK behaviour which I have not addressed here because they are not needed to move to 1.11.

Closes #241