### PR TITLE
Fix meta description on ballot page

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -1,7 +1,10 @@
 {% if postelection.people|length %}
-{% autoescape off %}See all {{ postelection.people|length }} candidates in the {{ object.election.name }} on {{
-object.election.election_date }}: {% for pp in person_posts %}{{ pp.person.name|safe }}
-({{ pp.party.party_name }}) {% endfor %}{% endautoescape %}
+  {% autoescape off %}
+    See all {{ postelection.people|length }} candidates in the {{ object.election.name }} on {{ object.election.election_date }}:
+    {% for pp in postelection.people %}
+      {{ pp.person.name|safe }} ({{ pp.party.party_name }})
+    {% endfor %}
+  {% endautoescape %}
 {% else %}
-{{ object.election.name }}: No candidates known yet.
+  {{ object.election.name }}: No candidates known yet.
 {% endif %}


### PR DESCRIPTION
Noticed that on the London Assembly page that the Django templating language was being included in the meta description, seems like this was due to the brackets opening on a new line. Fixes this, and also fixes the forloop to display all candidate names, as this was using an incorrect template variable.

Original:

<img width="1552" alt="Screenshot 2021-02-15 at 10 39 17" src="https://user-images.githubusercontent.com/15347726/107936367-78e68a80-6f7a-11eb-9bd8-501da4fa3897.png">

Updated:

<img width="1552" alt="Screenshot 2021-02-15 at 10 39 23" src="https://user-images.githubusercontent.com/15347726/107936389-800d9880-6f7a-11eb-9508-b22c6c3ae7be.png">

- Bug due to whitespace meant election date was not displayed
- Fixed forloop
- Reformated the html