### PR TITLE
Pin django above 3.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django<=3.3
+Django>=3.2<=3.3
 
 psycopg2-binary==2.8.6
 requests==2.25.1


### PR DESCRIPTION
Django 3.1 introduced their implementation of JSONField, which we are
now using in the application. So we need to pin the django version to
at least 3.1 otherwise migrations will not run. Pinning to >=3.2 as
this is the LTS version.