### PR TITLE
Remove election reminder email card

### DIFF
--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -28,21 +28,16 @@
 
 {% if not messages %}
   <section class="card">
+  <p>
     <h2>
       <span aria-hidden="true">⏰</span>
-      Election reminders for {{ postcode }}
+      Add future elections in {{ postcode }} to your calendar:
       <span aria-hidden="true">⏰</span>
     </h2>
-    <p>We can email you the next time there is an election in {{ postcode }}.</p>
-    {% include "email_form/election_reminders_form.html" %}
-
-    <p>
-    Or add future elections in {{ postcode }} to your calendar:
     <a href="webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}">iCal feed</a>
   </p>
   </section>
 {% endif %}
-
 
 {#{% include "feedback/feedback_form.html" %}#}
 


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/597

The election email reminder functionality is not currently in use so I have temporarily removed it until a time when the service can be offered. 