### PR TITLE
Only delete LocalParty objects for current elections

### DIFF
--- a/wcivf/apps/parties/management/commands/import_local_parties.py
+++ b/wcivf/apps/parties/management/commands/import_local_parties.py
@@ -23,8 +23,9 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, **options):
-        # Delete all data first, as rows in the source might have been deleted
-        LocalParty.objects.all().delete()
+        # Delete all data from non-current elections first,
+        # as rows in the source might have been deleted
+        LocalParty.objects.filter(post_election__election__current=True).delete()
         with open(options["filename"], "r") as fh:
             reader = csv.DictReader(fh)
             for row in reader:


### PR DESCRIPTION
This is a bit of a hack, as we don't have a good way to manage local
parties.

We don't want to delete the 2018 parties from candidates, as they're
still useful. But we have different sheets for 2018 and 2019.

At some point, this should be done properly, but for now, just take the
2019 sheet and leave the data from the 2018 sheet as it is.