### PR TITLE
Stop breadcrumbs messing up Person cards

### DIFF
--- a/wcivf/assets/scss/main.scss
+++ b/wcivf/assets/scss/main.scss
@@ -149,6 +149,10 @@ dd {
   @include media($max-width: 530px) {
       padding-left:20px;
     }
+  li {
+    display: inline-block;
+    float:none;
+  }
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/DemocracyClub/design-system/issues/12

I thought this was an issue with the design system, but it was actually our old theme interacting with the design system.

This change converts the dc theme implementation of floating elements to using `inline-block`. This prevents the floated elements from messing with the block level flow in the rest of the page.