### PR TITLE
Hotfix/people party mobile

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -30,7 +30,7 @@
       </div>
     {% endfor %}
   {% else %}
-    <div class="ds-padded-large">
+    <div>
       <div class="ds-with-sidebar">
         <div>
           <div class="ds-sidebar" style="flex-basis: 5rem">


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/808

This work removes the padding from people by party lists to allow more room for person cards in the mobile view. 
![Screen Shot 2021-05-10 at 2 17 17 PM](https://user-images.githubusercontent.com/7017118/117725198-b4d96680-b1dc-11eb-93a3-8eec8e32b537.png)

