### PR TITLE
ICS calendar validation errors on phone

### DIFF
--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -1,5 +1,5 @@
 from icalendar import Calendar, Event, vText
-
+from django.utils import timezone
 from django.conf import settings
 from django.http import HttpResponse
 from django.views.generic import TemplateView, View
@@ -86,7 +86,7 @@ class PostcodeiCalView(
             event["summary"] = "{} - {}".format(
                 post_election.election.name, post_election.post.label
             )
-
+            event.add("dtstamp", timezone.now())
             event.add("dtstart", post_election.election.start_time)
             event.add("dtend", post_election.election.end_time)
             event.add(


### PR DESCRIPTION
Ref [#274](https://github.com/DemocracyClub/WhoCanIVoteFor/issues/274)

The source code was missing a DTSTAMP in each VEVENT as well as time zone in the start and end date. 

With these changes, we've solved DSTAMP errors, but still need to address the setting of UTC and the 'floating time' issue. After experimenting with passing in UTC to the start and end time, we satisfied errors, but introduced a potential bug around time zones and rendering the correct time in calendars. I think what we want is for events that appear in BST to appear in the calendar without the +1 time difference. This may require the introduction of time zone settings. However, doing so adds complexity that may be avoided by using a different library or by trying to solve the issue in the iCalendar library.

After careful consideration, we've decided to only solve the DTSTAMP error here and add to the issue in iCalendar that relates to the time zone errors in hopes of a solution we can implement at a future date. 

ICS Cal research [here](https://docs.google.com/document/d/1KCQKzwtDPGZA_ywlFNjaocP7GOg855Sojv0NKP9TK2Y/edit#)

In collab with @michaeljcollinsuk 

