### PR TITLE
use better words for electoral divisions

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -165,7 +165,9 @@ class PostElection(models.Model):
             return "ward"
         if election_type == "parl":
             return "constituency"
-        return ""
+        if election_type == "europarl":
+            return "region"
+        return "area"
 
     def friendly_name(self):
         # TODO Take more info from YNR/EE about the election

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -73,7 +73,7 @@
       <p>
         {% if postelection.election.in_past %}
         <strong>{{ postelection.people|length }} candidates</strong> stood in
-        {{ postelection.post.label }}&nbsp;constituency.
+        {{ postelection.post.label }}&nbsp;{{ postelection.get_name_suffix }}.
         {% else %}
           {# Display different messages depending on the number of candidates #}
           {# Case: No candidates for a contested election #}
@@ -89,7 +89,7 @@
               {% if 'mayor' in postelection.election.slug %}
               {{ postelection.election.nice_election_name }}.
               {% else %}
-              {{ postelection.post.label }} ward.
+              {{ postelection.post.label }} {{ postelection.get_name_suffix }}.
               {% endif %}
 
               {% if postelection.winner_count and postelection.election.voting_system_id == 'FPTP' %}
@@ -101,7 +101,7 @@
             {# Case: Candidates and the post is NOT locked (add CTA) #}
               The official candidate list has not yet been published.
               However, we expect at least <strong>{{ postelection.people|length }} candidate{{postelection.people|pluralize}}</strong>
-              to stand in the {{ postelection.post.label }} ward.
+              to stand in the {{ postelection.post.label }} {{ postelection.get_name_suffix }}.
 
               You can help improve this page: <a href="{{ postelection.ynr_link }}">
                 add information about candidates to our database</a>.


### PR DESCRIPTION
1. EU parl areas are called 'regions'
2. If we don't have a special word set, return 'area' instead of empty string

This fixes various silly issues like

![Screenshot at 2019-04-22 13-28-11](https://user-images.githubusercontent.com/6025893/56500790-37166580-6504-11e9-8f33-f32cbad80ded.png)

![Screenshot at 2019-04-22 13-26-16](https://user-images.githubusercontent.com/6025893/56500781-354ca200-6504-11e9-9159-1008db61d839.png)

Thought for future (not now): I wonder if it would be sensible for Every Election to store the correct word for the type of division (constituency, region, ward, division, etc) as we need to use it in lots of place.
