### PR TITLE
Hotfix/empty postcode error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.vscode/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,4 @@
 -r testing.txt
 
 ipdb
-
-
+pre-commit

--- a/wcivf/apps/core/tests/test_views.py
+++ b/wcivf/apps/core/tests/test_views.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.shortcuts import reverse
+
+
+class TestPostcodeFormView(TestCase):
+    def test_no_postcode(self):
+        """
+        When postcode is not present in query string no redirect occurs.
+        """
+        response = self.client.get("/?postcode=")
+        assert response.status_code == 200
+
+    def test_has_postcode(self):
+        """
+        When poscode is present in request GET redirect to the postcode view
+        occurs.
+        """
+        response = self.client.get("/?postcode=TE11ST")
+
+        assert response.status_code == 302
+        assert response.url == reverse(
+            "postcode_view", kwargs={"postcode": "TE11ST"}
+        )
+
+    def test_has_invalid_postcode(self):
+        """
+        When invalid_postcode is in the request GET redirect does not occur.
+        """
+        response = self.client.get("/?postcode=TE11ST&invalid_postcode=1")
+
+        assert response.status_code == 200

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -18,7 +18,7 @@ class PostcodeFormView(FormView):
 
     def get(self, request, *args, **kwargs):
         if (
-            "postcode" in request.GET
+            request.GET.get("postcode")
             and "invalid_postcode" not in self.request.GET
         ):
             redirect_url = reverse(


### PR DESCRIPTION
Resolves #316 

Checks that a value is actually present in the request.GET rather than simply the key being present. If not, page is rendered as normal, without 500 error