### PR TITLE
don't attempt to set "geo" key if location not known

### DIFF
--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -94,9 +94,10 @@ class PostcodeiCalView(
             )
             if polling_station.get("polling_station_known"):
                 geometry = polling_station["polling_station"]["geometry"]
-                event["geo"] = "{};{}".format(
-                    geometry["coordinates"][0], geometry["coordinates"][1]
-                )
+                if geometry:
+                    event["geo"] = "{};{}".format(
+                        geometry["coordinates"][0], geometry["coordinates"][1]
+                    )
                 properties = polling_station["polling_station"]["properties"]
                 event["location"] = vText(
                     "{}, {}".format(


### PR DESCRIPTION
This fixes `'NoneType' object is not subscriptable` in the calendar appointment view if we know the station address but couldn't geocode point.