### PR TITLE
Delete manifestos before re-importing

### DIFF
--- a/wcivf/apps/parties/importers.py
+++ b/wcivf/apps/parties/importers.py
@@ -38,6 +38,12 @@ class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
         ).delete()
         self.write(f"Deleted {count} local parties for {self.election.date}")
 
+    def delete_manifestos_for_election_date(self):
+        count, _ = Manifesto.objects.filter(
+            election__election_date=self.election.date,
+        ).delete()
+        self.write(f"Deleted {count} manifestos for {self.election.date}")
+
     def current_elections(self):
         """
         Checks for current Election objects with the given date
@@ -141,6 +147,7 @@ class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
         parent party.
         """
         self.delete_parties_for_election_date()
+        self.delete_manifestos_for_election_date()
 
         if not self.current_elections():
             self.write(

--- a/wcivf/apps/parties/tests/test_importers.py
+++ b/wcivf/apps/parties/tests/test_importers.py
@@ -102,16 +102,19 @@ class TestLocalPartyImporter:
 
     def test_import_parties_no_current_elections(self, importer, mocker):
         mocker.patch.object(importer, "delete_parties_for_election_date")
+        mocker.patch.object(importer, "delete_manifestos_for_election_date")
         mocker.patch.object(importer, "current_elections", return_value=False)
         mocker.patch.object(importer, "all_rows")
 
         assert importer.import_parties() is None
         importer.delete_parties_for_election_date.assert_called_once()
+        importer.delete_manifestos_for_election_date.assert_called_once()
         importer.current_elections.assert_called_once()
         importer.all_rows.assert_not_called()
 
     def test_import_parties_runs(self, importer, row, mocker):
         mocker.patch.object(importer, "delete_parties_for_election_date")
+        mocker.patch.object(importer, "delete_manifestos_for_election_date")
         mocker.patch.object(importer, "current_elections")
 
         party = mocker.MagicMock()
@@ -134,8 +137,9 @@ class TestLocalPartyImporter:
         # actual call to do the import
         importer.import_parties()
 
-        # assert what we expet to have been called was called
+        # assert what we expect to have been called was called
         importer.delete_parties_for_election_date.assert_called_once()
+        importer.delete_manifestos_for_election_date.assert_called_once()
         importer.current_elections.assert_called_once()
         importer.all_rows.assert_called()
         importer.add_local_party.assert_called_once_with(row, party, ballots)


### PR DESCRIPTION
Sorry for having to do another PR for this - but I hadn't accounted for there being existing objects in the DB that still had a blank `language` value, so the error still gets raised. This updates the importer to delete manifestos before an import in the same way that we do for the LocalParty objects.