### PR TITLE
feat(linked-data): Reformat event data for parliamentary elections

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_ld_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_ld_election.html
@@ -3,15 +3,31 @@
 {
     "@context": "http://schema.org/",
     "@type": "Event",
-    "name": "{{ election.election.name }}",
-    "description": "{{ election.friendly_name }}",
-    "startDate": "{{ election.election.start_time | date:'Y-m-d H:i' }}",
-    "endDate": "{{ election.election.end_time | date:'Y-m-d H:i' }}",
     "url" : "{{ CANONICAL_URL }}{{ election.get_absolute_url }}",
     "image": "{{ CANONICAL_URL }}{% static "dc_theme/images/logo.png" %}",
+    "startDate": "{{ election.election.start_time | date:'Y-m-d H:i' }}",
+    "endDate": "{{ election.election.end_time | date:'Y-m-d H:i' }}",
+
+{% if election.election.election_type == 'parl' %}
+
+    "name": "UK Parliament Election - {{ election.post.area_name }}",
+    "description": "Election of the Member of Parliament for {{ election.post.area_name }}",
+    "location" : {
+        "@type" : "Place",
+        "address": "{{ election.post.area_name }}, UK"
+    }
+
+{% else %}
+
+    "name": "{{ election.election.name }}",
+    "description": "{{ election.friendly_name }}",
     "location" : {
         "@type" : "Place",
         "address": "{{ election.post.nice_organization }}, {{ election.post.nice_territory }}, UK"
     }
+
+{% endif %}
+
+
 }
 </script>


### PR DESCRIPTION
This PR is a tweak to how we render structured event data for Parliamentary elections.

A lot of the assumptions made in the first cut of event data were tailored towards by-elections. Some of these no longer hold true.

As example, the current rendering of the event data for [Na h-Eileanan an Iar](https://whocanivotefor.co.uk/elections/parl.na-h-eileanan-an-iar.2019-12-12/na-h-eileanan-an-iar/) looks as below:

```
{
    "@context": "http://schema.org/",
    "@type": "Event",
    "name": "UK Parliament elections",
    "description": "Na h-Eileanan an Iar constituency",
    "startDate": "2019-12-12 06:00",
    "endDate": "2019-12-12 22:00",
    "url" : "https://whocanivotefor.co.uk/elections/parl.na-h-eileanan-an-iar.2019-12-12/na-h-eileanan-an-iar/",
    "image": "https://whocanivotefor.co.uk/static/dc_theme/images/logo.b9e42a2f8e88.png",
    "location" : {
        "@type" : "Place",
        "address": ", , UK"
    }
}
```

The name is no longer unique (each parliamentary ballot will have the same name, "UK Parliament elections") and the address no longer renders at all.

This PR namespaces the event with the constituency, and falls back to using `<Ward>, UK` as the address. For some wards, like Na h-Eileanan an Iar, this is sufficient for Google to mark the location.

![Na h-Eileanan an Iar](https://user-images.githubusercontent.com/460299/68072675-15821a80-fd80-11e9-8c97-c213206d83b3.png)

However, for others where the ward does not correspond to a location, such as Basildon and Billericay, Google can't tag the event with a location.

![Basildon and Billericay](https://user-images.githubusercontent.com/460299/68072700-4a8e6d00-fd80-11e9-887f-91cda7fc0e8d.png)

This could be addressed with some work on another DC app to provide e.g. lat/long for the center of each ward, but I feel this is a decent revamp given the time constraints.