### PR TITLE
Lookup PostElection objects using ballot_paper_id

### DIFF
--- a/wcivf/apps/elections/managers.py
+++ b/wcivf/apps/elections/managers.py
@@ -60,8 +60,7 @@ class PostManager(models.Manager):
 
         for election_dict in post_dict["elections"]:
             election = Election.objects.get(slug=election_dict["id"])
-            kwargs = {}
-            kwargs["ballot_paper_id"] = election_dict["ballot_paper_id"]
+            kwargs = {"election": election, "post": post}
 
             kwargs["locked"] = election_dict.get("candidates_locked", False)
             if kwargs["locked"]:
@@ -72,9 +71,9 @@ class PostManager(models.Manager):
                 kwargs["winner_count"] = election_dict["winner_count"]
 
             kwargs["cancelled"] = election_dict["cancelled"]
-
             PostElection.objects.update_or_create(
-                election=election, post=post, defaults=kwargs
+                ballot_paper_id=election_dict["ballot_paper_id"],
+                defaults=kwargs,
             )
 
         return (post, created)


### PR DESCRIPTION
This deals with the case that the ballot has been added in the past but
the election or post object has changed. The post will normally be the
thing to change, especially if the division was assigned a GSS code over
the time the election was active, and EE was updated.

Using the ballot_paper_id as a look up will mean that the ballot always
gets imported with the post and election from EE, but it might cause
orphan posts to exist.