### PR TITLE
Adds REDIS_LOG_POSTCODE setting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,6 +86,12 @@ the cache backend with a file at `./wcivf/settings/local.py` with the following:
         }
     }
 
+You will also need to add:
+
+    REDIS_LOG_POSTCODE = False
+
+This will disable using redis to log postcodes.
+
 
 ## Setting up PostgreSQL and PostGIS
 

--- a/wcivf/apps/core/models.py
+++ b/wcivf/apps/core/models.py
@@ -23,7 +23,7 @@ def log_postcode(log_dict, blocking=False):
     Take a dict with all the kwargs needed to create a LoggedPostcode
     model and create it or add it to a queue to save later
     """
-    if blocking:
+    if blocking or not settings.REDIS_LOG_POSTCODE:
         return LoggedPostcode.objects.create(**log_dict)
 
     red = redis.Redis(connection_pool=settings.REDIS_POOL)

--- a/wcivf/apps/core/tests/test_models.py
+++ b/wcivf/apps/core/tests/test_models.py
@@ -1,0 +1,42 @@
+import pytest
+import redis
+
+from core.models import log_postcode, LoggedPostcode
+
+
+class TestLogPostcode:
+    @pytest.fixture(autouse=True)
+    def mock_redis(self, mocker):
+        mocker.patch("redis.Redis", autospec=True)
+
+    @pytest.fixture(autouse=True)
+    def mock_create(self, mocker):
+        mocker.patch.object(LoggedPostcode.objects, "create")
+
+    def test_redis_not_used_by_setting(self, settings):
+        settings.REDIS_LOG_POSTCODE = False
+        postcode = {"postcode": "TE1 1ST"}
+
+        log_postcode(log_dict=postcode)
+
+        LoggedPostcode.objects.create.assert_called_once_with(**postcode)
+        redis.Redis.assert_not_called()
+
+    def test_redis_not_used_by_arg(self, settings):
+        settings.REDIS_LOG_POSTCODE = True
+        postcode = {"postcode": "TE1 1ST"}
+
+        log_postcode(log_dict=postcode, blocking=True)
+
+        LoggedPostcode.objects.create.assert_called_once_with(**postcode)
+        redis.Redis.assert_not_called()
+
+    def test_redis_used(self, settings):
+        settings.REDIS_LOG_POSTCODE = True
+        postcode = {"postcode": "TE1 1ST"}
+
+        log_postcode(log_dict=postcode)
+
+        LoggedPostcode.objects.create.assert_not_called()
+        redis.Redis.assert_called_once()
+        redis.Redis.return_value.zadd.assert_called_once()

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -1,6 +1,7 @@
 import pytest
 import vcr
 
+from django.conf import settings
 from django.urls import reverse
 from django.test import TestCase, override_settings
 from pytest_django import asserts
@@ -13,6 +14,7 @@ from elections.tests.factories import (
 )
 from core.models import LoggedPostcode, write_logged_postcodes
 from elections.views.postcode_view import PostcodeView
+from unittest import skipIf
 
 
 @override_settings(
@@ -36,6 +38,7 @@ class PostcodeViewTests(TestCase):
 
     @vcr.use_cassette("fixtures/vcr_cassettes/test_postcode_view.yaml")
     @override_settings(REDIS_KEY_PREFIX="WCIVF_TEST")
+    @skipIf(settings.REDIS_LOG_POSTCODE is False, "Dependant on redis running")
     def test_logged_postcodes(self):
         assert LoggedPostcode.objects.all().count() == 0
         response = self.client.get("/elections/EC1A4EU", follow=True)

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -185,6 +185,7 @@ import redis
 
 REDIS_POOL = redis.ConnectionPool(host="127.0.0.1", port=6379, db=5)
 REDIS_KEY_PREFIX = "WCIVF"
+REDIS_LOG_POSTCODE = True
 
 REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,


### PR DESCRIPTION
Closes #620

- Allows project to be run without having redis running
- Updates postcode logging method to skip redis and add tests
- Updates existing test to skip if redis isnt running - an alternative to this would be to mock redis in existing test

Suggestions for further areas for testing welcome