### PR TITLE
update gunicorn

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
 -r base.txt
 
-gunicorn==19.4.5
+gunicorn==19.8.1


### PR DESCRIPTION
19.4.5 has known vuln: https://nvd.nist.gov/vuln/detail/CVE-2018-1000164

In general, I'd like to get this repo using automatic dependency updates. Dependabot seems to have been quite a good solution to attacking the problem in smaller chunks on YNR. Maybe once that one is up-to-date we should use the same approach on this repo? Probably doubling the amount that needs reviewing every day at this stage is not such a great idea.