### PR TITLE
Add endpoint to return Ballot/Person timestamps

### DIFF
--- a/wcivf/apps/api/urls.py
+++ b/wcivf/apps/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import path, include
 
 from rest_framework import routers
 
@@ -18,4 +18,11 @@ router.register(
 )
 
 
-urlpatterns = [re_path(r"^", include(router.urls))]
+urlpatterns = [
+    path(r"", include(router.urls)),
+    path(
+        "last-updated-timestamps/",
+        views.LastUpdatedView.as_view(),
+        name="last-updated-timestamps",
+    ),
+]

--- a/wcivf/apps/api/views.py
+++ b/wcivf/apps/api/views.py
@@ -3,6 +3,7 @@ import abc
 from rest_framework import viewsets
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from api import serializers
 from api.serializers import VotingSystemSerializer
 from core.helpers import clean_postcode
@@ -128,3 +129,23 @@ class CandidatesAndElectionsForBallots(BaseCandidatesAndElectionsViewSet):
             "election__election_date", "election__election_weight"
         )
         return pes
+
+
+class LastUpdatedView(APIView):
+    def get(self, request):
+        """
+        Returns the current timestamps used by the people and ballot recently
+        updated importers
+        """
+        try:
+            ballot_ts = PostElection.objects.last_updated_in_ynr().ynr_modified
+            ballot_ts = ballot_ts.isoformat()
+        except PostElection.DoesNotExist:
+            ballot_ts = None
+
+        return Response(
+            data={
+                "ballot_timestamp": ballot_ts,
+                "person_timestamp": Person.objects.latest().last_updated.isoformat(),
+            }
+        )

--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -185,11 +185,7 @@ class YNRBallotImporter:
 
     def get_last_updated(self):
         try:
-            return (
-                PostElection.objects.filter(ynr_modified__isnull=False)
-                .latest()
-                .ynr_modified
-            )
+            return PostElection.objects.last_updated_in_ynr().ynr_modified
         except PostElection.DoesNotExist:
             # default before changes were added to YNR
             return timezone.datetime(2021, 10, 27, tzinfo=timezone.utc)

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -327,6 +327,14 @@ class Post(models.Model):
         return f"{self.label} {self.division_suffix}".strip()
 
 
+class PostElectionQuerySet(models.QuerySet):
+    def last_updated_in_ynr(self):
+        """
+        Returns the ballot with the most recent change made in YNR we know about
+        """
+        return self.filter(ynr_modified__isnull=False).latest("ynr_modified")
+
+
 class PostElection(TimeStampedModel):
     ballot_paper_id = models.CharField(blank=True, max_length=800, unique=True)
     post = models.ForeignKey(Post, on_delete=models.CASCADE)
@@ -353,6 +361,8 @@ class PostElection(TimeStampedModel):
         null=True,
         help_text="Timestamp of when this ballot was updated in the YNR",
     )
+
+    objects = PostElectionQuerySet.as_manager()
 
     class Meta:
         get_latest_by = "ynr_modified"


### PR DESCRIPTION
Endpoint to help us debug which timestamps are being used when the
ballot and person importers run with the --recently-updated flag