### PR TITLE
Hotfix/Remove all parties link from base

### DIFF
--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -77,7 +77,6 @@
     <ul>
       <li><a href="{% url 'home_view' %}">Home</a></li>
       <li><a href="{% url 'elections_view' %}">All Elections</a></li>
-      <li><a href="{% url 'parties_view' %}">All Parties</a></li>
       <li><a href="{% url 'standing_as_a_candidate' %}">Standing as a candidate?</a></li>
       <li><a href="{% url 'about_view' %}">About {{ SITE_TITLE }}</a></li>
       <li><a href="https://democracyclub.org.uk/privacy/">Privacy</a></li>


### PR DESCRIPTION
Closes [#247 ](https://github.com/DemocracyClub/WhoCanIVoteFor/issues/247)

[As discussed with @pmk01,](https://github.com/DemocracyClub/WhoCanIVoteFor/issues/247#issuecomment-762869626) this work removes the 'All Parties' link from the base footer until a later date when content can be rebuilt.
