### PR TITLE
Fix dup PostElection object error in PersonView

### DIFF
--- a/wcivf/apps/people/views.py
+++ b/wcivf/apps/people/views.py
@@ -5,7 +5,6 @@ from django.utils.html import strip_tags
 from django.contrib.humanize.templatetags.humanize import intcomma
 
 from .models import Person, PersonPost
-from elections.models import PostElection
 from parties.models import Manifesto
 
 
@@ -72,12 +71,8 @@ class PersonView(DetailView, PersonMixin):
             obj.personpost = obj.past_not_current_candidacies.first()
         obj.postelection = None
         if obj.personpost:
-            try:
-                obj.postelection = PostElection.objects.get(
-                    post=obj.personpost.post, election=obj.personpost.election
-                )
-            except PostElection.DoesNotExist:
-                pass
+            obj.postelection = obj.personpost.post_election
+
         obj.title = self.get_title(obj)
         obj.intro = self.get_intro(obj)
         obj.text_intro = strip_tags(obj.intro)


### PR DESCRIPTION
- Fixes https://sentry.io/organizations/democracy-club-gp/issues/2327872192/?project=1426221&query=is%3Aunresolved
- Error was occurring when you had a by-election for the same post on the same day as local election ballot, as is the case for `local.castle-point.st-georges` which meant two PostElection objects are returned.
https://candidates.democracyclub.org.uk/elections/local.castle-point.st-georges.by.2021-05-06/
https://candidates.democracyclub.org.uk/elections/local.castle-point.st-georges.2021-05-06/
- Since at the point the `PostElection.objects.get` lookup was taking place we already have a `PersonPost` object, we can get the related `PostElection` directly from the candidacy object - as this relationship is enforced on the model https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wcivf/apps/people/models.py#L17