### PR TITLE
Update import_people to update current candidacies

### DIFF
--- a/wcivf/apps/people/tests/test_import_people.py
+++ b/wcivf/apps/people/tests/test_import_people.py
@@ -1,0 +1,71 @@
+import pytest
+
+from elections.models import PostElection
+from people.management.commands.import_people import Command
+from people.models import Person
+
+
+class TestUpdateCandidacies:
+    @pytest.fixture
+    def person_data(self):
+        return {
+            "candidacies": [
+                {
+                    "elected": False,
+                    "party_list_position": 1,
+                    "party": {
+                        "url": "http://candidates.democracyclub.org.uk/api/next/parties/PP53/",
+                        "ec_id": "PP53",
+                        "name": "Labour Party",
+                        "legacy_slug": "party:53",
+                    },
+                    "ballot": {
+                        "url": "http://candidates.democracyclub.org.uk/api/next/ballots/parl.romsey-and-southampton-north.2010-05-06/",
+                        "ballot_paper_id": "parl.romsey-and-southampton-north.2010-05-06",
+                    },
+                },
+            ],
+        }
+
+    def test_update_candidacies(self, person_data, mocker):
+        person_obj = mocker.MagicMock(spec=Person)
+        person_obj.personpost_set.update_or_create.return_value = (False, {})
+        ballot = mocker.MagicMock(
+            spec=PostElection,
+            ballot_paper_id="parl.romsey-and-southampton-north.2010-05-06",
+        )
+        mocker.patch.object(PostElection.objects, "get", return_value=ballot)
+
+        command = Command()
+        command.update_candidacies(
+            person_data=person_data,
+            person_obj=person_obj,
+        )
+
+        person_obj.personpost_set.update_or_create.assert_called_once_with(
+            post_election=ballot,
+            post=ballot.post,
+            election=ballot.election,
+            defaults={
+                "party_id": "party:53",
+                "list_position": 1,
+                "elected": False,
+            },
+        )
+
+    def test_delete_old_candidacies(self, person_data, mocker):
+        person_obj = mocker.MagicMock(spec=Person)
+        delete = mocker.MagicMock(return_value=(False, {}))
+        person_obj.personpost_set.exclude.return_value.delete = delete
+
+        command = Command()
+        command.delete_old_candidacies(
+            person_data=person_data, person_obj=person_obj
+        )
+
+        person_obj.personpost_set.exclude.assert_called_once_with(
+            post_election__ballot_paper_id__in=[
+                "parl.romsey-and-southampton-north.2010-05-06"
+            ]
+        )
+        delete.assert_called_once()


### PR DESCRIPTION
The main change here is to ensure that when `import_people --recent` is run (e.g. by [cron](https://github.com/DemocracyClub/who_deploy/blob/master/crontab.yml#L58)) existing candidacies are updated with information such as their `list_postion` on a ballot etc. Previously, the importer only deleted old candidacies and added new ones. This came about after a [message in slack](https://democracyclub.slack.com/archives/C04U18ETS/p1613335553060400) where a volunteer had updated details in YNR that were not replicated in WCIVF until the overnight import_ballots update cron was run.

In the process this has involved a slight refactor of how the importer runs to hopefully make it a little clearer, and easier to test.

I have also run the importer locally successfully - my local DB had the unordered list of candidates for London Assembly which now match the order on the live site:

localhost:
<img width="1552" alt="Screenshot 2021-02-16 at 16 53 36" src="https://user-images.githubusercontent.com/15347726/108095358-ad8c3c00-7077-11eb-851c-5d7848dc00dd.png">


WCIVF:
<img width="1552" alt="Screenshot 2021-02-16 at 16 54 00" src="https://user-images.githubusercontent.com/15347726/108095377-b1b85980-7077-11eb-9fb8-32163c05e8a9.png">

