### PR TITLE
Hotfix/Remove duplicate voting info

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -66,8 +66,6 @@
               {% if postelection.winner_count and postelection.election.voting_system_id == 'STV' %}
                 You can choose from {{ postelection.people.apnumber }} candidate{{ postelection.people|pluralize }}. 
               {% endif %}
-              You can choose from <strong>{{ postelection.party_ballot_count }}</strong>
-              in the {{ postelection.friendly_name }}.
             {% endif %}
 
             {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}


### PR DESCRIPTION
Removes a duplicate sentence that was missed during a merge conflict. 

The bug
![Screen Shot 2021-04-21 at 9 44 47 AM](https://user-images.githubusercontent.com/7017118/115524625-401ea680-a286-11eb-8b1b-3a80c63d74eb.png)
The fix
![Screen Shot 2021-04-21 at 9 42 40 AM](https://user-images.githubusercontent.com/7017118/115524645-43b22d80-a286-11eb-9528-7e6410baca05.png)
