### PR TITLE
Skip to content text is missing in link

### DIFF
--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -73,7 +73,7 @@
 
     <body class="ds-width-full">
         <div class="ds-page">
-            <p><a class="ds-skip-link" href="#main"></a></p>
+            <p><a class="ds-skip-link" href="#main">skip to content</a></p>
             {% block site_menu %}
                 <header class="ds-header">
                     <a class="ds-logo" href="/">


### PR DESCRIPTION
I noticed the skip to content text is missing on https://whocanivotefor.co.uk/ but is present on https://democracyclub.org.uk/ so have added some in.