### PR TITLE
Remove "not elected" if we don't know the vote count

### DIFF
--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -24,7 +24,7 @@
         {% if person_post.elected %}
             <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (elected){% else %}Vote count not available (elected){% endif %}</td>
         {% else %}
-            <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (not elected){% else %}Vote count not available (not elected){% endif %}</td>      
+            <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (not elected){% else %}Vote count not available{% endif %}</td>      
         {% endif %}
     </tr>
     {% endfor %}


### PR DESCRIPTION
If we don't have a vote count, we don't know if they were elected

eg: https://whocanivotefor.co.uk/person/4412/ian-gilbert was elected in 2015, but shows as "Vote count not available (not elected)"