### PR TITLE
fix(election): Start time is 7am, not 6am. Make consistent with copy.

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -102,7 +102,7 @@ class Election(models.Model):
     @property
     def start_time(self):
         election_datetime = self._election_datetime_tz()
-        return utc_to_local(election_datetime.replace(hour=6))
+        return utc_to_local(election_datetime.replace(hour=7))
 
     @property
     def end_time(self):


### PR DESCRIPTION
Joe pointed this out on Twitter.

The `start_time` being pulled in (and used for our Event data in Google) is hard-coded to 6am, whereas almost all copy in the codebase declares that polls open at 7am.

This minor change makes the code consistent with the copy.