### PR TITLE
Install Sentry

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,3 +22,4 @@ git+git://github.com/DemocracyClub/dc_base_theme.git@0.3.8
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.0.0
 djangorestframework-jsonp==1.0.2
 feedparser==5.2.1
+sentry-sdk==0.7.7


### PR DESCRIPTION
Fixes #267 

The set up seems a little different to before, so most of this work goes on at https://github.com/DemocracyClub/who_deploy/commit/00b36f6b746e2eec816c165daf3ace047c0fdb57