### PR TITLE
[RFC] Linked data proof-of-concept

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
@@ -1,0 +1,7 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Person",
+    "name": "{{ person.name }}"
+}
+</script>

--- a/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
@@ -3,6 +3,10 @@
     "@context": "http://schema.org/",
     "@type": "Person",
     "name": "{{ person.name }}",
-    "url": "{{ CANONICAL_URL }}{{ person.get_absolute_url }}"
+    "url": "{{ CANONICAL_URL }}{{ person.get_absolute_url }}",
+    "worksFor": {
+        "@type": "Organization",
+        "name": "{{ party.party_name }}"
+    }
 }
 </script>

--- a/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_candidate.html
@@ -2,6 +2,7 @@
 {
     "@context": "http://schema.org/",
     "@type": "Person",
-    "name": "{{ person.name }}"
+    "name": "{{ person.name }}",
+    "url": "{{ CANONICAL_URL }}{{ person.get_absolute_url }}"
 }
 </script>

--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -3,7 +3,9 @@
     "@context": "http://schema.org/",
     "@type": "Event",
     "name": "{{ election.election.name }}",
-    "startDate" : "{{ election.election.election_date }}",
+    "description": "{{ election.friendly_name }}",
+    "startDate": "{{ election.election.election_date }}",
+    "endDate": "{{ election.election.election_date }}",
     "url" : "{{ CANONICAL_URL }}{{ election.get_absolute_url }}",
     "location" : {
         "@type" : "Place",

--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -4,8 +4,8 @@
     "@type": "Event",
     "name": "{{ election.election.name }}",
     "description": "{{ election.friendly_name }}",
-    "startDate": "{{ election.election.election_date }}",
-    "endDate": "{{ election.election.election_date }}",
+    "startDate": "{{ election.election.start_time | date:'Y-m-d H:i' }}",
+    "endDate": "{{ election.election.end_time | date:'Y-m-d H:i' }}",
     "url" : "{{ CANONICAL_URL }}{{ election.get_absolute_url }}",
     "location" : {
         "@type" : "Place",

--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -1,0 +1,14 @@
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Event",
+    "name": "{{ election.election.name }}",
+    "startDate" : "{{ election.election.election_date }}",
+    "url" : "{{ CANONICAL_URL }}{{ election.get_absolute_url }}",
+    "location" : {
+        "@type" : "Place",
+        "name" : "{{ election.friendly_name }}",
+        "address": "{{ election.election.name }}"
+    }
+}
+</script>

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -49,6 +49,6 @@
         Learn more
       </a>
 
-      {% include "elections/includes/_ld_candidate.html" with person=person_post.person %}
+      {% include "elections/includes/_ld_candidate.html" with person=person_post.person party=person_post.party %}
     </span> <!-- /.candidate_info -->
   </section>

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -48,5 +48,7 @@
       <a class="more_info" href="{{ person_post.person.get_absolute_url }}">
         Learn more
       </a>
+
+      {% include "elections/includes/_ld_candidate.html" with person=person_post.person %}
     </span> <!-- /.candidate_info -->
   </section>

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -78,6 +78,8 @@
   </div>
   {% endif %}
 
+  {% include "elections/includes/_ld_election.html" with election=object %}
+
 </div>
 
 {% if postelection.husting_set.exists %}

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -369,4 +369,6 @@
   </ol>
 {% endif %}
 
+{% include "elections/includes/_ld_candidate.html" with person=object.personpost.person party=object.personpost.party %}
+
 {% endblock breadcrumbs %}


### PR DESCRIPTION
## What?

This commit is a small proof-of-concept for introducing more linked data into WCIVF, by templating out a [Person](https://schema.org/Person) for each candidate listed for a post.

You can verify the change by running WCIVF locally, and copying the rendered HTML into Google's [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool).

![Screen Shot 2019-09-17 at 22 12 27](https://user-images.githubusercontent.com/460299/65080058-57096280-d998-11e9-83a7-6037c93996a3.png)

## Why?

This will start WCIVF down the road to defining "Objects" and the links between them to make the content _on_ WCIVF digestable by search engines and easier to discover via search (in theory). [Google recommends](https://developers.google.com/search/docs/guides/intro-structured-data) marking up with JSON-LD, as in this commit.

## What next?

There are no top-level [Schema.org](https://schema.org) concepts specifically for elections (the closest is [VoteAction](https://schema.org/VoteAction) which is closer to election _results_).

You could make a rough mapping of:

* Candidate -> Person
* Poll -> Event (Google supports rich displays for [events](https://developers.google.com/search/docs/data-types/event)) 
* Polling Station -> Location
* Parties -> Organisation

This is just a small idea, interested to hear what the team's thoughts are.