### PR TITLE
Revise use of current/future

### DIFF
--- a/fixtures/vcr_cassettes/test_import_elections_from_ynr.yaml
+++ b/fixtures/vcr_cassettes/test_import_elections_from_ynr.yaml
@@ -11280,7 +11280,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.9.1]
     method: GET
-    uri: https://elections.democracyclub.org.uk/api/elections/?current=true
+    uri: https://elections.democracyclub.org.uk/api/elections/?poll_open_date__gte=2016-03-05
   response:
     body: {string: '{"count": 1,"next": null,"previous": null,"results": []}'}
     headers:

--- a/fixtures/vcr_cassettes/test_import_posts_from_ynr.yaml
+++ b/fixtures/vcr_cassettes/test_import_posts_from_ynr.yaml
@@ -15842,7 +15842,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.19.1]
     method: GET
-    uri: https://elections.democracyclub.org.uk/api/elections/?current=true
+    uri: https://elections.democracyclub.org.uk/api/elections/?poll_open_date__gte=2016-03-05
   response:
     body: {string: '{"count":0,"next":null,"previous":null,"results":[]}'}
     headers:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,7 @@ django-localflavor==2.1
 django-extensions==2.1.6
 djangorestframework==3.9.2
 django-redis==4.10.0
+freezegun==0.3.12
 hiredis==0.3.1
 redis==3.2.1
 Pillow==5.4.1

--- a/wcivf/apps/elections/management/commands/import_elections.py
+++ b/wcivf/apps/elections/management/commands/import_elections.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
@@ -30,8 +32,9 @@ class Command(BaseCommand):
                 )
 
     def import_extras(self):
+        poll_open_date_gte = str(date.today() - timedelta(days=30))
         pages = self.get_paginator(
-            "{}/api/elections/?current=true".format(settings.EE_BASE)
+            f"{settings.EE_BASE}/api/elections/?poll_open_date__gte={poll_open_date_gte}"
         )
         for page in pages:
             for election in page["results"]:

--- a/wcivf/apps/elections/management/commands/import_posts.py
+++ b/wcivf/apps/elections/management/commands/import_posts.py
@@ -95,9 +95,11 @@ class Command(BaseCommand):
             post_election.post.save()
 
     def populate_empty_voting_systems(self):
-        qs = Election.objects.filter(
-            voting_system=None, current=True
-        ).prefetch_related("postelection_set")
+        qs = (
+            Election.objects.current_or_future()
+            .filter(voting_system=None)
+            .prefetch_related("postelection_set")
+        )
         ee = EEHelper()
         for election in qs:
             for post_election in election.postelection_set.all():

--- a/wcivf/apps/elections/managers.py
+++ b/wcivf/apps/elections/managers.py
@@ -1,8 +1,22 @@
 from django.db import models
+from django.utils import timezone
 from .helpers import EEHelper
 
 
-class ElectionManager(models.Manager):
+class ElectionQuerySet(models.QuerySet):
+    def current(self):
+        return self.filter(current=True)
+
+    def future(self):
+        return self.filter(election_date__gt=timezone.now())
+
+    def current_or_future(self):
+        return self.filter(
+            models.Q(current=True) | models.Q(election_date__gt=timezone.now())
+        )
+
+
+class ElectionManager(models.Manager.from_queryset(ElectionQuerySet)):
     def get_explainer(self, election):
         ee = EEHelper()
         ee_data = ee.get_data(election["id"])

--- a/wcivf/apps/elections/templates/elections/elections_view.html
+++ b/wcivf/apps/elections/templates/elections/elections_view.html
@@ -11,7 +11,7 @@
   <h1>All Elections</h1>
   <h2>Current Elections</h2>
   <p>These are upcoming elections or those which happened recently.</p>
-  {% include "elections/includes/_election_list.html" with elections=current_elections %}
+  {% include "elections/includes/_election_list.html" with elections=current_or_future_elections %}
 
 
   <h2>Past Elections</h2>

--- a/wcivf/apps/elections/tests/test_import_elections_and_posts.py
+++ b/wcivf/apps/elections/tests/test_import_elections_and_posts.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import vcr
 import requests
+from freezegun import freeze_time
 
 from django.conf import settings
 from django.core.management import call_command
@@ -35,12 +36,14 @@ class TestElectionAndPostImporter(TestCase):
     @vcr.use_cassette(
         "fixtures/vcr_cassettes/test_import_elections_from_ynr.yaml"
     )
+    @freeze_time("2016-04-04")
     def test_import_elections_from_ynr(self):
         assert Election.objects.count() == 0
         self._import_elections()
         assert Election.objects.count() == 385
 
     @vcr.use_cassette("fixtures/vcr_cassettes/test_import_posts_from_ynr.yaml")
+    @freeze_time("2016-04-04")
     def test_import_posts_from_ynr(self):
         assert Election.objects.count() == 0
         self._import_elections()

--- a/wcivf/apps/elections/views/election_views.py
+++ b/wcivf/apps/elections/views/election_views.py
@@ -25,8 +25,9 @@ class ElectionsView(TemplateView):
         )
 
         context["past_elections"] = all_elections.filter(current=False)
-
-        context["current_elections"] = all_elections.filter(current=True)
+        context[
+            "current_or_future_elections"
+        ] = all_elections.current_or_future()
 
         return context
 


### PR DESCRIPTION
Refs https://github.com/DemocracyClub/EveryElection/pull/597 and https://github.com/DemocracyClub/yournextrepresentative/pull/1021

Less going on here than in https://github.com/DemocracyClub/yournextrepresentative/pull/1021

I've elected to keep what we show on the postcode page limited to `current=1` only. We could revise that assumption later if we want, but maybe we want to think about how to present non-current elections in the future differently. Like with the https://github.com/DemocracyClub/yournextrepresentative/pull/1021, I've also kept everything where we're looking at results using "current" because if we're talking about results, we only care about elections in the past.