### PR TITLE
Hotfix/sitemaps

### DIFF
--- a/wcivf/apps/core/tests/test_frontend.py
+++ b/wcivf/apps/core/tests/test_frontend.py
@@ -59,7 +59,6 @@ class TestHtml:
             ElectionFactory().get_absolute_url(),
             PostElectionFactory().get_absolute_url(),
             reverse("postcode_view", kwargs={"postcode": "EC1A4EU"}),
-            reverse("results_list_view"),
             reverse("api:api-root"),
             reverse("dc_signup_form:mailing_list_signup_view"),
             reverse("feedback_form_view"),

--- a/wcivf/apps/elections/sitemaps.py
+++ b/wcivf/apps/elections/sitemaps.py
@@ -25,4 +25,4 @@ class PostElectionSitemap(Sitemap):
             Q(election__election_type="parl")
             | Q(election__election_type="2010")
             | Q(election__election_type="2015")
-        )
+        ).order_by("-election__election_date")

--- a/wcivf/apps/people/sitemaps.py
+++ b/wcivf/apps/people/sitemaps.py
@@ -8,4 +8,4 @@ class PersonSitemap(Sitemap):
     protocol = "https"
 
     def items(self):
-        return Person.objects.all()
+        return Person.objects.all().order_by("pk")

--- a/wcivf/urls.py
+++ b/wcivf/urls.py
@@ -1,8 +1,8 @@
-from django.urls import include, re_path
+from django.urls import include, re_path, path
 from django.contrib import admin
 from django.conf.urls.static import static
 from django.conf import settings
-from django.contrib.sitemaps.views import sitemap
+from django.contrib.sitemaps.views import sitemap, index
 from django.views.decorators.cache import cache_page
 
 from elections.sitemaps import ElectionSitemap, PostElectionSitemap
@@ -26,8 +26,13 @@ urlpatterns = (
         re_path(r"^person/", include("people.urls")),
         re_path(r"^feedback/", include("feedback.urls")),
         re_path(r"^api/", include(("api.urls", "api"), namespace="api")),
-        re_path(
-            r"^sitemap\.xml$",
+        path(
+            "sitemap.xml",
+            cache_page(86400)(index),
+            {"sitemaps": sitemaps},
+        ),
+        path(
+            "sitemap-<section>.xml",
             cache_page(86400)(sitemap),
             {"sitemaps": sitemaps},
             name="django.contrib.sitemaps.views.sitemap",

--- a/wcivf/urls.py
+++ b/wcivf/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, re_path, path
+from django.urls import include, path
 from django.contrib import admin
 from django.conf.urls.static import static
 from django.conf import settings
@@ -18,13 +18,13 @@ sitemaps = {
 
 urlpatterns = (
     [
-        re_path(r"^admin/", admin.site.urls),
-        re_path(r"^", include("core.urls")),
-        re_path(r"^elections/", include("elections.urls")),
-        re_path(r"^parties/", include("parties.urls")),
-        re_path(r"^person/", include("people.urls")),
-        re_path(r"^feedback/", include("feedback.urls")),
-        re_path(r"^api/", include(("api.urls", "api"), namespace="api")),
+        path("admin/", admin.site.urls),
+        path("", include("core.urls")),
+        path("elections/", include("elections.urls")),
+        path("parties/", include("parties.urls")),
+        path("person/", include("people.urls")),
+        path("feedback/", include("feedback.urls")),
+        path("api/", include(("api.urls", "api"), namespace="api")),
         path(
             "sitemap.xml",
             cache_page(86400)(index),
@@ -36,10 +36,8 @@ urlpatterns = (
             {"sitemaps": sitemaps},
             name="django.contrib.sitemaps.views.sitemap",
         ),
-        re_path(r"^robots\.txt", include("robots.urls")),
-        re_path(
-            r"^mailing_list/", include("mailing_list.urls", "dc_signup_form")
-        ),
+        path("robots.txt", include("robots.urls")),
+        path("mailing_list/", include("mailing_list.urls", "dc_signup_form")),
     ]
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
@@ -51,7 +49,7 @@ if settings.DEBUG:
     from dc_utils.urls import dc_utils_testing_patterns
 
     urlpatterns = (
-        [re_path(r"^__debug__/", include(debug_toolbar.urls))]
+        [path("__debug__/", include(debug_toolbar.urls))]
         + dc_utils_testing_patterns
         + urlpatterns
     )

--- a/wcivf/urls.py
+++ b/wcivf/urls.py
@@ -21,7 +21,6 @@ urlpatterns = (
         re_path(r"^admin/", admin.site.urls),
         re_path(r"^", include("core.urls")),
         re_path(r"^elections/", include("elections.urls")),
-        re_path(r"^results/", include("results.urls")),
         re_path(r"^parties/", include("parties.urls")),
         re_path(r"^person/", include("people.urls")),
         re_path(r"^feedback/", include("feedback.urls")),


### PR DESCRIPTION
Uses a sitemap index so that the app sitemaps are then paginated by django - example when running locally:
```
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<sitemap>
<loc>https://whocanivotefor.co.uk/sitemap-elections.xml</loc>
</sitemap>
<sitemap>
<loc>
https://whocanivotefor.co.uk/sitemap-postelections.xml
</loc>
</sitemap>
<sitemap>
<loc>https://whocanivotefor.co.uk/sitemap-people.xml</loc>
</sitemap>
<sitemap>
<loc>
https://whocanivotefor.co.uk/sitemap-people.xml?p=2
</loc>
</sitemap>
<sitemap>
<loc>https://whocanivotefor.co.uk/sitemap-parties.xml</loc>
</sitemap>
</sitemapindex>
```

Also some minor updates in the same urls.py file
- Remove the results app URL (could delete the app itself?)
- Use path instead of re_path, as regexes not used in these urls so this is the standard/suggested django way of defining urls since updating versions