### PR TITLE
Don't expect the area keys from YNR any more

### DIFF
--- a/wcivf/apps/elections/managers.py
+++ b/wcivf/apps/elections/managers.py
@@ -59,8 +59,8 @@ class PostManager(models.Manager):
                 'role': post_dict['role'],
                 'group': post_dict['group'],
                 'organization': post_dict['organization']['name'],
-                'area_name': post_dict['area']['name'],
-                'area_id': post_dict['area']['identifier'],
+                'area_name': post_dict['label'],
+                'area_id': post_dict['id'],
             }
         )
 


### PR DESCRIPTION
Future commits will:

1. Remove the use an Area at all
2. Use the ballot_paper_id from YNR

However this commit will fix the importer for the time being.