### PR TITLE
Update hustings import management command for 2021

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_hustings_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/_hustings_list.html
@@ -3,6 +3,6 @@
 {% for husting in hustings %}
 <p>
 {% if husting.in_past %}(Past event) {% endif %}
-<strong>{{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:</strong> {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}, {{ husting.location }} {{ husting.postcode }}. {% if husting.postevent_url %}<a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>{% endif %}
+<strong>{{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:</strong> {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}{% if husting.location %}, {{ husting.location }} {{ husting.postcode }}{% endif %}{% if husting.postevent_url %}<br><a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>{% endif %}
 </p>
 {% endfor %}

--- a/wcivf/apps/elections/templates/elections/includes/_hustings_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/_hustings_list.html
@@ -1,8 +1,0 @@
-{% load humanize %}
-
-{% for husting in hustings %}
-<p>
-{% if husting.in_past %}(Past event) {% endif %}
-<strong>{{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:</strong> {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}{% if husting.location %}, {{ husting.location }} {{ husting.postcode }}{% endif %}{% if husting.postevent_url %}<br><a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>{% endif %}
-</p>
-{% endfor %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -141,13 +141,14 @@
     <div class="card">
       <h3>
         <span aria-hidden="true">📅</span>
-        Election events near you
+        Husting events
         <span aria-hidden="true">📅</span>
       </h3>
-      <p>You can meet candidates and question them at local hustings.</p>
+      <p>You can meet candidates and question them at husting events taking place online.</p>
       {% include "elections/includes/_hustings_list.html" with hustings=postelection.husting_set.all %}
     </div>
   {% endif %}
+
   {% if postelection.ballotnewsarticle_set.exists %}
     {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}
   {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -138,15 +138,7 @@
 
 
   {% if postelection.husting_set.exists %}
-    <div class="card">
-      <h3>
-        <span aria-hidden="true">📅</span>
-        Husting events
-        <span aria-hidden="true">📅</span>
-      </h3>
-      <p>You can meet candidates and question them at husting events taking place online.</p>
-      {% include "elections/includes/_hustings_list.html" with hustings=postelection.husting_set.all %}
-    </div>
+    {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.all %}
   {% endif %}
 
   {% if postelection.ballotnewsarticle_set.exists %}
@@ -160,5 +152,5 @@
       <p><a href="{{ postelection.wikipedia_url }}">Read more on Wikipedia</a></p>
     </div>
   {% endif %}
-  {% include "elections/includes/_ld_election.html" with election=object %}
+  {% include "elections/includes/_ld_election.html" with election=postelection %}
 </div>

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -32,14 +32,6 @@
   </div>
 {% endif %}
 
-
-{% if postelection.husting_set.exists %}
-  <div class="card">
-    <h3>Election events</h3>
-    {% include "elections/includes/_hustings_list.html" with hustings=postelection.husting_set.all %}
-  </div>
-{% endif %}
-
 {% include "elections/includes/_postcode_search_form.html" %}
 
 {#{% include "feedback/feedback_form.html" %}#}

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -181,4 +181,16 @@ class PostcodeiCalView(
 
             cal.add_component(event)
 
+            # add hustings events if there are any
+            for husting in post_election.husting_set.all():
+                event = Event()
+                event["uid"] = husting.uuid
+                event["summary"] = husting.title
+                event.add("dtstamp", timezone.now())
+                event.add("dtstart", husting.starts)
+                if husting.ends:
+                    event.add("dtend", husting.ends)
+                event.add("DESCRIPTION", f"Find out more at {husting.url}")
+                cal.add_component(event)
+
         return HttpResponse(cal.to_ical(), content_type="text/calendar")

--- a/wcivf/apps/hustings/README.md
+++ b/wcivf/apps/hustings/README.md
@@ -7,5 +7,11 @@ The term is used synonymously with stump in the United States.
 **Or so says [Wikipedia](https://en.wikipedia.org/wiki/Husting)**
 
 
-To load the hustings from a Google Sheet check the URLS in `import_hustings` are
-correct, then runx `python manage.py import_hustings`
+To load the hustings from a Google Sheet check the URLS in `import_hustings` are correct.
+
+Then run `python manage.py import_hustings`.
+
+You can also import hustings from a csv file by using the `--filename` flag and passing the
+path to the csv file. However this will delete all existing hustings and only create those
+from within the file, so be careful when using this - it is mainly intended to help with
+local development.

--- a/wcivf/apps/hustings/README.md
+++ b/wcivf/apps/hustings/README.md
@@ -7,6 +7,5 @@ The term is used synonymously with stump in the United States.
 **Or so says [Wikipedia](https://en.wikipedia.org/wiki/Husting)**
 
 
-To load the hustings, first download the Hustings Google Sheet as a CSV
-
-Then run `python manage.py import_hustings path/to/that.csv`
+To load the hustings from a Google Sheet check the URLS in `import_hustings` are
+correct, then runx `python manage.py import_hustings`

--- a/wcivf/apps/hustings/importers.py
+++ b/wcivf/apps/hustings/importers.py
@@ -1,0 +1,14 @@
+from core.mixins import ReadFromUrlMixin, ReadFromFileMixin
+
+
+class HustingImporter(ReadFromUrlMixin, ReadFromFileMixin):
+    def __init__(self, url=None, file_path=None):
+        self.url = url
+        self.file_path = file_path
+
+    @property
+    def rows(self):
+        if self.file_path:
+            yield from self.read_from_file(path_to_file=self.file_path)
+        else:
+            yield from self.read_from_url(url=self.url)

--- a/wcivf/apps/hustings/management/commands/import_hustings.py
+++ b/wcivf/apps/hustings/management/commands/import_hustings.py
@@ -2,7 +2,6 @@
 Importer for all our important Hustings data
 """
 import os
-import csv
 import datetime
 
 from django.core.management.base import BaseCommand
@@ -11,21 +10,27 @@ from django.utils import timezone
 
 from elections.models import PostElection
 from hustings.models import Husting
+from hustings.importers import HustingImporter
 
 
 def dt_from_string(dt):
     """
     Given a date string DT, return a datetime object.
-    Try multiple strptime formats b/c Google sheets doesn't
-    understand counting to three.
     """
-    date = None
+    try:
+        date = datetime.datetime.strptime(dt, "%Y-%m-%d")
+    except ValueError:
+        pass
+    else:
+        return timezone.make_aware(date, timezone.get_current_timezone())
+
+    # kept for legacy reasons - previous years used different date formatting
     try:
         date = datetime.datetime.strptime(dt, "%Y-%b-%d")
     except ValueError:
         date = datetime.datetime.strptime(dt, "%Y-%B-%d")
-    if date:
-        return timezone.make_aware(date, timezone.get_current_timezone())
+
+    return timezone.make_aware(date, timezone.get_current_timezone())
 
 
 def stringy_time_to_inty_time(stringy_time):
@@ -49,9 +54,22 @@ def set_time_string_on_datetime(dt, time_string):
 
 
 class Command(BaseCommand):
+
+    GOOGLE_SHEET_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQIvJtlR9j6BaOuLjd501W4mPznJX41k1LalgkXvwRLj0d90lyFaW3PoVLzLvw5K4Kvv4lETQIJyzdL/"
+    URLS = [
+        f"{GOOGLE_SHEET_URL}pub?gid=0&single=true&output=csv",
+        f"{GOOGLE_SHEET_URL}pub?gid=742711428&single=true&output=csv",
+        f"{GOOGLE_SHEET_URL}pub?gid=908428564&single=true&output=csv",
+        f"{GOOGLE_SHEET_URL}pub?gid=1265695055&single=true&output=csv",
+        f"{GOOGLE_SHEET_URL}pub?gid=668485812&single=true&output=csv",
+        f"{GOOGLE_SHEET_URL}pub?gid=1596983142&single=true&output=csv",
+    ]
+
     def add_arguments(self, parser):
         parser.add_argument(
-            "filename", help="Path to the file with the hustings in it"
+            "--filename",
+            required=False,
+            help="Path to the file with the hustings in it",
         )
         parser.add_argument(
             "--quiet",
@@ -60,27 +78,14 @@ class Command(BaseCommand):
             default=False,
             help="Only output errors",
         )
-        parser.add_argument(
-            "--for-date",
-            action="store",
-            dest="date",
-            required=True,
-            help="The date of the elections this file is about",
-        )
-
-    def delete_all_hustings(self, election_date):
-        """
-        Clear our hustings away.
-        """
-        Husting.objects.filter(
-            post_election__election__election_date=election_date
-        ).delete()
 
     def create_husting(self, row):
         """
         Create an individual husting
         """
-        starts = dt_from_string(row["Date (YYYY-Month-DD)"])
+        # kept the second option to work with previous years spreadsheets
+        starts = row.get("Date (YYYY-MM-DD)") or row.get("Date (YYYY-Month-DD)")
+        starts = dt_from_string(starts)
         ends = None
         if row["Start time (00:00)"]:
             starts = set_time_string_on_datetime(
@@ -97,19 +102,38 @@ class Command(BaseCommand):
             # This might be a parent election ID
             pes = PostElection.objects.filter(election__slug=row["Election ID"])
         for pe in pes:
-            husting = Husting(
+            husting = Husting.objects.create(
                 post_election=pe,
                 title=row["Title of event"],
                 url=row["Link to event information"],
                 starts=starts,
                 ends=ends,
-                location=row["Name of event location (e.g. Church hall)"],
-                postcode=row["Postcode of event location"],
+                location=row.get("Name of event location (e.g. Church hall)"),
+                postcode=row.get("Postcode of event location"),
                 postevent_url=row[
                     "Link to post-event information (e.g. blog post, video)"
                 ],
             )
-            husting.save()
+            return husting
+
+    def import_hustings(self):
+        for row in self.importer.rows:
+            try:
+                husting = self.create_husting(row)
+            except ValueError as e:
+                self.stdout.write(repr(e))
+                husting = None
+
+            if not husting:
+                self.stdout.write(f"Couldn't create {row['Title of event']}")
+                continue
+
+            self.hustings_counter += 1
+            self.stdout.write(
+                "Created husting {0} <{1}>".format(
+                    self.hustings_counter, husting
+                )
+            )
 
     @transaction.atomic
     def handle(self, **options):
@@ -119,22 +143,14 @@ class Command(BaseCommand):
         if options["quiet"]:
             self.stdout = open(os.devnull, "w")
 
-        for_election = options["date"]
+        count, _ = Husting.objects.all().delete()
+        self.stdout.write(f"Deleted {count} Husting objects")
 
-        self.delete_all_hustings(for_election)
-        hustings_counter = 0
-        self.not_a_constituency_friend = []
-        with open(options["filename"], "r") as fh:
-            reader = csv.DictReader(fh)
-            for row in reader:
-                try:
-                    husting = self.create_husting(row)
-                except:
-                    husting = None
-                if husting:
-                    hustings_counter += 1
-                    self.stdout.write(
-                        "Created husting {0} <{1}>".format(
-                            hustings_counter, husting
-                        )
-                    )
+        self.hustings_counter = 0
+        if options["filename"]:
+            self.importer = HustingImporter(file_path=options["filename"])
+            return self.import_hustings()
+
+        for url in self.URLS:
+            self.importer = HustingImporter(url=url)
+            self.import_hustings()

--- a/wcivf/apps/hustings/management/commands/import_hustings.py
+++ b/wcivf/apps/hustings/management/commands/import_hustings.py
@@ -143,11 +143,19 @@ class Command(BaseCommand):
         if options["quiet"]:
             self.stdout = open(os.devnull, "w")
 
+        file = options["filename"]
+        if file:
+            answer = input(
+                "All hustings will be deleted and replaced with only those included in the file proved. Do you want to continue? y/n\n"
+            )
+            if answer != "y":
+                return
+
         count, _ = Husting.objects.all().delete()
-        self.stdout.write(f"Deleted {count} Husting objects")
+        self.stdout.write(f"Deleting {count} Husting objects")
 
         self.hustings_counter = 0
-        if options["filename"]:
+        if file:
             self.importer = HustingImporter(file_path=options["filename"])
             return self.import_hustings()
 

--- a/wcivf/apps/hustings/models.py
+++ b/wcivf/apps/hustings/models.py
@@ -2,6 +2,7 @@
 Models for Hustings
 """
 import datetime
+import hashlib
 
 from django.db import models
 
@@ -27,3 +28,11 @@ class Husting(models.Model):
 
     def in_past(self):
         return self.starts.date() < datetime.date.today()
+
+    @property
+    def uuid(self):
+        """
+        Build a uuid to be used when creating an iCal event for the object
+        """
+        s = f"{self.title}{self.starts.timestamp()}"
+        return hashlib.md5(s.encode("utf-8")).hexdigest()

--- a/wcivf/apps/hustings/templates/hustings/includes/_ballot.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_ballot.html
@@ -1,9 +1,9 @@
 <div class="card" id="hustings">
     <h3>
       <span aria-hidden="true">📅</span>
-      Husting events
+      Election events
       <span aria-hidden="true">📅</span>
     </h3>
-    <p>You can meet candidates and question them at husting events taking place online.</p>
+    <p>You can meet candidates and question them at online events (often known as 'hustings'). Here are some events that are taking place:</p>
     {% include "hustings/includes/_list.html" with hustings=postelection.husting_set.all %}
 </div>

--- a/wcivf/apps/hustings/templates/hustings/includes/_ballot.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_ballot.html
@@ -1,0 +1,9 @@
+<div class="card" id="hustings">
+    <h3>
+      <span aria-hidden="true">📅</span>
+      Husting events
+      <span aria-hidden="true">📅</span>
+    </h3>
+    <p>You can meet candidates and question them at husting events taking place online.</p>
+    {% include "hustings/includes/_list.html" with hustings=postelection.husting_set.all %}
+</div>

--- a/wcivf/apps/hustings/templates/hustings/includes/_ld_husting.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_ld_husting.html
@@ -1,0 +1,21 @@
+{% load static %}
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org/",
+    "@type": "Event",
+    "url" : "{{ CANONICAL_URL }}{{ husting.post_election.get_absolute_url }}#hustings",
+    "image": "{{ CANONICAL_URL }}{% static "dc_theme/images/logo.png" %}",
+    "startDate": "{{ husting.starts | date:'Y-m-d H:i' }}",
+{% if husting.ends %}
+    "endDate": "{{ husting.ends | date:'Y-m-d H:i' }}",
+{% endif %}
+    "name": "{{ husting.title}}",
+    "description": "Husting event for {{ husting.post_election.friendly_name}}",
+{% if husting.location and husting.postcode %}
+    "location" : {
+        "@type" : "Place",
+        "address": "{{ husting.location }}, {{ husting.postcode }}, UK"
+    }
+{% endif %}
+}
+</script>

--- a/wcivf/apps/hustings/templates/hustings/includes/_list.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_list.html
@@ -1,0 +1,9 @@
+{% load humanize %}
+
+{% for husting in hustings %}
+  <p>
+    {% if husting.in_past %}(Past event) {% endif %}
+    <strong>{{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:</strong> {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}{% if husting.location %}, {{ husting.location }} {{ husting.postcode }}{% endif %}{% if husting.postevent_url %}<br><a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>{% endif %}
+  </p>
+  {% include "hustings/includes/_ld_husting.html" %}
+{% endfor %}

--- a/wcivf/apps/hustings/templates/hustings/includes/_list.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_list.html
@@ -3,7 +3,15 @@
 {% for husting in hustings %}
   <p>
     {% if husting.in_past %}(Past event) {% endif %}
-    <strong>{{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:</strong> {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}{% if husting.location %}, {{ husting.location }} {{ husting.postcode }}{% endif %}{% if husting.postevent_url %}<br><a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>{% endif %}
+    <strong>
+      {{ husting.starts|naturalday:"l j F Y"|title }} {{ husting.starts|date:"H:i"}}{% if husting.ends %}&ndash;{{ husting.ends | date:"H:i"}}{% endif %}:
+    </strong> 
+    {% if husting.url %}<a href="{{ husting.url }}">{% endif %}{{ husting.title}}{% if husting.url %}</a>{% endif %}
+    {% if husting.location %}, {{ husting.location }} {{ husting.postcode }}{% endif %}
+    {% if husting.postevent_url %}
+      <br>
+      <a href="{{ husting.postevent_url }}"><i class="icon-videocam" aria-hidden="true"></i> See video or other info from this event.</a>
+    {% endif %}
   </p>
   {% include "hustings/includes/_ld_husting.html" %}
 {% endfor %}

--- a/wcivf/apps/hustings/templates/hustings/includes/_person.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_person.html
@@ -1,10 +1,7 @@
 <section class="ds-card ds-stack-smaller">
   <div class="ds-card-body">
-      <h3>Husting events</h3>
-      <p>You can meet candidates and question them at online husting events. Here are hustings where {{ object.name }} may
-      be
-      appearing.
-      </p>
+      <h3>Election events</h3>
+      <p>You can meet candidates and question them at online events (often known as 'hustings'). Here are some events where {{ person.name }} may be appearing:</p>
       {% include "hustings/includes/_list.html" with hustings=object.postelection.husting_set.all %}
   </div>
 </section>

--- a/wcivf/apps/hustings/templates/hustings/includes/_person.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_person.html
@@ -1,0 +1,10 @@
+<section class="ds-card ds-stack-smaller">
+  <div class="ds-card-body">
+      <h3>Husting events</h3>
+      <p>You can meet candidates and question them at online husting events. Here are hustings where {{ object.name }} may
+      be
+      appearing.
+      </p>
+      {% include "hustings/includes/_list.html" with hustings=object.postelection.husting_set.all %}
+  </div>
+</section>

--- a/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
@@ -1,3 +1,3 @@
 {% if object.postelection.husting_set.exists and object.current_or_future_candidacies %}
-    {% include "hustings/includes/_person.html" with hustings=object.postelection.husting_set.all %}
+    {% include "hustings/includes/_person.html" with hustings=object.postelection.husting_set.all person=object %}
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
@@ -3,8 +3,8 @@
 {% if object.postelection.husting_set.exists and object.current_or_future_candidacies %}
 <section class="ds-card ds-stack-smaller">
 <div class="ds-card-body">
-    <h3>Local hustings</h3>
-    <p>You can meet candidates and question them at local hustings. Here are hustings where {{ object.name }} may
+    <h3>Husting events</h3>
+    <p>You can meet candidates and question them at online husting events. Here are hustings where {{ object.name }} may
     be
     appearing.
     </p>

--- a/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
@@ -1,14 +1,3 @@
-{% load humanize %}
-
 {% if object.postelection.husting_set.exists and object.current_or_future_candidacies %}
-<section class="ds-card ds-stack-smaller">
-<div class="ds-card-body">
-    <h3>Husting events</h3>
-    <p>You can meet candidates and question them at online husting events. Here are hustings where {{ object.name }} may
-    be
-    appearing.
-    </p>
-    {% include "elections/includes/_hustings_list.html" with hustings=object.postelection.husting_set.all %}
-</div>
-</section>
+    {% include "hustings/includes/_person.html" with hustings=object.postelection.husting_set.all %}
 {% endif %}


### PR DESCRIPTION
- Import hustings via urls by default
- Tried to keep backwards compatible so old hustings could be imported (is this necessary?)
- Optionally import from file