### PR TITLE
Hotfix/person card fixes

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -8,7 +8,7 @@
     {#  This is a special case where we don't want to group independants, but show a single card per person  #}
     {% for pp in person_post.list %} 
       <div class="ds-candidate"> 
-        <div class="ds-candidate body ds-stack-smallest">
+        <div class="ds-candidate-body ds-stack-smallest">
           <h4 class="ds-candidate-name">
             <a href="{{ pp.person.get_absolute_url }}" class="ds-card-link">
               {% if pp.elected %}🌟 <span class="elected_text">Elected:</span> {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -4,10 +4,10 @@
 <li class="ds-candidate" style="list-style-type: none;">
   <div class="ds-candidate-body ds-stack-smaller">
     <h3 class="ds-candidate-name ds-h5">
-      <a href="{{ person_post.person.get_absolute_url }}" class="ds-card-link">{{ person_post.person.name}}</a>
-    </h3>
-    {% if person_post.elected %}🌟 <span class="elected_text">Elected:</span>
-    {% endif %}
+      {% if person_post.list_position %}
+        {{ person_post.list_position }}. 
+      {% endif %}
+      <a href="{{ person_post.person.get_absolute_url }}" class="ds-card-link">
     {% if postelection.election.current and person_post.person.death_date %}
       {% if person_post.party.is_independent %}
         (Deceased)

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -1,13 +1,17 @@
 {% load static %}
 {% load humanize %}
 
-<li class="ds-candidate" style="list-style-type: none;">
+<li class="ds-candidate" style="list-style: none; {% if person_post.elected %} grid-column: 1/3;{% endif %}">
   <div class="ds-candidate-body ds-stack-smaller">
     <h3 class="ds-candidate-name ds-h5">
       {% if person_post.list_position %}
         {{ person_post.list_position }}. 
       {% endif %}
       <a href="{{ person_post.person.get_absolute_url }}" class="ds-card-link">
+        {{ person_post.person.name}}
+      </a>
+    </h3>
+    {% if person_post.elected %}<span aria-hidden="true">🌟Elected🌟</span>{% endif %}
     {% if postelection.election.current and person_post.person.death_date %}
       {% if person_post.party.is_independent %}
         (Deceased)
@@ -15,7 +19,6 @@
     </p>
     <!-- {% include "elections/includes/_ld_candidate.html" with person=person_post.person party=person_post.party %} -->
     {% endif %}
-    {% if person_post.elected %}🌟{% endif %}
     {% if not person_post.list_position or not postelection.display_as_party_list %}
       <div class="ds-h6">{{ person_post.party.party_name }}</div>
     {% endif %}

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -1,13 +1,13 @@
 from datetime import date
 
 import requests
-
-from django.urls import reverse
+from django.db.models import F
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.core.cache import cache
 from django.db.models import IntegerField
 from django.db.models import When, Case, Count
+from django.urls import reverse
 
 from core.models import log_postcode
 from core.utils import LastWord
@@ -104,7 +104,9 @@ class PostelectionsToPeopleMixin(object):
         else:
             order_by = ["person__sort_name", "last_name", "person__name"]
 
-        people_for_post = people_for_post.order_by("-elected", *order_by)
+        people_for_post = people_for_post.order_by(
+            F("elected").desc(nulls_last=True), *order_by
+        )
         people_for_post = people_for_post.select_related(
             "post", "election", "person", "party"
         )

--- a/wcivf/apps/people/templates/people/includes/_person_about_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_about_card.html
@@ -1,14 +1,18 @@
-{% if object.wikipedia_bio %}
-<section class="ds-card">
-  <div class="ds-card-body">
-    <h2 class="ds-candidate-name ds-h3">
-      About {{ object.name }}
-    </h2>
-
-    <h3>Wikipedia</h3>
-    <p>{{ object.wikipedia_bio }}</p>
-    <a href="{{ object.wikipedia_url }}" class="link-button">Read more on Wikipedia</a>
-
+{% if object.wikipedia_bio or object.favourite_biscuit %}
+  <div class="ds-card">
+    <div class="ds-card-body">
+      <h2 class="ds-candidate-name ds-h3">
+        About {{ object.name }}
+      </h2>
+      {% if object.wikipedia_bio %}
+        <h4>Wikipedia</h4>
+        <p>{{ object.wikipedia_bio }}</p>
+        <a href="{{ object.wikipedia_url }}" class="link-button">Read more on Wikipedia</a>
+      {% endif %} 
+      {% if object.favourite_biscuit %}
+        <h4>Favourite Biscuit?</h4>
+        <p>{{ object.favourite_biscuit }}</p>
+      {% endif %}
+    </div>
   </div>
-</section>
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_local_party_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_local_party_card.html
@@ -1,7 +1,7 @@
 {% if person.local_party %}
-  <section class="ds-card">
+  <div class="ds-card">
     <div class="ds-card-body">
-      <h3 class="ds-h3">{{ person.local_party.name }}</h3>
+      <h4 class="ds-h3">{{ person.local_party.name }}</h4>
       <p>
         {% if person.local_party.is_local %}
           {{ person.name }}'s local party is {{ person.local_party.label }}.
@@ -9,38 +9,38 @@
           {{ person.name }} is a {{ person.local_party.label }} candidate.
         {% endif %}
       </p>
-
-      {% if person.local_party.twitter %}
-        <p>
-        <a href="https://twitter.com/{{ person.local_party.twitter }}">
-          @{{ person.local_party.twitter }}</a>
-          on Twitter
-        </p>
-      {% endif %}
-
-      {% if person.local_party.facebook_page %}
-        <p>
+      <dl class="ds-descriptions">
+        <div>
+        {% if person.local_party.twitter %}
+          <dt>Twitter</dt>
+          <a href="https://twitter.com/{{ person.local_party.twitter }}">
+            {{ person.local_party.twitter }}
+          </a>
+        {% endif %}
+        </div>
+        <div>
+        {% if person.local_party.facebook_page %}
+         <dt>Facebook</dt>
           <a href="{{ person.local_party.facebook_page }}">
             {{ person.local_party.facebook_page }}
-          </a>
-          &nbsp;on Facebook
-        </p>
+          </a>  
+        </div>
         {% endif %}
-
-      {% if person.local_party.homepage %}
-        <p>
+        {% if person.local_party.homepage %}
+         <dt>Party Homepage</dt>
           <a href="{{ person.local_party.homepage }}">
-            {{ person.local_party.name }}'s website</a>
-        </p>
-      {% endif %}
-
-      {% if person.local_party.email %}
-        <p>
-          <a href="mailto:{{ person.local_party.email }}">
-            Email {{ person.local_party.email }}</a>
-        </p>
-      {% endif %}
-
+            {{ person.local_party.name }}'s website}
+          </a>  
+        </div>
+        {% endif %}
+        {% if person.local_party.email%}
+         <dt>Email</dt>
+          <a href="{{ person.local_party.email }}">
+            {{ person.local_party.name }}'s email}
+          </a>  
+        </div>
+        {% endif %}
+      </dl>
     </div>
-  </section>
+  </div>
 {% endif %}


### PR DESCRIPTION
Closes 
https://github.com/DemocracyClub/WhoCanIVoteFor/issues/778
https://github.com/DemocracyClub/WhoCanIVoteFor/issues/779
https://github.com/DemocracyClub/WhoCanIVoteFor/issues/785
https://github.com/DemocracyClub/WhoCanIVoteFor/issues/786 

- Favourite biscuit is back on the About Candidate card (below Wikipedia link, if it exists)
- Replace list position, if it exists, in people by party list
- Reformats elected stars and full width card
- Implement description list of local party card on person detail page

![Screen Shot 2021-05-04 at 1 31 35 PM](https://user-images.githubusercontent.com/7017118/117003794-36149300-acdd-11eb-9ee3-e4edeeaf3632.png)

![Screen Shot 2021-05-04 at 1 32 34 PM](https://user-images.githubusercontent.com/7017118/117004008-78d66b00-acdd-11eb-9afd-bb98923bd938.png)

![Screen Shot 2021-05-04 at 2 38 19 PM](https://user-images.githubusercontent.com/7017118/117012089-775d7080-ace6-11eb-81ed-46b963a6b18a.png)


