### PR TITLE
Display correct polls open msg in PostcodeView

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -43,11 +43,8 @@
         <a href="{{ polling_station.custom_finder }}">
         following this link</a>.</p>
     {% else %}
-      {% now "j F Y" as current_day %}
-      {% if elections_by_date and elections_by_date.0.grouper|date:"j F Y" == current_day %}
-        {% with today_election=elections_by_date.0.list.0.election %}
-          <strong>Polling stations are open from {{ today_election.polls_open|time:"ga" }} till {{ today_election.polls_close|time:"ga" }} today.</strong>
-        {% endwith %}
+      {% if ballots_today %}
+        <strong>Polling stations are open from {{ ballots_today.0.election.polls_open|time:"ga" }} till {{ ballots_today.0.election.polls_close|time:"ga" }} today.</strong>
       {% endif %}
       {% if polling_station.addresses %}
         <p>Your polling station in {{ postcode }} depends on your address. <a href="https://wheredoivote.co.uk/postcode/{{ postcode }}/">Check the correct polling station for your address &raquo;</a></p>

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -25,7 +25,6 @@
   You don't need to take your poll card with you{% if not postcode|ni_postcode %}, or any identification{% endif %}.
   {% endif %}
 
-
   {% if polling_station.polling_station_known %}
     <p>
       Your polling station is <strong>{{ polling_station.polling_station.properties.address }}</strong>.
@@ -46,7 +45,9 @@
     {% else %}
       {% now "j F Y" as current_day %}
       {% if elections_by_date and elections_by_date.0.grouper|date:"j F Y" == current_day %}
-      <strong>Polling stations are open from 7am till 10pm today.</strong>
+        {% with today_election=elections_by_date.0.list.0.election %}
+          <strong>Polling stations are open from {{ today_election.polls_open|time:"ga" }} till {{ today_election.polls_close|time:"ga" }} today.</strong>
+        {% endwith %}
       {% endif %}
       {% if polling_station.addresses %}
         <p>Your polling station in {{ postcode }} depends on your address. <a href="https://wheredoivote.co.uk/postcode/{{ postcode }}/">Check the correct polling station for your address &raquo;</a></p>

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -43,7 +43,7 @@
         <a href="{{ polling_station.custom_finder }}">
         following this link</a>.</p>
     {% else %}
-      {% if ballots_today %}
+      {% if ballots_today and not multiple_city_of_london_elections_today %}
         <strong>Polling stations are open from {{ ballots_today.0.election.polls_open|time:"ga" }} till {{ ballots_today.0.election.polls_close|time:"ga" }} today.</strong>
       {% endif %}
       {% if polling_station.addresses %}

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -232,7 +232,7 @@ class TestPostcodeViewMethods:
         view_obj.ballots = PostElection.objects.all()
         ballots = view_obj.get_todays_ballots()
 
-        assert ballots.count() == 1
+        assert len(ballots) == 1
         assert today in ballots
         assert tomorrow not in ballots
 
@@ -274,7 +274,7 @@ class TestPostcodeViewMethods:
         mocker.patch.object(
             view_obj,
             "get_todays_ballots",
-            return_value=PostElection.objects.all(),
+            return_value=list(PostElection.objects.all()),
         )
 
         assert view_obj.multiple_city_of_london_elections_today() is True
@@ -292,7 +292,7 @@ class TestPostcodeViewMethods:
         mocker.patch.object(
             view_obj,
             "get_todays_ballots",
-            return_value=PostElection.objects.all(),
+            return_value=list(PostElection.objects.all()),
         )
 
         assert view_obj.multiple_city_of_london_elections_today() is False
@@ -308,7 +308,7 @@ class TestPostcodeViewMethods:
         mocker.patch.object(
             view_obj,
             "get_todays_ballots",
-            return_value=PostElection.objects.all(),
+            return_value=list(PostElection.objects.all()),
         )
 
         assert view_obj.multiple_city_of_london_elections_today() is False

--- a/wcivf/settings/ci.py
+++ b/wcivf/settings/ci.py
@@ -1,11 +1,11 @@
 # Use normal pipeline on travis as it doesn't work with fingerprinting
 STATICFILES_STORAGE = "pipeline.storage.PipelineStorage"
 
-# CACHES = {
-#     "default": {
-#         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-#     }
-# }
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Closes #441 

Updates template to read the poll open/close times for the first object in pre-ordered grouping of elections.

Does not account for edge case where City of London has both a local election and e.g. parliamentary by election on the same day - it will use the opening times of the first election within the list of elections for that day. However this should be ok as @symroe has [mentioned in the issue](https://github.com/DemocracyClub/WhoCanIVoteFor/issues/441#issuecomment-771163882) that this would not occur.
