### PR TITLE
Feature/election enhancements

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -363,16 +363,15 @@ class PostElection(models.Model):
     def friendly_name(self):
         """
         Helper property used in templates to build a 'friendly' name using
-        details from associated Post object, with exceptions for GLA, mayoral
-        elections and pcc elections
+        details from associated Post object, with exceptions for mayoral and
+        Police and Crime Commissioner elections
         """
-        if self.is_mayoral or self.is_pcc:
-            return self.election.nice_election_name
+        if self.is_mayoral:
+            return f"{self.post.full_label} mayoral election"
 
-        # edge case - as this is for a single region we display this below the
-        # election name
-        if self.is_london_assembly_additional:
-            return "Additional members"
+        if self.is_pcc:
+            label = self.post.full_label.replace(" Police", "")
+            return f"{label} Police force area"
 
         return self.post.full_label
 

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -1,4 +1,5 @@
 import datetime
+from django.utils.functional import cached_property
 import pytz
 import re
 
@@ -199,6 +200,23 @@ class Election(models.Model):
             settings.YNR_BASE, self.slug, settings.YNR_UTM_QUERY_STRING
         )
 
+    @cached_property
+    def pluralized_division_name(self):
+        """
+        Returns a string for the pluarlized divison name for the posts in the
+        election
+        """
+        pluralise = {
+            "parish": "parishes",
+            "constituency": "constituencies",
+        }
+        suffix = self.post_set.first().division_suffix
+
+        if not suffix:
+            return "posts"
+
+        return pluralise.get(suffix, f"{suffix}s")
+
 
 class Post(models.Model):
     """
@@ -270,7 +288,7 @@ class Post(models.Model):
     @property
     def division_description(self):
         """
-        Return a string to describe the division
+        Return a string to describe the division.
         """
         mapping = {
             choice[0]: choice[1] for choice in self.DIVISION_TYPE_CHOICES

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -434,6 +434,24 @@ class PostElection(models.Model):
             return True
         return False
 
+    @cached_property
+    def next_ballot(self):
+        """
+        Return the next ballot for the related post. Return None if this is
+        the current election to avoid making an unnecessary db query.
+        """
+        if self.election.current:
+            return None
+
+        try:
+            return self.post.postelection_set.filter(
+                election__election_date__gt=self.election.election_date,
+                election__election_date__gte=datetime.date.today(),
+                election__election_type=self.election.election_type,
+            ).latest("election__election_date")
+        except PostElection.DoesNotExist:
+            return None
+
 
 class VotingSystem(models.Model):
     slug = models.SlugField(primary_key=True)

--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -35,7 +35,7 @@
             {% endif %}
         {% endif %}
 
-        <h3>Posts</h3>
+        <h3>{{ object.pluralized_division_name|title }}</h3>
         <ul>
           {% for postelection in object.postelection_set.all %}
             <li>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -2,8 +2,8 @@
 {% load humanize %}
 {% load static %}
 
-<section id="election_{{ postelection.election.slug }}">
-  <div class="card">
+<section>
+  <div class="card" id="election_{{ postelection.election.slug }}">
     {% if postelection.cancelled %}
       {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
     {% else %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -12,8 +12,8 @@
         {{ postelection.election.name_without_brackets }}
         <span aria-hidden="true">🗳️</span>
       </h1>
-      {% if postelection.friendly_name != postelection.election.nice_election_name %}
-        <h2>{{ postelection.friendly_name }}</h2>
+      {% if not postelection.is_pcc and not postelection.is_mayoral %}
+        <h2>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h2>
       {% endif %}
       {% if postelection.metadata.coronavirus_message %}
         <div style="border:1px solid red;margin:1em 0;padding:1em">
@@ -38,7 +38,7 @@
 
       <p>
         {% if postelection.election.in_past %}
-          <strong>{{ postelection.people|length }} candidates</strong> stood in {{ postelection.post.full_label }}.
+          <strong>{{ postelection.people|length }} candidates</strong> stood in the {{ postelection.friendly_name }}.
         {% else %}
           {# Display different messages depending on the number of candidates #}
           {# Case: No candidates for a contested election #}
@@ -53,12 +53,7 @@
                 You will have one vote, and can vote for a single party list or independent candidate.
               {% else %}
                 You can choose from <strong>{{ postelection.people|length }} candidates</strong>
-                in the
-                {% if 'mayor' in postelection.election.slug %}
-                  {{ postelection.election.nice_election_name }}.
-                {% else %}
-                  {{ postelection.post.full_label }}.
-                {% endif %}
+                in the {{ postelection.friendly_name }}.
 
                 {% if postelection.winner_count and postelection.election.voting_system_id == 'FPTP' %}
                   You will have {{ postelection.winner_count|intword }} vote{{ postelection.winner_count|pluralize }}.
@@ -72,7 +67,7 @@
               {# Case: Candidates and the post is NOT locked (add CTA) #}
               The official candidate list has not yet been published.
               However, we expect at least <strong>{{ postelection.people|length }} candidate{{postelection.people|pluralize}}</strong>
-              to stand in the {{ postelection.post.full_label }}.
+              to stand in the {{ postelection.friendly_name }}.
 
               You can help improve this page: <a href="{{ postelection.ynr_link }}">
               add information about candidates to our database</a>.

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -36,10 +36,8 @@
 
             <a href="#election_{{ ballot.election.slug }}">
             {{ ballot.election.nice_election_name }}
-            {% if ballot.post.label != post.election %}
-              {% if 'mayor' not in ballot.election.slug %}
-                : {{ ballot.post.label }}
-              {% endif %}
+            {% if ballot.post.label != post.election and not ballot.is_mayoral and not ballot.is_pcc %}
+              : {{ ballot.post.label }}
             {% endif %}
             </a>
             {{ ballot.short_cancelled_message_html }}

--- a/wcivf/apps/elections/templates/elections/party_list_view.html
+++ b/wcivf/apps/elections/templates/elections/party_list_view.html
@@ -7,7 +7,7 @@
     {% endif %}
 
     <h2>{{ party_name }}</h2>
-    <h3>{{ ballot.election.nice_election_name }}{% if ballot.friendly_name != ballot.election.nice_election_name %}: {{ ballot.friendly_name }}{% endif %}</h3>
+    <h3>{{ ballot.election.nice_election_name }}{% if not ballot.is_pcc and not ballot.is_mayoral %}: {{ ballot.friendly_name }}{% endif %}</h3>
     </header>
     <dl>
         {% if local_party.facebook_page %}

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -18,6 +18,21 @@
   {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}
 {% endif %}
 
+{% if postelection.next_ballot %}
+  <div class="card">
+    <h3>Next election</h3>
+    <p>
+      The <a href="{{ postelection.next_ballot.get_absolute_url }}">next election for {{ postelection.friendly_name }}</a> is
+        {% if postelection.next_ballot.election.is_election_day %}
+          <strong>being held today</strong>.
+        {% else %}
+          due to take place <strong>on {{ postelection.next_ballot.election.election_date|date:"l j F Y"}}</strong>.
+        {% endif %}
+    </p>
+  </div>
+{% endif %}
+
+
 {% if postelection.husting_set.exists %}
   <div class="card">
     <h3>Election events</h3>

--- a/wcivf/apps/elections/tests/factories.py
+++ b/wcivf/apps/elections/tests/factories.py
@@ -53,3 +53,13 @@ class PostElectionFactory(factory.django.DjangoModelFactory):
     ballot_paper_id = factory.Sequence(
         lambda n: "parl.place-name-%d.2015-05-07" % n
     )
+
+
+class ElectionWithPostFactory(ElectionFactoryLazySlug):
+    """
+    Builds an Election with a related Post through a PostElection
+    """
+
+    ballot = factory.RelatedFactory(
+        PostElectionFactory, factory_related_name="election"
+    )

--- a/wcivf/apps/elections/tests/factories.py
+++ b/wcivf/apps/elections/tests/factories.py
@@ -38,7 +38,6 @@ class PostFactory(factory.django.DjangoModelFactory):
 
     ynr_id = "WMC:E14000647"
     label = "copeland"
-    elections = factory.RelatedFactory(ElectionFactory)
     organization_type = "local-authority"
 
 

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -19,18 +19,10 @@ from pytest_django.asserts import assertContains
 )
 class ElectionViewTests(TestCase):
     def setUp(self):
-        self.election = ElectionFactory(
+        self.election = ElectionWithPostFactory(
             name="City of London Corporation local election",
             election_date="2017-03-23",
             slug="local.city-of-london.2017-03-23",
-        )
-        self.post = PostFactory(
-            ynr_id="LBW:E05009288", label="Aldersgate", elections=self.election
-        )
-        PostElection.objects.get_or_create(
-            election=self.election,
-            post=self.post,
-            ballot_paper_id="local.city-of-london.aldersgate.2017-03-23",
         )
 
     def test_election_list_view(self):

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -2,9 +2,10 @@ import pytest
 from django.shortcuts import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
-from elections.models import PostElection, Post
+from elections.models import Post
 from elections.tests.factories import (
     ElectionFactory,
+    ElectionWithPostFactory,
     PostElectionFactory,
     PostFactory,
 )
@@ -73,6 +74,25 @@ class ElectionViewTests(TestCase):
                 )
                 self.assertContains(response, election[0].nice_election_name)
                 self.assertContains(response, election[1])
+
+    def test_division_name_displayed(self):
+        """
+        For each Post.DIVISION_TYPE, creates an elections, gets a response for
+        from the ElectionDetail view, and checks that the response contains the
+        correct value for division name .e.g Ward
+        """
+        Post.DIVISION_TYPE_CHOICES.append(("", ""))
+        for division_type in Post.DIVISION_TYPE_CHOICES:
+            election = ElectionWithPostFactory(
+                ballot__post__division_type=division_type[0]
+            )
+            with self.subTest(election=election):
+                response = self.client.get(
+                    election.get_absolute_url(), follow=True
+                )
+                self.assertContains(
+                    response, election.pluralized_division_name.title()
+                )
 
 
 class ElectionPostViewTests(TestCase):

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -121,7 +121,7 @@ class TestYNRBallotImporter(TestCase):
         self.post = PostFactory(label="Adur local election")
         self.post.elections.add(election)
         self.orphan_post = PostFactory(
-            label="Adur local election", elections=None, ynr_id="foo"
+            label="Adur local election", ynr_id="foo"
         )
 
     def test_delete_orphan_posts(self):

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -2,14 +2,21 @@ import datetime
 import pytest
 
 from elections.models import Election, Post
-from elections.tests.factories import PostElectionFactory, PostFactory
-from django.test import TestCase
+from elections.tests.factories import (
+    ElectionWithPostFactory,
+    PostElectionFactory,
+    PostFactory,
+)
 
 
-class TestElectionModel(TestCase):
-    def setUp(self):
-        self.election = Election(slug="not.city-of-london")
-        self.city_of_london_election = Election(slug="local.city-of-london")
+class TestElectionModel:
+    @pytest.fixture
+    def election(self):
+        return Election(slug="not.city-of-london")
+
+    @pytest.fixture
+    def city_of_london_election(self):
+        return Election(slug="local.city-of-london")
 
     def test_in_past(self):
         yesterday = datetime.date.today() - datetime.timedelta(days=1)
@@ -17,17 +24,17 @@ class TestElectionModel(TestCase):
 
         assert election.in_past is True
 
-    def test_is_city_of_london(self):
-        assert self.election.is_city_of_london is False
-        assert self.city_of_london_election.is_city_of_london is True
+    def test_is_city_of_london(self, election, city_of_london_election):
+        assert election.is_city_of_london is False
+        assert city_of_london_election.is_city_of_london is True
 
-    def test_polls_close(self):
-        assert self.election.polls_close == datetime.time(22, 00)
-        assert self.city_of_london_election.polls_close == datetime.time(20, 0)
+    def test_polls_close(self, election, city_of_london_election):
+        assert election.polls_close == datetime.time(22, 00)
+        assert city_of_london_election.polls_close == datetime.time(20, 0)
 
-    def test_polls_open(self):
-        assert self.election.polls_open == datetime.time(7, 00)
-        assert self.city_of_london_election.polls_open == datetime.time(8, 0)
+    def test_polls_open(self, election, city_of_london_election):
+        assert election.polls_open == datetime.time(7, 00)
+        assert city_of_london_election.polls_open == datetime.time(8, 0)
 
     @pytest.mark.freeze_time("2021-05-06")
     def test_is_election_day(self):
@@ -39,8 +46,9 @@ class TestElectionModel(TestCase):
         assert future.is_election_day is False
         assert past.is_election_day is False
 
-    def test_name_without_brackets(self):
-        names = [
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
             (
                 "London Assembly Elections (Additional)",
                 "London Assembly Elections",
@@ -62,18 +70,41 @@ class TestElectionModel(TestCase):
                 "Scottish Parliament elections (Regions)",
                 "Scottish Parliament elections",
             ),
-        ]
-        for name in names:
-            with self.subTest(name=name):
-                self.election.any_non_by_elections = True
-                self.election.name = name[0]
-                self.assertEqual(self.election.name_without_brackets, name[1])
+        ],
+    )
+    def test_name_without_brackets(self, name, expected):
+        election = Election(name=name, any_non_by_elections=True)
+        assert election.name_without_brackets == expected
 
-    def test_name_without_brackets_by_election(self):
-        self.election.any_non_by_elections = False
-        self.election.name = "Scottish Parliament (Constituencies)"
+    def test_name_without_brackets_by_election(self, election):
+        election.any_non_by_elections = False
+        election.name = "Scottish Parliament (Constituencies)"
         expected = "Scottish Parliament by-election"
-        self.assertEqual(self.election.name_without_brackets, expected)
+        assert election.name_without_brackets == expected
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "suffix, expected",
+        [
+            ("constituency", "constituencies"),
+            ("parish", "parishes"),
+            ("ward", "wards"),
+            ("division", "divisions"),
+            ("area", "areas"),
+            ("region", "regions"),
+            ("", "posts"),
+        ],
+    )
+    def test_pluralized_division_suffix(self, mocker, suffix, expected):
+        election = ElectionWithPostFactory()
+        mocker.patch.object(
+            Post,
+            "division_suffix",
+            new_callable=mocker.PropertyMock,
+            return_value=suffix,
+        )
+
+        assert election.pluralized_division_name == expected
 
 
 class TestPostModel:

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -152,10 +152,26 @@ class TestPostElectionModel:
 
     def test_friendly_name_mayoral(self, post_election):
         post_election.ballot_paper_id = "mayor.of.london"
+        post_election.post.label = "Greater London Authority"
         assert (
             post_election.friendly_name
-            == post_election.election.nice_election_name
+            == "Greater London Authority mayoral election"
         )
+
+    @pytest.mark.parametrize(
+        "label, expected",
+        [
+            (
+                "Avon and Somerset Constabulary",
+                "Avon and Somerset Constabulary Police force area",
+            ),
+            ("North Yorkshire Police", "North Yorkshire Police force area"),
+        ],
+    )
+    def test_friendly_name_pcc(self, post_election, label, expected):
+        post_election.ballot_paper_id = "pcc.election"
+        post_election.post.label = label
+        assert post_election.friendly_name == expected
 
     def test_friendly_name(self, post_election):
         assert post_election.friendly_name == post_election.post.full_label
@@ -169,10 +185,6 @@ class TestPostElectionModel:
     ):
         post_election.ballot_paper_id = ballot_paper_id
         assert post_election.is_london_assembly_additional == expected
-
-    def test_friendly_name_london_assembly_additonal(self, post_election):
-        post_election.ballot_paper_id = "gla.a.2021-05-06"
-        assert post_election.friendly_name == "Additional members"
 
     @pytest.mark.parametrize(
         "org_type,expected", [("pcc.ballot", True), ("not.pcc", False)]

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -51,9 +51,7 @@ class PostcodeViewTests(TestCase):
     @vcr.use_cassette("fixtures/vcr_cassettes/test_ical_view.yaml")
     def test_ical_view(self):
         election = ElectionFactory(slug="local.cambridgeshire.2017-05-04")
-        post = PostFactory(
-            ynr_id="CED:romsey", label="Romsey", elections=election
-        )
+        post = PostFactory(ynr_id="CED:romsey", label="Romsey")
 
         PostElectionFactory(post=post, election=election)
         response = self.client.get("/elections/CB13HU.ics", follow=True)
@@ -62,9 +60,7 @@ class PostcodeViewTests(TestCase):
     @vcr.use_cassette("fixtures/vcr_cassettes/test_mayor_elections.yaml")
     def test_mayor_election_postcode_lookup(self):
         election = ElectionFactory(slug="mayor.tower-hamlets.2018-05-03")
-        post = PostFactory(
-            ynr_id="tower-hamlets", label="Tower Hamlets", elections=election
-        )
+        post = PostFactory(ynr_id="tower-hamlets", label="Tower Hamlets")
 
         PostElectionFactory(
             post=post,

--- a/wcivf/apps/hustings/tests/test_hustings.py
+++ b/wcivf/apps/hustings/tests/test_hustings.py
@@ -17,7 +17,6 @@ class TestHustings(TestCase):
         self.post = PostFactory(
             ynr_id="tower-hamlets",
             label="Tower Hamlets",
-            elections=self.election,
         )
         self.ballot = PostElectionFactory(
             post=self.post,

--- a/wcivf/apps/people/tests/test_person_standing_in_many_elections.py
+++ b/wcivf/apps/people/tests/test_person_standing_in_many_elections.py
@@ -13,10 +13,8 @@ class TestPersonInMultipleElections(TestCase):
         person = PersonFactory()
         election1 = ElectionFactory()
         election2 = ElectionFactory(slug="parl.2010")
-        post1 = PostFactory(elections=election2)
-        post2 = PostFactory(
-            ynr_id="WMC:E14000645", label="Southwark", elections=election2
-        )
+        post1 = PostFactory()
+        post2 = PostFactory(ynr_id="WMC:E14000645", label="Southwark")
 
         pe1 = PostElectionFactory(election=election1, post=post1)
         pe2 = PostElectionFactory(election=election2, post=post2)


### PR DESCRIPTION
Closes #183 

Display the next ballot for the same post on a previous ballot page. Open to suggestions about better wording/placing on the page, screenshot below of how it looks currently

<img width="1552" alt="Screenshot 2021-02-12 at 17 21 00" src="https://user-images.githubusercontent.com/15347726/107804134-73f7c000-6d5b-11eb-96f6-4de9de15f1e2.png">

Also updates the Election page to remove the hardcoded "Posts" and return the same work that is used on the ballot page e.g. "wards", "divisions" etc.

<img width="1552" alt="Screenshot 2021-02-12 at 17 21 09" src="https://user-images.githubusercontent.com/15347726/107804356-b4573e00-6d5b-11eb-8666-f09ad8842afe.png">

<img width="1552" alt="Screenshot 2021-02-12 at 17 21 14" src="https://user-images.githubusercontent.com/15347726/107804375-bae5b580-6d5b-11eb-99d6-79b0cc962521.png">

<img width="1552" alt="Screenshot 2021-02-12 at 17 21 19" src="https://user-images.githubusercontent.com/15347726/107804393-c0430000-6d5b-11eb-97b2-2654bc9af4a9.png">
