### PR TITLE
Update dc_signup_form to 2.0.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ django-debug-toolbar
 gocardless==0.5.3
 
 git+git://github.com/DemocracyClub/dc_base_theme.git@39c3588e7f29e83c9f77dbba0083cd0811321811
-git+https://github.com/DemocracyClub/dc_signup_form.git@1.0.0
+git+https://github.com/DemocracyClub/dc_signup_form.git@2.0.0
 libsass
 djangorestframework-jsonp
 feedparser


### PR DESCRIPTION
2.0.0 drops support for Django < 1.10, Adds support for Django 2.0 and drops support for Postgres < 9.4

This dependency can be safely upgraded on the 'client' installs independently of upgrading the main website ( https://github.com/DemocracyClub/Website/pull/102 ) because the API does not change in 2.0.0. All the BC-breaks are just platform compatibility