### PR TITLE
Feature/local parties 2021

### DIFF
--- a/wcivf/apps/core/helpers.py
+++ b/wcivf/apps/core/helpers.py
@@ -1,6 +1,7 @@
 import re
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 import json
 
 
@@ -47,3 +48,10 @@ def clean_postcode(postcode):
     space_regex = re.compile(r" *(%s)$" % incode_pattern)
     postcode = space_regex.sub(r" \1", postcode.upper())
     return postcode
+
+
+def twitter_username(url):
+    """
+    Returns username from a twitter url
+    """
+    return urlparse(url).path.strip("/")

--- a/wcivf/apps/core/mixins.py
+++ b/wcivf/apps/core/mixins.py
@@ -1,0 +1,16 @@
+import csv
+import requests
+
+
+class ReadFromUrlMixin:
+    def read_from_url(self, url):
+        with requests.get(url, stream=True) as r:
+            r.encoding = "utf-8"
+            yield from csv.DictReader(r.iter_lines(decode_unicode=True))
+
+
+class ReadFromFileMixin:
+    def read_from_file(self, path_to_file):
+        with open(path_to_file, "r") as fh:
+            reader = csv.DictReader(fh)
+            yield from reader

--- a/wcivf/apps/parties/importers.py
+++ b/wcivf/apps/parties/importers.py
@@ -1,31 +1,78 @@
 import sys
+from collections import namedtuple
 
-from core.mixins import ReadFromUrlMixin
+from core.mixins import ReadFromUrlMixin, ReadFromFileMixin
 from core.helpers import twitter_username
-from elections.models import PostElection
+from elections.models import PostElection, Election
 from parties.models import LocalParty, Party
 
 
-class LocalPartyImporter(ReadFromUrlMixin):
-    def __init__(self, url, stdout=sys.stdout) -> None:
-        self.url = url
-        self.stdout = stdout
+LocalElection = namedtuple("LocalElection", ["date", "csv_files"])
+
+
+class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
+
+    # TODO check if this need updating
+    JOINT_PARTIES = [["party:53", "joint-party:53-119"]]
+
+    def __init__(self, election, force_update=False, from_file=False):
+        self.election = election
+        self.force_update = force_update
+        self.read_from = getattr(self, "read_from_url")
+        if from_file:
+            self.read_from = getattr(self, "read_from_file")
+
+    def write(self, msg):
+        """
+        Ensures all outputs include a new line
+        """
+        sys.stdout.write(f"{msg}\n")
+
+    def delete_parties_for_election_date(self):
+        """
+        Deletes LocalParty objects associated with elections for the given
+        election date
+        """
+        count, _ = LocalParty.objects.filter(
+            post_election__election__election_date=self.election.date,
+        ).delete()
+        self.write(f"Deleted {count} local parties for {self.election.date}")
+
+    def current_elections(self):
+        """
+        Checks for current Election objects with the given date
+        """
+        if self.force_update:
+            return True
+
+        return Election.objects.filter(
+            current=True, election_date=self.election.date
+        ).exists()
 
     def get_party_list_from_party_id(self, party_id):
+        """
+        Checks for any joint parties for the given party id
+        """
         party_id = f"party:{party_id}"
 
-        PARTIES = [["party:53", "joint-party:53-119"]]
-
-        for party_list in PARTIES:
+        for party_list in self.JOINT_PARTIES:
             if party_id in party_list:
                 return party_list
         return [party_id]
 
     def get_parties(self, party_id):
+        """
+        Return a QuerySet of Party objects for the party_id
+        """
         party_list = self.get_party_list_from_party_id(party_id)
         return Party.objects.filter(party_id__in=party_list)
 
     def get_ballots(self, election_id, parties):
+        """
+        Attempts to find a single PostElection object for the election_id. If
+        this does not exist, it may be that the ID is for an Election object, so
+        we return all ballots for that election ID.
+        """
         ballots = PostElection.objects.filter(ballot_paper_id=election_id)
 
         if not ballots:
@@ -38,33 +85,18 @@ class LocalPartyImporter(ReadFromUrlMixin):
 
         return ballots
 
-    def add_parties(self):
-        for row in self.read_from_url(url=self.url):
-            name = row["Local party name"]
-            party_id = (row["party_id"] or "").strip()
-            if not party_id or not name:
-                self.stdout.write("Missing data, skipping row\n")
-                continue
-
-            parties = self.get_parties(party_id=party_id)
-            if not parties:
-                self.stdout.write(
-                    f"Parent party not found with IDs {party_id}\n"
-                )
-                continue
-
-            ballots = self.get_ballots(
-                election_id=row["election_id"],
-                parties=parties,
-            )
-            if not ballots:
-                self.stdout.write("Skipping as no ballots to use\n")
-                continue
-
-            for party in parties:
-                self.add_local_party(row, party, ballots)
+    def all_rows(self):
+        """
+        Yields all CSV rows from multiple files
+        """
+        for file in self.election.csv_files:
+            yield from self.read_from(file)
 
     def add_local_party(self, row, party, ballots):
+        """
+        Takes a row of data, a Party, and a QuerySet of at least one
+        PostElection objects, and craetes a LocalParty for each of the ballots.
+        """
         twitter = twitter_username(url=row["Twitter"] or "")
         for post_election in ballots:
             local_party, created = LocalParty.objects.update_or_create(
@@ -79,6 +111,44 @@ class LocalPartyImporter(ReadFromUrlMixin):
                 },
             )
 
-            self.stdout.write(
-                f"{local_party.name} was {'created' if created else 'updated'}\n"
+            self.write(
+                f"{local_party.name} was {'created' if created else 'updated'}"
             )
+
+    def import_parties(self):
+        """
+        This is the main action that is run by the class. First existing
+        LocalParty objects for an election are deleted. Then it validates the
+        row contains data we can use. Then adds a LocalParty object for each
+        parent party.
+        """
+        self.delete_parties_for_election_date()
+
+        if not self.current_elections():
+            self.write(
+                f"No current elections for {self.election.date}, skipping"
+            )
+            return
+
+        for row in self.all_rows():
+            name = row["Local party name"]
+            party_id = (row["party_id"] or "").strip()
+            if not party_id or not name:
+                self.write("Missing data, skipping row")
+                continue
+
+            parties = self.get_parties(party_id=party_id)
+            if not parties:
+                self.write(f"Parent party not found with IDs {party_id}")
+                continue
+
+            ballots = self.get_ballots(
+                election_id=row["election_id"],
+                parties=parties,
+            )
+            if not ballots:
+                self.write("Skipping as no ballots to use")
+                continue
+
+            for party in parties:
+                self.add_local_party(row, party, ballots)

--- a/wcivf/apps/parties/importers.py
+++ b/wcivf/apps/parties/importers.py
@@ -1,0 +1,84 @@
+import sys
+
+from core.mixins import ReadFromUrlMixin
+from core.helpers import twitter_username
+from elections.models import PostElection
+from parties.models import LocalParty, Party
+
+
+class LocalPartyImporter(ReadFromUrlMixin):
+    def __init__(self, url, stdout=sys.stdout) -> None:
+        self.url = url
+        self.stdout = stdout
+
+    def get_party_list_from_party_id(self, party_id):
+        party_id = f"party:{party_id}"
+
+        PARTIES = [["party:53", "joint-party:53-119"]]
+
+        for party_list in PARTIES:
+            if party_id in party_list:
+                return party_list
+        return [party_id]
+
+    def get_parties(self, party_id):
+        party_list = self.get_party_list_from_party_id(party_id)
+        return Party.objects.filter(party_id__in=party_list)
+
+    def get_ballots(self, election_id, parties):
+        ballots = PostElection.objects.filter(ballot_paper_id=election_id)
+
+        if not ballots:
+            # This might be an election ID, in that case,
+            # apply thie row to all post elections without
+            # info already
+            ballots = PostElection.objects.filter(
+                election__slug=election_id
+            ).exclude(localparty__parent__in=parties)
+
+        return ballots
+
+    def add_parties(self):
+        for row in self.read_from_url(url=self.url):
+            name = row["Local party name"]
+            party_id = (row["party_id"] or "").strip()
+            if not party_id or not name:
+                self.stdout.write("Missing data, skipping row\n")
+                continue
+
+            parties = self.get_parties(party_id=party_id)
+            if not parties:
+                self.stdout.write(
+                    f"Parent party not found with IDs {party_id}\n"
+                )
+                continue
+
+            ballots = self.get_ballots(
+                election_id=row["election_id"],
+                parties=parties,
+            )
+            if not ballots:
+                self.stdout.write("Skipping as no ballots to use\n")
+                continue
+
+            for party in parties:
+                self.add_local_party(row, party, ballots)
+
+    def add_local_party(self, row, party, ballots):
+        twitter = twitter_username(url=row["Twitter"] or "")
+        for post_election in ballots:
+            local_party, created = LocalParty.objects.update_or_create(
+                parent=party,
+                post_election=post_election,
+                defaults={
+                    "name": row["Local party name"],
+                    "twitter": twitter,
+                    "facebook_page": row["Facebook"],
+                    "homepage": row["Website"],
+                    "email": row["Email"],
+                },
+            )
+
+            self.stdout.write(
+                f"{local_party.name} was {'created' if created else 'updated'}\n"
+            )

--- a/wcivf/apps/parties/management/commands/import_local_parties.py
+++ b/wcivf/apps/parties/management/commands/import_local_parties.py
@@ -1,36 +1,28 @@
-from collections import namedtuple
 from dateutil.parser import parse
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from core.mixins import ReadFromUrlMixin
-from core.helpers import twitter_username
-from parties.models import Party, LocalParty
-from parties.importers import LocalPartyImporter
-from elections.models import Election, PostElection
+from parties.importers import LocalPartyImporter, LocalElection
 
 
-LocalElection = namedtuple("LocalElection", ["date", "urls"])
-
-
-class Command(ReadFromUrlMixin, BaseCommand):
+class Command(BaseCommand):
     ELECTIONS = [
         LocalElection(
             date="2018-05-03",
-            urls=[
+            csv_files=[
                 "https://docs.google.com/spreadsheets/d/e/2PACX-1vS3pC0vtT9WaCyKDzqARQZY6aoYCyKZLyIvumKaX3TpqG0rt4y0fXp6dOPOZGMX6v0dFczHfizwidwZ/pub?gid=582783400&single=true&output=csv",
             ],
         ),
         LocalElection(
             date="2019-05-02",
-            urls=[
+            csv_files=[
                 "https://docs.google.com/spreadsheets/d/e/2PACX-1vTO-z37bBMxKwCuORIl2vE8v0kMFHlHETvBhGjuDidM1Wy4QxQawRou53kNLjEiJmpMhebRqoWZL9s-/pub?gid=0&single=true&output=csv",
             ],
         ),
         LocalElection(
             date="2021-05-06",
-            urls=[
+            csv_files=[
                 "https://docs.google.com/spreadsheets/d/e/2PACX-1vQx49JTec8i5oz_x6SJanvSKPc8BccanIlnGR4j0plbD99QFslXw7JEvWSNtdrJiePBMBi0AXkvw3e7/pub?gid=1210343217&single=true&output=csv",
                 "https://docs.google.com/spreadsheets/d/e/2PACX-1vQx49JTec8i5oz_x6SJanvSKPc8BccanIlnGR4j0plbD99QFslXw7JEvWSNtdrJiePBMBi0AXkvw3e7/pub?gid=2091491905&single=true&output=csv",
                 "https://docs.google.com/spreadsheets/d/e/2PACX-1vQx49JTec8i5oz_x6SJanvSKPc8BccanIlnGR4j0plbD99QFslXw7JEvWSNtdrJiePBMBi0AXkvw3e7/pub?gid=1013163356&single=true&output=csv",
@@ -41,41 +33,56 @@ class Command(ReadFromUrlMixin, BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--force-update",
             "-f",
+            "--force-update",
             action="store_true",
-            help="The date of elections this file has data about",
+            help="Will update regardless of whether there are current elections for the date",
+        )
+        parser.add_argument(
+            "-ff",
+            "--from-file",
+            nargs=2,
+            metavar=("election_date", "path_to_file"),
+            help="To import from a file, pass in an election date and the path to the file",
         )
 
     def valid_date(self, value):
         return parse(value)
 
-    def delete_current_data(self, election):
-        count, _ = LocalParty.objects.filter(
-            post_election__election__election_date=election.date,
-        ).delete()
-        self.stdout.write(f"Deleted {count} old objects")
+    def import_from_file(self):
+        """
+        Runs the importer for the file passed in arguments
+        """
+        date, filepath = self.options["from_file"]
+        if not self.valid_date(value=date):
+            self.stdout.write("Date is invalid")
+            return
 
-    def current_elections(self, election):
-        if self.force_update:
-            return True
-        return Election.objects.filter(
-            current=True, election_date=election.date
-        ).exists()
+        election = LocalElection(date=date, csv_files=[filepath])
+        importer = LocalPartyImporter(
+            election=election,
+            force_update=self.options["force_update"],
+            from_file=True,
+        )
+        importer.import_parties()
+
+    def import_from_elections(self):
+        """
+        Runs the importer for all elections in the ELECTIONS list. This is the
+        default method of running the import process
+        """
+        for election in self.ELECTIONS:
+            importer = LocalPartyImporter(
+                election=election,
+                force_update=self.options["force_update"],
+            )
+            importer.import_parties()
 
     @transaction.atomic
     def handle(self, **options):
-        self.force_update = options["force_update"]
+        self.options = options
 
-        for election in self.ELECTIONS:
-            self.delete_current_data(election=election)
+        if options["from_file"]:
+            return self.import_from_file()
 
-            if not self.current_elections(election=election):
-                self.stdout.write(
-                    f"No current elections for {election.date}, skipping"
-                )
-                continue
-
-            for url in election.urls:
-                importer = LocalPartyImporter(url=url)
-                importer.add_parties()
+        self.import_from_elections()

--- a/wcivf/apps/parties/models.py
+++ b/wcivf/apps/parties/models.py
@@ -101,6 +101,9 @@ class LocalParty(models.Model):
     homepage = models.URLField(blank=True, max_length=800)
     email = models.EmailField(blank=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Manifesto(models.Model):
     COUNTRY_CHOICES = (

--- a/wcivf/apps/parties/tests/test_importers.py
+++ b/wcivf/apps/parties/tests/test_importers.py
@@ -1,0 +1,157 @@
+import sys
+import pytest
+from elections.models import Election, PostElection
+
+from parties.importers import LocalPartyImporter, LocalElection
+from parties.models import LocalParty
+
+
+class TestLocalPartyImporter:
+    @pytest.fixture
+    def local_election(self):
+        return LocalElection(
+            date="2021-05-06",
+            csv_files=[
+                "https://docs.google.com/spreadsheets/d/e/2PACX-1vQx49JTec8i5oz_x6SJanvSKPc8BccanIlnGR4j0plbD99QFslXw7JEvWSNtdrJiePBMBi0AXkvw3e7/pub?gid=1210343217&single=true&output=csv",
+            ],
+        )
+
+    @pytest.fixture
+    def importer(self, local_election):
+        return LocalPartyImporter(election=local_election)
+
+    @pytest.fixture
+    def row(self):
+        return {
+            "Local party name": "Labour Ecclesall",
+            "party_id": "53",
+            "election_id": "local.sheffield.2021-05-06",
+            "Twitter": "https://twitter.com/example",
+            "Facebook": "https://facebook.com/example",
+            "Website": "https://example.com",
+            "Email": "email@example.com",
+        }
+
+    def test_init(self, local_election):
+        importer = LocalPartyImporter(election=local_election)
+        assert importer.election == local_election
+        assert importer.force_update is False
+        assert importer.read_from == importer.read_from_url
+
+    def test_init_from_file(self, mocker):
+        election = mocker.Mock()
+        importer = LocalPartyImporter(election=election, from_file=True)
+        assert importer.election == election
+        assert importer.force_update is False
+        assert importer.read_from == importer.read_from_file
+
+    def test_write(self, importer, mocker):
+        mocker.patch.object(sys.stdout, "write")
+        importer.write("Foo")
+        sys.stdout.write.assert_called_once_with("Foo\n")
+
+    def test_delete_parties_for_election_date(self, importer, mocker):
+        filter = mocker.MagicMock()
+        filter.return_value.delete.return_value = (0, {})
+        mocker.patch.object(LocalParty.objects, "filter", new=filter)
+        importer.delete_parties_for_election_date()
+        filter.assert_called_once_with(
+            post_election__election__election_date=importer.election.date
+        )
+        filter.return_value.delete.assert_called_once()
+
+    def test_current_elections(self, importer):
+        importer.force_update = True
+        assert importer.current_elections() is True
+
+    @pytest.mark.parametrize("exists", [True, False])
+    def test_current_elections_dont_force(self, importer, mocker, exists):
+        filter = mocker.MagicMock()
+        filter.return_value.exists.return_value = exists
+        mocker.patch.object(Election.objects, "filter", new=filter)
+        assert importer.current_elections() is exists
+        filter.assert_called_once_with(
+            current=True, election_date=importer.election.date
+        )
+        filter.return_value.exists.assert_called_once()
+
+    def test_get_ballots_filters_by_ballot_paper_id(self, importer, mocker):
+        mocker.patch.object(PostElection.objects, "filter", return_value=True)
+        parties = mocker.MagicMock()
+        result = importer.get_ballots(election_id="Foo", parties=parties)
+        assert result is True
+        PostElection.objects.filter.assert_called_once()
+        PostElection.objects.filter.assert_called_once_with(
+            ballot_paper_id="Foo"
+        )
+
+    def test_get_ballots_filter_by_election_slug(self, importer, mocker):
+        mock = mocker.MagicMock()
+        mock.__bool__.return_value = False
+        mocker.patch.object(PostElection.objects, "filter", return_value=mock)
+        parties = mocker.MagicMock()
+        importer.get_ballots(election_id="Foo", parties=parties)
+        PostElection.objects.filter.assert_called_with(
+            election__slug="Foo",
+        )
+        mock.exclude.assert_called_once_with(
+            localparty__parent__in=parties,
+        )
+
+    def test_import_parties_no_current_elections(self, importer, mocker):
+        mocker.patch.object(importer, "delete_parties_for_election_date")
+        mocker.patch.object(importer, "current_elections", return_value=False)
+        mocker.patch.object(importer, "all_rows")
+
+        assert importer.import_parties() is None
+        importer.delete_parties_for_election_date.assert_called_once()
+        importer.current_elections.assert_called_once()
+        importer.all_rows.assert_not_called()
+
+    def test_import_parties_runs(self, importer, row, mocker):
+        mocker.patch.object(importer, "delete_parties_for_election_date")
+        mocker.patch.object(importer, "current_elections")
+
+        party = mocker.MagicMock()
+        mocker.patch.object(importer, "get_parties", return_value=[party])
+
+        ballots = mocker.MagicMock()
+        mocker.patch.object(importer, "get_ballots", return_value=ballots)
+
+        mocker.patch.object(importer, "all_rows", return_value=[row])
+
+        mocker.patch.object(importer, "add_local_party")
+
+        # actual call to do the import
+        importer.import_parties()
+
+        # assert what we expet to have been called was called
+        importer.delete_parties_for_election_date.assert_called_once()
+        importer.current_elections.assert_called_once()
+        importer.all_rows.assert_called()
+        importer.add_local_party.assert_called_once_with(row, party, ballots)
+
+    def test_add_local_party(self, importer, row, mocker):
+        party = mocker.MagicMock(name="Example Local Party")
+        mocker.patch.object(
+            LocalParty.objects,
+            "update_or_create",
+            return_value=(party, True),
+        )
+        party = mocker.MagicMock()
+        post_election = mocker.MagicMock()
+        ballots = mocker.MagicMock()
+        ballots.__iter__.return_value = [post_election]
+
+        importer.add_local_party(row=row, party=party, ballots=ballots)
+        LocalParty.objects.update_or_create.assert_called_once_with(
+            parent=party,
+            post_election=post_election,
+            defaults={
+                "name": row["Local party name"],
+                "twitter": "example",
+                "facebook_page": row["Facebook"],
+                "homepage": row["Website"],
+                "email": row["Email"],
+            },
+        )


### PR DESCRIPTION
Update the local parties import management command so that it can be run without passing a file, reading directly from urls. This will allow us to clean up the cron jobs in the deployment repo when merged. This has been done by refactoring to remove the bulk of the import process in to a new importer class.

Have left partial commit history to try to help with the review, but intend to rebase before merging