### PR TITLE
If an election is cancelled don't add it to ical feed.

### DIFF
--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -77,6 +77,8 @@ class PostcodeiCalView(
         cal.add("prodid", "-//Elections in {}//mxm.dk//".format(postcode))
 
         for post_election in self.postcode_to_ballots(postcode):
+            if post_election.cancelled:
+                continue
             event = Event()
             event["uid"] = "{}-{}".format(
                 post_election.post.ynr_id, post_election.election.slug


### PR DESCRIPTION
Based on error report here: https://twitter.com/DanielJUK/status/1257596394250084356

Any pointers on getting a test running would be great. When I inspect the current 'response' object in `wcivf/apps/elections/tests/test_postcode_views.py:PostcodeViewTests:test_ical_view`, it hasn't picked up any elections. So changing the cassette to include  a cancelled election seems like it would need something changing with the existing test first. 