### PR TITLE
Hotfix/Conditional to display number of candidates in tab

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -1,1 +1,7 @@
-{% autoescape off %}See all {{ person_posts|length }} candidates in {{ object.post.label }} in the {{ object.election.name }} on {{ object.election.election_date }}: {% for pp in person_posts %}{{ pp.person.name|safe }} ({{ pp.party.party_name }}) {% endfor %}{% endautoescape %}
+{% if postelection.people|length %}
+{% autoescape off %}See all {{ postelection.people|length }} candidates in the {{ object.election.name }} on {{
+object.election.election_date }}: {% for pp in person_posts %}{{ pp.person.name|safe }}
+({{ pp.party.party_name }}) {% endfor %}{% endautoescape %}
+{% else %}
+{{ object.election.name }}: No candidates known yet.
+{% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_title.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_title.html
@@ -1,1 +1,5 @@
-{{ object.election.name }}: The {{ person_posts|length }} candidates in {{ object.post.label }}
+{% if postelection.people|length %}
+    {{ object.election.name }}: The {{ postelection.people|length }} candidates in {{ object.post.label }}
+{% else %}
+    {{ object.election.name }}: No candidates known yet.
+{% endif %}

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -1,14 +1,14 @@
 import pytest
-
+from django.shortcuts import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.shortcuts import reverse
+from elections.models import PostElection
 from elections.tests.factories import (
     ElectionFactory,
-    PostFactory,
     PostElectionFactory,
+    PostFactory,
 )
-from elections.models import PostElection
+from people.tests.factories import PersonFactory, PersonPostFactory
 
 
 @override_settings(
@@ -73,3 +73,56 @@ class ElectionViewTests(TestCase):
                 )
                 self.assertContains(response, election[0].nice_election_name)
                 self.assertContains(response, election[1])
+
+
+class ElectionPostViewTests(TestCase):
+    def setUp(self):
+        self.election = ElectionFactory(
+            name="Adur local election",
+            election_date="2021-05-06",
+            slug="local.adur.churchill.2021-05-06",
+        )
+        self.post = PostFactory(label="Adur local election")
+        self.post_election = PostElectionFactory(
+            election=self.election, post=self.post
+        )
+
+    def test_zero_candidates(self):
+        response = self.client.get(
+            self.post_election.get_absolute_url(), follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "elections/post_view.html")
+        self.assertTemplateUsed(
+            response, "elections/includes/_post_meta_title.html"
+        )
+        self.assertTemplateUsed(
+            response, "elections/includes/_post_meta_description.html"
+        )
+        self.assertContains(response, "No candidates known yet.")
+
+    def test_num_candidates(self):
+        people = [PersonFactory() for p in range(5)]
+        for person in people:
+            PersonPostFactory(
+                post_election=self.post_election,
+                election=self.election,
+                post=self.post,
+                person=person,
+            )
+
+        response = self.client.get(
+            self.post_election.get_absolute_url(), follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "elections/post_view.html")
+        self.assertTemplateUsed(
+            response, "elections/includes/_post_meta_title.html"
+        )
+        self.assertTemplateUsed(
+            response, "elections/includes/_post_meta_description.html"
+        )
+        self.assertContains(response, f"The 5 candidates in {self.post.label}")
+        self.assertContains(
+            response, f"See all 5 candidates in the {self.post.label}"
+        )


### PR DESCRIPTION
Closes #596

In the context of the meta title, person_posts was undefined and therefore defaulted to 0 regardless of the number of candidates actually standing for a post.