### PR TITLE
Hotfix/import elected

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -261,13 +261,16 @@ class YNRBallotImporter:
                         defaults={"name": candidate["person"]["name"]},
                     )
                     result = candidate["result"] or {}
+                    # if we dont have a result, get the "elected" value from
+                    # the main candidacy data
+                    elected = result.get("elected", candidate["elected"])
 
                     PersonPost.objects.create(
                         post_election=ballot,
                         person=person,
                         party_id=candidate["party"]["legacy_slug"],
                         list_position=candidate["party_list_position"],
-                        elected=result.get("elected"),
+                        elected=elected,
                         votes_cast=result.get("num_ballots", None),
                         post=ballot.post,
                         election=ballot.election,

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -133,10 +133,8 @@ class PersonViewTests(TestCase):
             person=self.person, election=election_two, party=party
         )
         response = self.client.get(self.person_url, follow=True)
-        self.assertContains(
-            response,
-            "is a Liberal Democrat candidate in the following elections:",
-        )
+        expected = f"<h5>{self.person.name} is a Liberal Democrat candidate in the following elections:"
+        self.assertContains(response, expected, html=True)
 
     def test_multiple_independent_candidacies_intro(self):
         election_one = ElectionFactory()
@@ -149,9 +147,8 @@ class PersonViewTests(TestCase):
             person=self.person, election=election_two, party=party
         )
         response = self.client.get(self.person_url, follow=True)
-        self.assertContains(
-            response, "is an Independent candidate in the following elections:"
-        )
+        expected = f"<h5>{self.person.name} is an Independent candidate in the following elections:"
+        self.assertContains(response, expected, html=True)
 
     def test_one_candidacy_intro(self):
         election = ElectionFactory()


### PR DESCRIPTION
Closes #806 

For ballots where we don't store a full result in YNR, the `import_ballots` management command is used to update whether a candidate was elected (rather than `import_votes_cast` as we don't have votes cast for these elections). Previously the importer was looking for this data in a `result` object that won't exist, so instead we fall back to the main candidacy data where we do include the `elected` value.

Have re-run import_ballots locally and have now got results for Mayoral elections, London Assembly, Senedd etc
<img width="1552" alt="Screenshot 2021-05-10 at 12 17 45" src="https://user-images.githubusercontent.com/15347726/117651327-bd548180-b189-11eb-9ca2-fcfca9dcafb0.png">
<img width="1552" alt="Screenshot 2021-05-10 at 12 19 52" src="https://user-images.githubusercontent.com/15347726/117651630-115f6600-b18a-11eb-93f6-467c2bb4a90e.png">
<img width="1552" alt="Screenshot 2021-05-10 at 12 18 39" src="https://user-images.githubusercontent.com/15347726/117651643-158b8380-b18a-11eb-9589-8f742f209cc6.png">


Also fixes some previously failing tests (unrelated)
