### PR TITLE
Hotfix/Candidate order

### DIFF
--- a/wcivf/apps/people/managers.py
+++ b/wcivf/apps/people/managers.py
@@ -96,7 +96,7 @@ class PersonManager(models.Manager):
 
         sort_name = person.get("sort_name")
         if not sort_name:
-            sort_name = person["name"].split(" ")[-1]
+            sort_name = person["name"].strip().split(" ")[-1]
 
         defaults = {
             "name": person["name"],


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/775

This work strips whitespace from sort_name to render candidates with the same first letter of surname in alphabetical order. 

