### PR TITLE
Add a missing dash to the 'add information' sentence

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -324,7 +324,7 @@
 
       {% if object.cta_example_details %}
       - such as {{ object.name }}'s
-      {{ object.cta_example_details|join:", " }}
+      {{ object.cta_example_details|join:", " }} -
       {% endif %}
       please use our crowdsourcing website to add it.</p>
     <a href="{{ object.get_ynr_url }}update/" class="link-button">


### PR DESCRIPTION
Before:

```
If you can add information that should be on this page - such as <candidate>'s CV, homepage, twitter account please use our crowdsourcing website to add it.
```

After:

```
If you can add information that should be on this page - such as <candidate>'s CV, homepage, twitter account - please use our crowdsourcing website to add it.
```