### PR TITLE
Feature/hide polling card

### DIFF
--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -32,7 +32,9 @@
 {% endif %}
 
 {# Add this at the top of the page if it's known, or at the bottom if it's not #}
-{% include "elections/includes/_polling_place.html" with elections_by_date=elections_by_date voter_id_required=voter_id_required %}
+{% if show_polling_card %} 
+  {% include "elections/includes/_polling_place.html" with elections_by_date=elections_by_date %}
+{% endif %}
 
 {% if not postelections.first.past_registration_deadline %}
   {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %} 

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -316,6 +316,29 @@ class TestPostcodeViewMethods:
 
         assert view_obj.multiple_city_of_london_elections_today() is False
 
+    @pytest.fixture
+    def post_elections(self, request):
+        return self.post_elections
+
+    @pytest.mark.django_db
+    def test_show_polling_card(self, view_obj, post_elections):
+        post_elections = [
+            PostElectionFactory(
+                election__slug="local.city-of-london.2020-05-06",
+                election__election_date="2020-05-06",
+                contested=True,
+                cancelled=False,
+            ),
+            PostElectionFactory(
+                election__slug="local.city-of-london.2020-05-06",
+                election__election_date="2020-05-06",
+                contested=False,
+                cancelled=True,
+            ),
+        ]
+
+        assert view_obj.show_polling_card(post_elections) is True
+
     def test_num_ballots_no_parish_election(self, view_obj, mocker):
         future_post_election = mocker.MagicMock(spec=PostElection, past_date=0)
         past_post_election = mocker.MagicMock(spec=PostElection, past_date=1)

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -142,6 +142,12 @@ class PollingStationInfoMixin(object):
         cache.set(key, info)
         return info
 
+    def show_polling_card(self, post_elections):
+        for p in post_elections:
+            if p.contested and not p.cancelled:
+                return True
+        return False
+
 
 class LogLookUpMixin(object):
     def log_postcode(self, postcode):

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -56,6 +56,9 @@ class PostcodeView(
 
         context["postcode"] = self.postcode
         context["postelections"] = self.get_ballots()
+        context["show_polling_card"] = self.show_polling_card(
+            context["postelections"]
+        )
         context["people_for_post"] = {}
         for postelection in context["postelections"]:
             postelection.people = self.people_for_ballot(postelection)


### PR DESCRIPTION
closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/440

Hides the polling station card on the postcode page if any of the post elections are cancelled or uncontested. 
