### PR TITLE
Fix SoPN publish date comparison

### DIFF
--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -50,7 +50,8 @@
       {% if object.expected_sopn_date and not object.election.in_past %}
         <p>
         The official candidate list
-        {% if object.expected_sopn_date|date:"j F Y" <= current_day %}
+        {% now "Y-m-d" as today %}
+        {% if object.expected_sopn_date|date:"Y-m-d" <= today %}
         should have been
         {% else %}
         should be


### PR DESCRIPTION
Annoyingly, I missed this one.

The date comparison wasn't using YYYY-MM-DD which works for direct inequality comparisons, but was using the long format used in the copy.

I noticed this checking the Forest of Dean local election on live:
![Screen Shot 2019-05-09 at 17 10 21](https://user-images.githubusercontent.com/460299/57468927-5db2fb00-727d-11e9-8f63-53e96fff0e5b.png)

The example cases I chose during local testing must have, by pure chance, not hit this bug.