### PR TITLE
Create Manifesto for all Election objects

### DIFF
--- a/wcivf/apps/parties/importers.py
+++ b/wcivf/apps/parties/importers.py
@@ -170,7 +170,12 @@ class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
 
             for party in parties:
                 self.add_local_party(row, party, ballots)
-                self.add_manifesto(row, party, ballots[0].election)
+                elections = ballots.values_list(
+                    "election__slug", flat=True
+                ).distinct()
+                for slug in elections:
+                    election = Election.objects.get(slug=slug)
+                    self.add_manifesto(row, party, election)
 
     def get_country(self, election_type):
         country_mapping = {


### PR DESCRIPTION
Sometimes we have multiple election objects within the Ballot QuerySet that we use to create Manifesto objects. This change ensures that we create an object for each distinct Election 