### PR TITLE
Hotfix/Add method to delete orphan posts

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -170,6 +170,14 @@ class YNRBallotImporter:
             # This is because there's a high chance we've not
             # got all the ballots we need yet.
             self.run_post_ballot_import_tasks()
+        self.delete_orphan_posts()
+
+    def delete_orphan_posts(self):
+        """
+        This method cleans orphan posts.
+        This typically gets called at the end of the import process.
+        """
+        return Post.objects.filter(postelection=None).delete()
 
     @transaction.atomic()
     def add_ballots(self, results):


### PR DESCRIPTION
Closes #433 
Co-authored with @michaeljcollinsuk 

This work adds a method and tests to delete orphan posts. We have not added tests on the importer because it falls outside the scope of this ticket, but it could be a nice addition. 
