### PR TITLE
Display full person_detail.html if twfy_id exists

### DIFF
--- a/wcivf/apps/elections/migrations/0032_auto_20210210_1155.py
+++ b/wcivf/apps/elections/migrations/0032_auto_20210210_1155.py
@@ -6,7 +6,6 @@ from django.db import migrations
 def forwards(apps, schema_editor):
     Post = apps.get_model("elections", "Post")
     count, _ = Post.objects.filter(ynr_id="").delete()
-    print(f"Deleted {count} Post objects")
 
 
 class Migration(migrations.Migration):

--- a/wcivf/apps/people/views.py
+++ b/wcivf/apps/people/views.py
@@ -54,12 +54,11 @@ class PersonView(DetailView, PersonMixin):
 
     def get_template_names(self):
         """
-        When we don't have current candidacies,
-        we return an alternative template with
-        just intro and past elections.
+        When we don't have a TheyWorkForYou ID or the person has no current
+        candidacies, we return an alternative template with just intro and past
+        elections.
         """
-
-        if self.object.current_or_future_candidacies:
+        if self.object.twfy_id or self.object.current_or_future_candidacies:
             return ["people/person_detail.html"]
         return ["people/not_current_person_detail.html"]
 


### PR DESCRIPTION
As per #647 a reduced person detail page is displayed if a person did not have any current or future candidacies.

This resulted in lots of reduced pages for some high profile serving people such as MP's. Therefore this introduces a compromise, whereby if the person has a TheyWorkForYou profile that we have an ID for, then we display the full `person_detail.html` page.