### PR TITLE
Hotfix/social media preview

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-debug-toolbar==3.2.1
 newspaper3k==0.2.8
 
 git+https://github.com/DemocracyClub/dc_signup_form.git@2.1.0
-git+https://github.com/DemocracyClub/design-system.git@0.1.4
+git+https://github.com/DemocracyClub/design-system.git@0.1.5
 git+https://github.com/DemocracyClub/dc_django_utils.git@0.0.5
 djangorestframework-jsonp==1.0.2
 feedparser==6.0.8

--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -92,11 +92,18 @@
                     <meta property="fb:app_id" content="262795130596272" />
                     <meta name="twitter:card" content="summary">
                     <meta name="twitter:site" content="@democlub">
-                    <meta property="og:image" content="{% block og_image %}{{ CANONICAL_URL }}{% static "images/logo.png" %}{% endblock og_image %}" />
+                    <meta property="og:image" content="{% block og_image %}{{ CANONICAL_URL }}{% static "images/logo_icon.png" %}{% endblock og_image %}" />
                     <meta property="og:image:width" content="{{ site_logo_width }}">
                     <meta property="og:title" content="{% block og_title %}{{ SITE_TITLE }} by Democracy Club{% endblock og_title %}" />
                     <meta property="og:description" content="{% block og_description %}Find out about elections, candidates and polling stations with Democracy Club's {{ SITE_TITLE }}{% endblock og_description %}" />
                 {% endblock site_meta %}
+                {% block site_icons %}
+                    <link rel="apple-touch-icon" sizes="180x180" href="{% static "images/logo_icon.png" %}">
+                    <link rel="icon" type="image/png" href="{% static "images/logo_icon.png" %}" sizes="32x32">
+                    <link rel="icon" type="image/png" href="{% static "images/logo_icon.png" %}" sizes="16x16">
+                    <link rel="mask-icon" href="{% static "images/logo_icon.png" %}" color="#ec008c">
+                    <link rel="shortcut icon" href="{% static "images/logo_icon.png" %}">
+                {% endblock site_icons %}
 
                 {% if messages %}
                     <aside class="ds-status messages" aria-label="Status">


### PR DESCRIPTION
This work updates the Open Graph image used in social media post previews as well as adds the favicons lost with the removal `dc_base_theme`.