### PR TITLE
change link text for twitter embed fallback

### DIFF
--- a/wcivf/apps/elections/templates/elections/party_list_view.html
+++ b/wcivf/apps/elections/templates/elections/party_list_view.html
@@ -53,7 +53,7 @@
     <h3>Latest tweets</h3>
     <div class="twitter_container">
     <a data-width="100%" data-height="500" class="twitter-timeline" href="https://twitter.com/{{ object.twitter_username }}">
-      Loading Tweets...</a>
+      Tweets by @{{ object.twitter_username }}</a>
       <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
   </div>

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -154,7 +154,7 @@
     <h3>Latest tweets</h3>
     <div class="twitter_container">
     <a data-width="100%" data-height="500" class="twitter-timeline" href="https://twitter.com/{{ object.twitter_username }}">
-      Loading Tweets...</a>
+      Tweets by @{{ object.twitter_username }}</a>
       <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
   </div>


### PR DESCRIPTION
Its quite common for the user's browser security policies/adblocker/content blocker settings to block the twitter feed from loading. Changing the link text makes it slightly more obvious this is a clickable link in the fallback situation.