### PR TITLE
PCC elections displayed the same as mayoral

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -268,19 +268,6 @@ class Post(models.Model):
         return self.territory
 
     @property
-    def is_police_area(self):
-        return self.organization_type == "police-area"
-
-    @property
-    def _label_for_police_area(self):
-        """
-        Ensures all pcc Post labels consistently end in 'Police Force Area'
-        """
-        # remove Police if already present
-        stripped = self.label.replace(" Police", "")
-        return f"{stripped} Police force area"
-
-    @property
     def division_description(self):
         """
         Return a string to describe the division
@@ -302,9 +289,6 @@ class Post(models.Model):
         """
         Returns label with division suffix
         """
-        if self.is_police_area:
-            return self._label_for_police_area
-
         return f"{self.label} {self.division_suffix}".strip()
 
 
@@ -351,13 +335,20 @@ class PostElection(models.Model):
         return self.ballot_paper_id.startswith("gla.a")
 
     @property
+    def is_pcc(self):
+        """
+        Return a boolean for if this is a PCC ballot
+        """
+        return self.ballot_paper_id.startswith("pcc")
+
+    @property
     def friendly_name(self):
         """
         Helper property used in templates to build a 'friendly' name using
-        details from associated Post object, with exceptions for by-elections
-        and mayoral elections
+        details from associated Post object, with exceptions for GLA, mayoral
+        elections and pcc elections
         """
-        if self.is_mayoral:
+        if self.is_mayoral or self.is_pcc:
             return self.election.nice_election_name
 
         # edge case - as this is for a single region we display this below the

--- a/wcivf/apps/elections/templates/elections/party_list_view.html
+++ b/wcivf/apps/elections/templates/elections/party_list_view.html
@@ -7,7 +7,7 @@
     {% endif %}
 
     <h2>{{ party_name }}</h2>
-    <h3>{{ ballot.election.nice_election_name }}: {{ ballot.friendly_name }}</h3>
+    <h3>{{ ballot.election.nice_election_name }}{% if ballot.friendly_name != ballot.election.nice_election_name %}: {{ ballot.friendly_name }}{% endif %}</h3>
     </header>
     <dl>
         {% if local_party.facebook_page %}

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -104,25 +104,6 @@ class TestPostModel:
         assert post.full_label == "Ecclesall ward"
         suffix.assert_called_once()
 
-    @pytest.mark.parametrize(
-        "org_type,expected", [("police-area", True), ("another", False)]
-    )
-    def test_is_police_area(self, org_type, expected):
-        post = PostFactory.build(organization_type=org_type)
-        assert post.is_police_area == expected
-
-    @pytest.mark.parametrize(
-        "suffix, expected",
-        [
-            ("Police", "Police force area"),
-            ("Constabulary", "Constabulary Police force area"),
-        ],
-    )
-    def test_label_for_police_area(self, suffix, expected):
-        label = f"South Yorkshire {suffix}"
-        post = PostFactory.build(label=label)
-        assert post._label_for_police_area == f"South Yorkshire {expected}"
-
 
 class TestPostElectionModel:
     @pytest.fixture
@@ -160,3 +141,10 @@ class TestPostElectionModel:
     def test_friendly_name_london_assembly_additonal(self, post_election):
         post_election.ballot_paper_id = "gla.a.2021-05-06"
         assert post_election.friendly_name == "Additional members"
+
+    @pytest.mark.parametrize(
+        "org_type,expected", [("pcc.ballot", True), ("not.pcc", False)]
+    )
+    def test_is_pcc(self, org_type, expected):
+        post = PostElectionFactory.build(ballot_paper_id=org_type)
+        assert post.is_pcc == expected


### PR DESCRIPTION
Implements missing changes from previous PR

- Hide h2 element from the ballot page for PCC elections
- Remove redundant Post method/tests. Move logic to PostElection

<img width="1552" alt="Screenshot 2021-02-09 at 14 39 22" src="https://user-images.githubusercontent.com/15347726/107379212-9cc25000-6ae4-11eb-9acb-42b717d470a5.png">
