### PR TITLE
Try to fix dependabot ignore syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,5 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   ignore:
-  - dependency-name: django
-    versions:
-    - 2.x
+    - dependency-name: django
+      versions: [">=3.0", "<3.2"]


### PR DESCRIPTION
Dependabot PR for Django 3.0 was opened to this tried to update the config to ignore updates for version 3 matching syntax in the docs https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore