### PR TITLE
Fix: Event data improvements

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -159,6 +159,30 @@ class Post(models.Model):
 
     objects = PostManager()
 
+    def nice_organization(self):
+        return (
+            self.organization.replace(" County Council", "")
+            .replace(" Borough Council", "")
+            .replace(" District Council", "")
+            .replace("London Borough of ", "")
+            .replace(" Council", "")
+        )
+
+    def nice_territory(self):
+        if self.territory == "WLS":
+            return "Wales"
+
+        if self.territory == "ENG":
+            return "England"
+
+        if self.territory == "SCT":
+            return "Scotland"
+
+        if self.territory == "NIR":
+            return "Northern Ireland"
+
+        return self.territory
+
 
 class PostElection(models.Model):
     ballot_paper_id = models.CharField(blank=True, max_length=800, unique=True)

--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -1,3 +1,4 @@
+{% load static %}
 <script type="application/ld+json">
 {
     "@context": "http://schema.org/",
@@ -7,6 +8,7 @@
     "startDate": "{{ election.election.start_time | date:'Y-m-d H:i' }}",
     "endDate": "{{ election.election.end_time | date:'Y-m-d H:i' }}",
     "url" : "{{ CANONICAL_URL }}{{ election.get_absolute_url }}",
+    "image": "{{ CANONICAL_URL }}{% static "dc_theme/images/logo.png" %}",
     "location" : {
         "@type" : "Place",
         "name" : "{{ election.friendly_name }}",

--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -11,8 +11,7 @@
     "image": "{{ CANONICAL_URL }}{% static "dc_theme/images/logo.png" %}",
     "location" : {
         "@type" : "Place",
-        "name" : "{{ election.friendly_name }}",
-        "address": "{{ election.election.name }}"
+        "address": "{{ election.post.nice_organization }}, {{ election.post.nice_territory }}, UK"
     }
 }
 </script>

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -8,7 +8,7 @@ class ExpectedSoPNDate(TestCase):
     def test_with_territory_code_eng(self):
         expected = expected_sopn_publish_date("local.2019-05-02", "ENG")
 
-        assert expected == date(2019, 4, 3)
+        assert expected == date(2019, 4, 4)
 
     def test_with_territory_code_nir(self):
         expected = expected_sopn_publish_date("local.2019-05-02", "NIR")


### PR DESCRIPTION
The structured Event data for elections has been running for about a week, and two major bugs appeared.

## Image

There were scenarios where, lacking an image in the event markup, Google had scraped the page being linked to and used an image from there - in one scenario this was a candidate image.

This could come across as biased, so 632bfe1 resolves this by setting the image as the DC logo.

In future, this could be a more neutral image (in a previous PR I suggested something like a minimal ballot box and vote) but this is much better for now.

## Location

There were scenarios where, lacking a proper location (it seemed unhappy with `X local by-election` as a name), Google tried to fit a location based on a "best guess".

According to the documentation, `location.name` is an _optional_ field whereas address is not.

3184e06 adds two helper methods to create friendly names for the organisation and territory, and fills out the address as `<Location>, <Country>, UK`.

## Examples

![Screen Shot 2019-10-12 at 15 53 40](https://user-images.githubusercontent.com/460299/66703260-877abd00-ed08-11e9-9a46-8655e4635382.png)

![Screen Shot 2019-10-12 at 15 45 19](https://user-images.githubusercontent.com/460299/66703261-8cd80780-ed08-11e9-8e72-bf933317e765.png)
