### PR TITLE
Hotfix/delete deleted elections

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -10,3 +10,4 @@ pytest-cov
 factory_boy
 vcrpy==4.1.1
 pytest-freezegun
+pytest-mock

--- a/wcivf/apps/elections/helpers.py
+++ b/wcivf/apps/elections/helpers.py
@@ -53,7 +53,6 @@ class EEHelper:
 
         elections_count, _ = Election.objects.filter(
             slug__in=self.deleted_election_ids,
-            current=False,
         ).delete()
 
         post_elections_count, _ = PostElection.objects.filter(

--- a/wcivf/apps/elections/management/commands/import_ballots.py
+++ b/wcivf/apps/elections/management/commands/import_ballots.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from elections.import_helpers import YNRBallotImporter
+from elections.import_helpers import YNRBallotImporter, EEHelper
 from elections.models import Election
 
 
@@ -39,6 +39,20 @@ class Command(YNRBallotImporter, BaseCommand):
             election.any_non_by_elections = any_non_by_elections
             election.save()
 
+    def delete_deleted_elections(self):
+        """
+        Deletes elections that are marked as deleted in Every Election and any
+        related objects
+        """
+        ee_helper = EEHelper()
+        elections, post_elections = ee_helper.delete_deleted_elections()
+        self.stdout.write(
+            f"Deleted {elections} Election objects and relations\n"
+        )
+        self.stdout.write(
+            f"Deleted {post_elections} PostElection objects and relations\n"
+        )
+
     def handle(self, **options):
         importer = YNRBallotImporter(
             stdout=self.stdout,
@@ -48,3 +62,4 @@ class Command(YNRBallotImporter, BaseCommand):
         )
         importer.do_import()
         self.populate_any_non_by_elections_field()
+        self.delete_deleted_elections()

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -101,9 +101,7 @@ class TestEEHelper:
 
         ee_helper.delete_deleted_elections()
 
-        election_filter.assert_called_once_with(
-            slug__in=["foo_id", "bar_id"], current=False
-        )
+        election_filter.assert_called_once_with(slug__in=["foo_id", "bar_id"])
         election_filter.return_value.delete.assert_called_once()
         postelection_filter.assert_called_once_with(
             ballot_paper_id__in=["foo_id", "bar_id"]

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -1,6 +1,14 @@
+import pytest
+import sys
+
 from django.test import TestCase
 
-from elections.helpers import expected_sopn_publish_date
+from elections.helpers import (
+    expected_sopn_publish_date,
+    EEHelper,
+    JsonPaginator,
+)
+from elections.models import Election, PostElection
 from datetime import date
 
 
@@ -31,3 +39,73 @@ class ExpectedSoPNDate(TestCase):
         expected = expected_sopn_publish_date("whoknows", "ENG")
 
         assert expected is None
+
+
+class TestEEHelper:
+    @pytest.fixture
+    def ee_helper(self, settings):
+        settings.EE_BASE = "https://elections.democracyclub.org.uk"
+        return EEHelper()
+
+    def test_base_elections_url(self, ee_helper):
+        assert (
+            ee_helper.base_elections_url
+            == "https://elections.democracyclub.org.uk/api/elections/"
+        )
+
+    @pytest.mark.freeze_time("2021-02-20")
+    def test_deleted_election_ids(self, ee_helper, mocker):
+        """
+        Check a generator object of ID's to be deleted is returned.
+        Patchs the JsonPaginator so that no actual API call is made, and
+        instead return mock data to match the structure of the API
+        """
+        mock_data = [
+            {"results": [{"election_id": "foo_id"}, {"election_id": "bar_id"}]},
+        ]
+        paginator = mocker.MagicMock(spec=JsonPaginator)
+        paginator.return_value.__iter__.return_value = iter(mock_data)
+        mocker.patch("elections.helpers.JsonPaginator", new=paginator)
+
+        result = ee_helper.deleted_election_ids
+
+        assert result == ["foo_id", "bar_id"]
+        paginator.assert_called_once_with(
+            page1="https://elections.democracyclub.org.uk/api/elections/?deleted=1&poll_open_date__gte=2021-01-01",
+            stdout=sys.stdout,
+        )
+
+    @pytest.mark.django_db
+    def test_deleted_deleted_elections(self, ee_helper, mocker):
+        """
+        Patch the EEHelper to return a list of ID's to be deleted
+        Patch the filter method on the Election QuerySet
+        Assert that the correct kwargs are passed to the filter call
+        Assert that delete is called on the return value
+        """
+        mocker.patch.object(
+            EEHelper,
+            "deleted_election_ids",
+            new_callable=mocker.PropertyMock,
+            return_value=["foo_id", "bar_id"],
+        )
+        election_filter = mocker.MagicMock()
+        election_filter.return_value.delete.return_value = ("foo", "bar")
+        mocker.patch.object(Election.objects, "filter", new=election_filter)
+
+        postelection_filter = mocker.MagicMock()
+        postelection_filter.return_value.delete.return_value = ("foo", "bar")
+        mocker.patch.object(
+            PostElection.objects, "filter", new=postelection_filter
+        )
+
+        ee_helper.delete_deleted_elections()
+
+        election_filter.assert_called_once_with(
+            slug__in=["foo_id", "bar_id"], current=False
+        )
+        election_filter.return_value.delete.assert_called_once()
+        postelection_filter.assert_called_once_with(
+            ballot_paper_id__in=["foo_id", "bar_id"]
+        )
+        postelection_filter.return_value.delete.assert_called_once()

--- a/wcivf/apps/hustings/tests/test_hustings.py
+++ b/wcivf/apps/hustings/tests/test_hustings.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.utils.timezone import datetime, utc
 
 import vcr
 
@@ -28,8 +29,8 @@ class TestHustings(TestCase):
             post_election=self.ballot,
             title="Local Election Hustings",
             url="https://example.com/hustings",
-            starts="2017-03-23 19:00",
-            ends="2017-03-23 21:00",
+            starts=datetime(2017, 3, 23, 19, 00, tzinfo=utc),
+            ends=datetime(2017, 3, 23, 21, 00, tzinfo=utc),
             location="St George's Church",
             postcode="BN2 1DW",
         )


### PR DESCRIPTION
Closes #456 

Implementation notes/queries:
- Wasn't sure if the delete needs to replicate the checks made in YNR `safe_delete` method [here](https://github.com/DemocracyClub/yournextrepresentative/blob/bd0db75e46ef27efb2d2f459087f26f5e03cba21/ynr/apps/elections/models.py#L226) so for now have gone for a more straightforward MVP and I can update to add this check if necessary. This is also ensures that any associated PostElection objects are deleted as it is using `CASCADE` on the FK on PostElection.
- I've added the call to actually make the delete directly to the management command as this seemed most clear and explicit. Although there is an argument to be made for having it run on the `YNRBallotImporter` itself somewhere (e.g. `do_import` or `add_ballots`) so interested to hear any thoughts on this

Some notes about the tests:
- I have used mocks as it allowed me more control of what data to test against. I also had a look at using `vcrpy` since that is already used in the project, but I think this would have meant in my `test_deleted_election_ids` I'd have to parse the created fixtures in the same way as I do in the method itself, so it didn't feel right to me. But interested to hear any feedback about this.
- Since I was already using mocks, I also used these for my `test_deleted_deleted_elections` rather than using factories to create objects and then allowing the tests to hit the DB. However this does make them somewhat more abstract, so they could be amended if necessary