### PR TITLE
Hotfix/migration fixup

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,10 +18,9 @@ django-robots==4.0
 django-debug-toolbar==3.2.1
 newspaper3k==0.2.8
 
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/0.1.4.tar.gz
 https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.1.tar.gz
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.1.6.tar.gz
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/0.1.4.tar.gz
+https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/0.1.5.tar.gz
 
 djangorestframework-jsonp==1.0.2
 feedparser==6.0.8

--- a/wcivf/apps/people/migrations/0028_person_pk_to_int.py
+++ b/wcivf/apps/people/migrations/0028_person_pk_to_int.py
@@ -47,9 +47,4 @@ class Migration(migrations.Migration):
             name="ynr_id",
             field=models.IntegerField(primary_key=True, serialize=False),
         ),
-        migrations.AlterField(
-            model_name="personpost",
-            name="person_id",
-            field=models.IntegerField(serialize=False),
-        ),
     ]


### PR DESCRIPTION
Between Django versions 3.0.14 and 3.1.0, an unexpected migration was generated: 

```
`# Generated by Django 3.2.7 on 2021-09-29 08:37

from django.db import migrations


class Migration(migrations.Migration):

    dependencies = [
        ('people', '0039_auto_20210928_1303'),
    ]

    operations = [
        migrations.RemoveField(
            model_name='personpost',
            name='person_id',
        ),
    ]
`
```

@michaeljcollinsuk discovered a possible cause: a [manual migration written by Sym](https://github.com/DemocracyClub/WhoCanIVoteFor/pull/282/commits/c930b6b3eaf3ab55168ecd01bb2408ebc8c9f3fe) rather than django generated. And then something (still a mystery) must have changed in Django 3.1 that caused `makemigrations` to get confused when it reads these [migration lines](https://github.com/DemocracyClub/WhoCanIVoteFor/pull/894/commits/e9d2605ab583010cf6a1ff4e57fa444a84467212), and then reviews the PersonPost model and thinks that a field has been removed.