### PR TITLE
Hotfix/person intro

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -32,7 +32,8 @@ class YNRElectionImporter:
             election_type = slug.split(".")[0]
 
             election_weight = 10
-            if ballot_dict["election"]["party_lists_in_use"]:
+            uses_lists = ballot_dict["election"]["party_lists_in_use"]
+            if uses_lists:
                 election_weight = 20
             if election_type == "mayor":
                 election_weight = 5
@@ -45,6 +46,7 @@ class YNRElectionImporter:
                     "name": ballot_dict["election"]["name"].strip(),
                     "current": ballot_dict["election"]["current"],
                     "election_weight": election_weight,
+                    "uses_lists": uses_lists,
                 },
             )
 

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -368,6 +368,14 @@ class PostElection(models.Model):
         return self.ballot_paper_id.startswith("mayor")
 
     @property
+    def is_parliamentary(self):
+        """
+        Return a boolean for if this is a parliamentary election, determined by
+        checking ballot paper id
+        """
+        return self.ballot_paper_id.startswith("parl")
+
+    @property
     def is_london_assembly_additional(self):
         """
         Return a boolean for if this is a London Assembley additional ballot

--- a/wcivf/apps/elections/tests/factories.py
+++ b/wcivf/apps/elections/tests/factories.py
@@ -14,6 +14,7 @@ class ElectionFactory(factory.django.DjangoModelFactory):
     election_date = timezone.datetime(2015, 5, 7).date()
     current = True
     name = "UK General Election 2015"
+    any_non_by_elections = True
 
 
 class ElectionFactoryLazySlug(ElectionFactory):

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -169,7 +169,8 @@ class TestPostViewName:
         Test for by elections
         """
         post_election = PostElectionFactory(
-            ballot_paper_id="local.by.election.2020"
+            ballot_paper_id="local.by.election.2020",
+            election__any_non_by_elections=False,
         )
 
         response = client.get(post_election.get_absolute_url(), follow=True)

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -157,6 +157,14 @@ class TestPostElectionModel:
         post_election.ballot_paper_id = ballot_paper_id
         assert post_election.is_mayoral == expected
 
+    @pytest.mark.parametrize(
+        "ballot_paper_id,expected",
+        [("parl.hallam", True), ("an.other.election", False)],
+    )
+    def test_is_parliamentary(self, post_election, ballot_paper_id, expected):
+        post_election.ballot_paper_id = ballot_paper_id
+        assert post_election.is_parliamentary == expected
+
     def test_friendly_name_mayoral(self, post_election):
         post_election.ballot_paper_id = "mayor.of.london"
         post_election.post.label = "Greater London Authority"

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -177,6 +177,10 @@ class TestPostElectionModel:
     def test_is_constituency(self, post_election):
         post_election.ballot_paper_id = "gla.c.2021-05-06"
         assert post_election.is_constituency is True
+        post_election.ballot_paper_id = "senedd.c.2021-05-06"
+        assert post_election.is_constituency is True
+        post_election.ballot_paper_id = "sp.c.2021-05-06"
+        assert post_election.is_constituency is True
 
     @pytest.mark.django_db
     def test_is_regional(self, post_election):

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -287,6 +287,9 @@ class Person(models.Model):
         if ballot.is_pcc:
             return f"{base}_pcc.html"
 
+        if ballot.is_constituency:
+            return f"{base}_constituency.html"
+
         return f"{base}base.html"
 
     @property

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -290,6 +290,9 @@ class Person(models.Model):
         if ballot.is_constituency:
             return f"{base}_constituency.html"
 
+        if ballot.election.uses_lists:
+            return f"{base}_list_ballot.html"
+
         return f"{base}base.html"
 
     @property

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -284,6 +284,9 @@ class Person(models.Model):
         if ballot.is_mayoral:
             return f"{base}_mayor.html"
 
+        if ballot.is_pcc:
+            return f"{base}_pcc.html"
+
         return f"{base}base.html"
 
     @property

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -2,6 +2,7 @@ from django.contrib.postgres.fields import JSONField
 from django.urls import reverse
 from django.db import models
 from django.template.loader import render_to_string
+from django.utils.html import strip_tags
 from django.utils.text import slugify
 from django.utils.timezone import now
 from django.utils.functional import cached_property
@@ -302,6 +303,16 @@ class Person(models.Model):
         return render_to_string(
             template_name=self.intro_template, context=context
         )
+
+    @property
+    def text_intro(self):
+        """
+        Return intro without any HTML, special chars and extra whitespace
+        """
+        intro = self.intro
+        intro = strip_tags(intro)
+        intro = intro.strip()
+        return " ".join(intro.split())
 
 
 class AssociatedCompany(models.Model):

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -295,7 +295,7 @@ class Person(models.Model):
 
         return f"{base}base.html"
 
-    @property
+    @cached_property
     def intro(self):
         """
         Return a rendered string of the persons intro from a template.

--- a/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
@@ -1,3 +1,3 @@
-{% if object.postelection.husting_set.displayable and object.current_or_future_candidacies %}
+{% if object.featured_candidacy.post_election.husting_set.displayable and object.current_or_future_candidacies %}
     {% include "hustings/includes/_person.html" with hustings=object.postelection.husting_set.displayable person=object %}
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -3,12 +3,12 @@
       <h2 class="ds-candidate-name ds-h3">
         {{ object.name }}
       </h2>
-      {% if person.display_deceased and person.personpost.party.is_independent %}
+      {% if person.display_deceased and person.featured_candidacy.party.is_independent %}
       (Deceased)
       {% endif %}
 
       {% if object.current_or_future_candidacies.all.count > 1 %}
-        <h5>{{ object.name }} is {% if object.personpost.party.is_independent %}an{% else %}a{% endif %} {{object.personpost.party.party_name }} candidate in the following elections:</h5>
+        <h5>{{ object.name }} is {% if object.current_or_future_candidacies.0.party.is_independent %}an{% else %}a{% endif %} {{object.current_or_future_candidacies.0.party.party_name }} candidate in the following elections:</h5>
 
           {% for candidacy in object.current_or_future_candidacies %}
           <ul>

--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -21,7 +21,7 @@
 
       {% else %}
       <p>
-        {{ object.intro|safe }}.
+        {{ object.intro|safe }}
       </p>
       {% endif %}
     </div>

--- a/wcivf/apps/people/templates/people/includes/_person_manifesto_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_manifesto_card.html
@@ -1,12 +1,12 @@
 {% if object.manifestos %}
-{% with object.personpost.party as party %}
+{% with object.featured_candidacy.party as party %}
 <section class="ds-candidate">
     <div class="ds-candidate-body ds-stack-smaller">
         <h2 class="ds-candidate-name ds-h3">
             Party manifesto
         </h2>
         <p>
-            {{ object.name }} {{ object.personpost.election.in_past|yesno:"was,is" }} the {{ party.party_name }}
+            {{ object.name }} {{ object.featured_candidacy.election.in_past|yesno:"was,is" }} the {{ party.party_name }}
             candidate.
             Find out more about their policies in the {{ party.party_name }} manifesto.
         </p>

--- a/wcivf/apps/people/templates/people/includes/_person_meta_description.html
+++ b/wcivf/apps/people/templates/people/includes/_person_meta_description.html
@@ -1,1 +1,1 @@
-{% autoescape off %}{{ object.text_intro }}. Get the latest information on this candidate at {{ SITE_TITLE }}{% endautoescape %}
+{% autoescape off %}{{ object.text_intro }} Get the latest information on this candidate at {{ SITE_TITLE }}{% endautoescape %}

--- a/wcivf/apps/people/templates/people/includes/intros/_constituency.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_constituency.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate for {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name_without_brackets }}</a>.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_independent.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_independent.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.nice_election_name }}">{{ candidacy.election.nice_election_name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_independent.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_independent.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_independent.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_independent.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_independent.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_independent.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} an independent candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_list_ballot.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_list_ballot.html
@@ -1,0 +1,7 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% load humanize %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} the {{ person.featured_candidacy.list_position|ordinal }} place candidate for the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_mayor.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_mayor.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the {{ candidacy.party.party_name }} candidate for {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_mayor.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_mayor.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.nice_election_name }}">{{ candidacy.election.nice_election_name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_mayor.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_mayor.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} the {{ candidacy.party.party_name }} candidate for {{ candidacy.election.name }}.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_mayor.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_mayor.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_parl.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_parl.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_parl.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_parl.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.nice_election_name }}">{{ candidacy.election.nice_election_name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_parl.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_parl.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in {{ candidacy.post.label }} constituency in the {{ candidacy.election.name }}.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_parl.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_parl.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in {{ candidacy.post.label }} constituency in the {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_parl.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_parl.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_pcc.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_pcc.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} the <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate for <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the Speaker seeking re-election in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the {{ candidacy.election.name }}.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.nice_election_name }}">{{ candidacy.election.nice_election_name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,0 +1,5 @@
+{% extends "people/includes/intros/base.html" %}
+
+{% block intro_line %}
+{{ person.name }} {{ verb }} the Speaker seeking re-election in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}
+{% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the Speaker seeking re-election in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}
+{{ person.name }} {{ verb }} the Speaker seeking re-election in the constituency of {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_speaker.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_speaker.html
@@ -1,5 +1,5 @@
 {% extends "people/includes/intros/base.html" %}
 
 {% block intro_line %}
-{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the {{ candidacy.election.name }}.
+{{ person.name }} {{ verb }} the Speaker seeking re-election in {{ candidacy.post.label }} constituency in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
 {% endblock %}

--- a/wcivf/apps/people/templates/people/includes/intros/_votes_cast.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_votes_cast.html
@@ -1,3 +1,3 @@
 {% load humanize %}
 
-They{% if candidacy.elected %} were elected with {% else %} received {% endif %} <strong>{{ candidacy.votes_cast|intcomma }}</strong> votes.
+They{% if candidacy.elected %} were elected with {% else %} received {% endif %}<strong>{{ candidacy.votes_cast|intcomma }}</strong> votes.

--- a/wcivf/apps/people/templates/people/includes/intros/_votes_cast.html
+++ b/wcivf/apps/people/templates/people/includes/intros/_votes_cast.html
@@ -1,0 +1,3 @@
+{% load humanize %}
+
+They{% if candidacy.elected %} were elected with {% else %} received {% endif %} <strong>{{ candidacy.votes_cast|intcomma }}</strong> votes.

--- a/wcivf/apps/people/templates/people/includes/intros/base.html
+++ b/wcivf/apps/people/templates/people/includes/intros/base.html
@@ -1,0 +1,6 @@
+{% block intro_line %}
+    {{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+{% endblock %}
+{% if candidacy.votes_cast %}
+    {% include "people/includes/intros/_votes_cast.html" %}
+{% endif %}

--- a/wcivf/apps/people/templates/people/includes/intros/base.html
+++ b/wcivf/apps/people/templates/people/includes/intros/base.html
@@ -1,5 +1,5 @@
 {% block intro_line %}
-{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.nice_election_name }}</a>.
 {% endblock %}
 {% if candidacy.votes_cast %}
     {% include "people/includes/intros/_votes_cast.html" %}

--- a/wcivf/apps/people/templates/people/includes/intros/base.html
+++ b/wcivf/apps/people/templates/people/includes/intros/base.html
@@ -1,5 +1,5 @@
 {% block intro_line %}
-    {{ person.name }} {{ verb }} a {{ candidacy.party.party_name }} candidate in {{ candidacy.post.label }} in the {{ candidacy.election.name }}.
+    {{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
 {% endblock %}
 {% if candidacy.votes_cast %}
     {% include "people/includes/intros/_votes_cast.html" %}

--- a/wcivf/apps/people/templates/people/includes/intros/base.html
+++ b/wcivf/apps/people/templates/people/includes/intros/base.html
@@ -1,5 +1,5 @@
 {% block intro_line %}
-    {{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}">{{ candidacy.election.name }}</a>.
+{{ person.name }} {{ verb }} a <a href="{{ candidacy.party.get_absolute_url }}" title="{{ candidacy.party.name }}">{{ candidacy.party.party_name }}</a> candidate in {{ candidacy.post.label }} in the <a href="{{ candidacy.election.get_absolute_url }}" title="{{ candidacy.election.name }}">{{ candidacy.election.name }}</a>.
 {% endblock %}
 {% if candidacy.votes_cast %}
     {% include "people/includes/intros/_votes_cast.html" %}

--- a/wcivf/apps/people/templates/people/not_current_person_detail.html
+++ b/wcivf/apps/people/templates/people/not_current_person_detail.html
@@ -19,7 +19,7 @@
         <div class="ds-candidate-body ds-stack-smaller">
           <h2 class="ds-candidate-name ds-h3">
             {{ object.name }}
-            {% if person.display_deceased and person.personpost.party.is_independent %}
+            {% if person.display_deceased and person.featured_candidacy.party.is_independent %}
             (Deceased)
             {% endif %}
           </h2>
@@ -44,6 +44,6 @@
 
 {% block breadcrumbs %}
 
-{% include "elections/includes/_ld_candidate.html" with person=object.personpost.person party=object.personpost.party %}
+{% include "elections/includes/_ld_candidate.html" with person=object.featured_candidacy.person party=object.featured_candidacy.party %}
 
 {% endblock breadcrumbs %}

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -64,11 +64,11 @@
 <ol vocab="http://schema.org/" typeof="BreadcrumbList" class="breadcrumbs" aria-label="You are here:" role="navigation">
   {% url 'home_view' as home_view %}
   {% breadcrumb_item home_view 'Home' 1 %}
-  {% breadcrumb_item object.personpost.post_election.get_absolute_url 'Candidates in '|add:object.personpost.post.label 2 %}
+  {% breadcrumb_item object.featured_candidacy.post_election.get_absolute_url 'Candidates in '|add:object.featured_candidacy.post.label 2 %}
   <li class="disabled"><span class="show-for-sr">Current: </span> {{ object.name }}</li>
 </ol>
 {% endif %}
 
-{% include "elections/includes/_ld_candidate.html" with person=object.personpost.person party=object.personpost.party %}
+{% include "elections/includes/_ld_candidate.html" with person=object.featured_candidacy.person party=object.featured_candidacy.party %}
 
 {% endblock breadcrumbs %}

--- a/wcivf/apps/people/tests/factories.py
+++ b/wcivf/apps/people/tests/factories.py
@@ -1,4 +1,5 @@
 import factory
+from parties.tests.factories import PartyFactory
 
 from people.models import Person, PersonPost
 from elections.tests.factories import (
@@ -26,3 +27,8 @@ class PersonPostFactory(factory.django.DjangoModelFactory):
     post_election = factory.SubFactory(PostElectionFactory)
     party = None
     list_position = None
+
+
+class PersonPostWithPartyFactory(PersonPostFactory):
+
+    party = factory.SubFactory(PartyFactory)

--- a/wcivf/apps/people/tests/helpers.py
+++ b/wcivf/apps/people/tests/helpers.py
@@ -9,6 +9,8 @@ def create_person(
     party_name=None,
     election_type="local",
     election_name=None,
+    list_election=False,
+    by_election=False,
     **kwargs,
 ):
     election_date = "2021-05-06" if current else "2019-12-12"
@@ -21,6 +23,8 @@ def create_person(
         name=election_name or "Sheffield local election",
         election_date=election_date,
         current=current,
+        uses_lists=list_election,
+        any_non_by_elections=not by_election,
     )
 
     return PersonPostWithPartyFactory(

--- a/wcivf/apps/people/tests/helpers.py
+++ b/wcivf/apps/people/tests/helpers.py
@@ -8,6 +8,7 @@ def create_person(
     deceased=False,
     party_name=None,
     election_type="local",
+    election_name=None,
     **kwargs,
 ):
     election_date = "2021-05-06" if current else "2019-12-12"
@@ -17,7 +18,7 @@ def create_person(
     if party_name == "Independent":
         party_id = "ynmp-party:2"
     election = ElectionFactoryLazySlug(
-        name="Sheffield local election",
+        name=election_name or "Sheffield local election",
         election_date=election_date,
         current=current,
     )

--- a/wcivf/apps/people/tests/helpers.py
+++ b/wcivf/apps/people/tests/helpers.py
@@ -1,0 +1,35 @@
+from django.utils.text import slugify
+from elections.tests.factories import ElectionFactoryLazySlug
+from people.tests.factories import PersonPostWithPartyFactory
+
+
+def create_person(
+    current=True,
+    deceased=False,
+    party_name=None,
+    election_type="local",
+    **kwargs,
+):
+    election_date = "2021-05-06" if current else "2019-12-12"
+    death_date = "2021-04-01" if deceased else None
+    party_name = party_name or "Test Party"
+    party_id = slugify(party_name)
+    if party_name == "Independent":
+        party_id = "ynmp-party:2"
+    election = ElectionFactoryLazySlug(
+        name="Sheffield local election",
+        election_date=election_date,
+        current=current,
+    )
+
+    return PersonPostWithPartyFactory(
+        election=election,
+        person__name="Joe Bloggs",
+        post__label="Ecclesall",
+        post_election__election=election,
+        person__death_date=death_date,
+        party__party_name=party_name,
+        party__party_id=party_id,
+        post_election__ballot_paper_id=f"{election_type}.{election.slug}",
+        **kwargs,
+    )

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -116,16 +116,25 @@ class TestPersonModel(TestCase):
                 "people/includes/intros/base.html",
             ),
             (
-                create_person(election_type="gla"),
-                "people/includes/intros/base.html",
-            ),
-            (
                 create_person(election_type="nia"),
                 "people/includes/intros/base.html",
             ),
             (
                 create_person(election_type="naw"),
                 "people/includes/intros/base.html",
+            ),
+            # constituency
+            (
+                create_person(election_type="sp.c"),
+                "people/includes/intros/_constituency.html",
+            ),
+            (
+                create_person(election_type="senedd.c"),
+                "people/includes/intros/_constituency.html",
+            ),
+            (
+                create_person(election_type="gla.c"),
+                "people/includes/intros/_constituency.html",
             ),
         ]
         for candidacy in candidacies:

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -2,6 +2,7 @@ from elections.tests.factories import (
     ElectionFactory,
 )
 from parties.tests.factories import PartyFactory
+from people.tests.helpers import create_person
 from people.tests.factories import PersonFactory, PersonPostFactory
 from django.test import TestCase
 
@@ -69,3 +70,66 @@ class TestPersonModel(TestCase):
             "https://www.youtube.com/user/pierscorbyn2"
         )
         assert self.person.youtube_username == "pierscorbyn2"
+
+    def test_intro_template(self):
+        candidacies = [
+            # independent
+            (
+                create_person(party_name="Independent"),
+                "people/includes/intros/_independent.html",
+            ),
+            # mayor
+            (
+                create_person(election_type="mayor"),
+                "people/includes/intros/_mayor.html",
+            ),
+            # pcc
+            (
+                create_person(election_type="pcc"),
+                "people/includes/intros/_pcc.html",
+            ),
+            # parl
+            (
+                create_person(election_type="parl"),
+                "people/includes/intros/_parl.html",
+            ),
+            # speaker
+            (
+                create_person(party_name="Speaker seeking re-election"),
+                "people/includes/intros/_speaker.html",
+            ),
+            # base
+            (
+                create_person(election_type="local"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="sp"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="senedd"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="europarl"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="gla"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="nia"),
+                "people/includes/intros/base.html",
+            ),
+            (
+                create_person(election_type="naw"),
+                "people/includes/intros/base.html",
+            ),
+        ]
+        for candidacy in candidacies:
+            person = candidacy[0].person
+            expected = candidacy[1]
+            with self.subTest(msg=candidacy[1]):
+                self.assertEqual(person.intro_template, expected)

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -136,6 +136,11 @@ class TestPersonModel(TestCase):
                 create_person(election_type="gla.c"),
                 "people/includes/intros/_constituency.html",
             ),
+            # list,
+            (
+                create_person(list_election=True),
+                "people/includes/intros/_list_ballot.html",
+            ),
         ]
         for candidacy in candidacies:
             person = candidacy[0].person

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -583,3 +583,4 @@ class TestPersonIntro(TestCase):
                 intro = intro.strip()
                 intro = " ".join(intro.split())
                 self.assertEqual(intro, expected)
+                self.assertEqual(person.text_intro, expected)

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -438,6 +438,12 @@ class TestPersonIntro(TestCase):
             election_type="pcc",
             election_name="Police and Crime Commissioner for South Yorkshire",
         )
+        self.list_candidate = create_person(
+            election_type="gla.a",
+            list_election=True,
+            list_position=1,
+            election_name="London Assembly elections (additional)",
+        )
 
     def test_intro_in_view(self):
         candidacies = [
@@ -492,6 +498,10 @@ class TestPersonIntro(TestCase):
             (
                 self.pcc_candidate,
                 "Joe Bloggs is the Test Party candidate for Police and Crime Commissioner for South Yorkshire.",
+            ),
+            (
+                self.list_candidate,
+                "Joe Bloggs is the 1st place candidate for the Test Party in the London Assembly elections (additional).",
             ),
         ]
         for candidacy in candidacies:
@@ -558,6 +568,10 @@ class TestPersonIntro(TestCase):
             (
                 self.pcc_candidate,
                 "Joe Bloggs is the Test Party candidate for Police and Crime Commissioner for South Yorkshire.",
+            ),
+            (
+                self.list_candidate,
+                "Joe Bloggs is the 1st place candidate for the Test Party in the London Assembly elections (additional).",
             ),
         ]
 

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -162,6 +162,7 @@ class PersonViewTests(TestCase):
             person=self.person, election=election, party=party
         )
         response = self.client.get(self.person_url, follow=True)
+
         self.assertContains(
             response,
             f"{self.person.name} is a {party.party_name} candidate in {person_post.post.label} constituency in the {election.name}.",

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -164,7 +164,7 @@ class PersonViewTests(TestCase):
         response = self.client.get(self.person_url, follow=True)
         self.assertContains(
             response,
-            f"{self.person.name} is a {party.party_name} candidate in the constituency of {person_post.post.label} in the {election.name}.",
+            f"{self.person.name} is a {party.party_name} candidate in {person_post.post.label} constituency in the {election.name}.",
         )
 
     def test_no_previous_elections(self):
@@ -496,7 +496,7 @@ class TestPersonIntro(TestCase):
             ),
             (
                 self.parliamentary_candidate,
-                "Joe Bloggs is a Test Party candidate in the constituency of Hallam in the UK General Election 2023.",
+                "Joe Bloggs is a Test Party candidate in Hallam constituency in the UK General Election 2023.",
             ),
             (
                 self.mayoral_candidate,
@@ -550,15 +550,15 @@ class TestPersonIntro(TestCase):
             ),
             (
                 self.speaker,
-                "Joe Bloggs is the Speaker seeking re-election in the constituency of Ecclesall in the Sheffield local election.",
+                "Joe Bloggs is the Speaker seeking re-election in Ecclesall constituency in the Sheffield local election.",
             ),
             (
                 self.speaker_past,
-                "Joe Bloggs was the Speaker seeking re-election in the constituency of Ecclesall in the Sheffield local election.",
+                "Joe Bloggs was the Speaker seeking re-election in Ecclesall constituency in the Sheffield local election.",
             ),
             (
                 self.parliamentary_candidate,
-                "Joe Bloggs is a Test Party candidate in the constituency of Hallam in the UK General Election 2023.",
+                "Joe Bloggs is a Test Party candidate in Hallam constituency in the UK General Election 2023.",
             ),
             (
                 self.mayoral_candidate,

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -393,10 +393,14 @@ class TestPersonIntro(TestCase):
             current=False, party_name="Independent"
         )
         self.speaker = create_person(
-            current=True, party_name="Speaker seeking re-election"
+            current=True,
+            party_name="Speaker seeking re-election",
+            election_name="UK General Election",
         )
         self.speaker_past = create_person(
-            current=False, party_name="Speaker seeking re-election"
+            current=False,
+            party_name="Speaker seeking re-election",
+            election_name="UK General Election",
         )
         parl_election = ElectionFactory(
             current=True,
@@ -430,6 +434,10 @@ class TestPersonIntro(TestCase):
         self.candidate_with_votes_elected = create_person(
             current=False, votes_cast=10000, elected=True
         )
+        self.pcc_candidate = create_person(
+            election_type="pcc",
+            election_name="Police and Crime Commissioner for South Yorkshire",
+        )
 
     def test_intro_in_view(self):
         candidacies = [
@@ -457,10 +465,13 @@ class TestPersonIntro(TestCase):
                 self.independent_candidate_past,
                 "Joe Bloggs was an independent candidate in Ecclesall in the Sheffield local election.",
             ),
-            (self.speaker, "Joe Bloggs is the Speaker seeking re-election"),
+            (
+                self.speaker,
+                "Joe Bloggs is the Speaker seeking re-election in Ecclesall constituency in the UK General Election",
+            ),
             (
                 self.speaker_past,
-                "Joe Bloggs was the Speaker seeking re-election",
+                "Joe Bloggs was the Speaker seeking re-election in Ecclesall constituency in the UK General Election",
             ),
             (
                 self.parliamentary_candidate,
@@ -477,6 +488,10 @@ class TestPersonIntro(TestCase):
             (
                 self.candidate_with_votes_elected,
                 "They were elected with 10,000 votes.",
+            ),
+            (
+                self.pcc_candidate,
+                "Joe Bloggs is the Test Party candidate for Police and Crime Commissioner for South Yorkshire.",
             ),
         ]
         for candidacy in candidacies:
@@ -518,11 +533,11 @@ class TestPersonIntro(TestCase):
             ),
             (
                 self.speaker,
-                "Joe Bloggs is the Speaker seeking re-election in Ecclesall constituency in the Sheffield local election.",
+                "Joe Bloggs is the Speaker seeking re-election in Ecclesall constituency in the UK General Election.",
             ),
             (
                 self.speaker_past,
-                "Joe Bloggs was the Speaker seeking re-election in Ecclesall constituency in the Sheffield local election.",
+                "Joe Bloggs was the Speaker seeking re-election in Ecclesall constituency in the UK General Election.",
             ),
             (
                 self.parliamentary_candidate,
@@ -539,6 +554,10 @@ class TestPersonIntro(TestCase):
             (
                 self.candidate_with_votes_elected,
                 "Joe Bloggs was a Test Party candidate in Ecclesall in the Sheffield local election. They were elected with 10,000 votes.",
+            ),
+            (
+                self.pcc_candidate,
+                "Joe Bloggs is the Test Party candidate for Police and Crime Commissioner for South Yorkshire.",
             ),
         ]
 

--- a/wcivf/apps/people/views.py
+++ b/wcivf/apps/people/views.py
@@ -1,8 +1,6 @@
 from django.views.generic import DetailView
 from django.http import Http404
 from django.db.models import Prefetch, Q
-from django.utils.html import strip_tags
-from django.contrib.humanize.templatetags.humanize import intcomma
 
 from .models import Person, PersonPost
 from parties.models import Manifesto
@@ -74,7 +72,6 @@ class PersonView(DetailView, PersonMixin):
             obj.postelection = obj.personpost.post_election
 
         obj.title = self.get_title(obj)
-        obj.intro = self.get_intro(obj)
         obj.text_intro = strip_tags(obj.intro)
         obj.post_country = self.get_post_country(obj)
 
@@ -122,55 +119,6 @@ class PersonView(DetailView, PersonMixin):
             title += " for " + person.personpost.post.label + " in the "
             title += person.personpost.election.name
         return title
-
-    def get_intro(self, person):
-        intro = [person.name]
-
-        if person.current_or_future_candidacies and not person.death_date:
-            intro.append("is")
-        else:
-            intro.append("was")
-        # clear CTAs below
-        if person.personpost:
-            party = person.personpost.party
-            if party:
-                if party.party_name == "Independent":
-                    intro.append("an independent candidate")
-                elif party.party_name == "Speaker seeking re-election":
-                    intro.append("the Speaker seeking re-election")
-                else:
-                    intro.append("a")
-                    str = party.party_name + " candidate"
-                    intro.append(str)
-            else:
-                intro.append("a candidate")
-            intro.append("in")
-            if (
-                person.personpost.post.organization
-                == "House of Commons of the United Kingdom"
-            ):
-                intro.append("the constituency of")
-            if person.postelection:
-                str = person.personpost.post.label
-            else:
-                str = person.personpost.post.label
-            str += " in the "
-            str += person.personpost.election.name
-            intro.append(str)
-
-            if person.personpost.votes_cast:
-                votes = intcomma(person.personpost.votes_cast)
-                if person.personpost.elected:
-                    intro[-1] = intro[-1] + "."
-                    results_str = (
-                        "They were elected with <strong>{}</strong> votes"
-                    )
-                else:
-                    results_str = ". They got <strong>{}</strong> votes"
-                results_str = results_str.format(votes)
-                intro.append(results_str)
-
-        return " ".join(intro)
 
 
 class EmailPersonView(PersonMixin, DetailView):

--- a/wcivf/apps/people/views.py
+++ b/wcivf/apps/people/views.py
@@ -72,7 +72,6 @@ class PersonView(DetailView, PersonMixin):
             obj.postelection = obj.personpost.post_election
 
         obj.title = self.get_title(obj)
-        obj.text_intro = strip_tags(obj.intro)
         obj.post_country = self.get_post_country(obj)
 
         if obj.personpost:


### PR DESCRIPTION
This started out as a quick fix to change the intro text on candidates running in Mayoral elections as per https://docs.google.com/document/d/1xRgw441CIBvYo3YdwNIqejxaRhl_BUseZ4ucSGB-tUw/edit#... but turned in to something a bit bigger.

- Removes `get_intro` method and its logic from the PersonView
- Replaced with property method on the Person model which uses template files and `render_to_string`
- This should make it much easier to change the intro text on a case by case basis - as each type of election can have their own HTML include that the intro string can be built from
- Adds lots of tests to attempt to make sure we havent broken anything in the process. I still think that this should be deployed to test site initially for a good click through