### PR TITLE
Update instance sizes to use t3a, new AMI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,11 @@ jobs:
         type: integer
       desired-capacity:
         type: integer
+      dc-environment:
+        type: enum
+        enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: <<parameters.dc-environment>>
     steps:
       - checkout
       - restore_cache:
@@ -164,6 +169,7 @@ jobs:
           - v4-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}
       - attach_workspace:
           at: ~/repo/
+      - run: printenv DC_ENVIRONMENT
       - run:
           name: ensure the deployment group ready
           command: |
@@ -209,6 +215,7 @@ workflows:
 
       - code_deploy:
           name: code_deploy_development
+          dc-environment: development
           min-size: 1
           max-size: 1
           desired-capacity: 1
@@ -236,6 +243,7 @@ workflows:
 
       - code_deploy:
           name: code_deploy_staging
+          dc-environment: staging
           min-size: 1
           max-size: 1
           desired-capacity: 1
@@ -263,6 +271,7 @@ workflows:
 
       - code_deploy:
           name: code_deploy_production
+          dc-environment: production
           min-size: 1
           max-size: 1
           desired-capacity: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ workflows:
           vpc-id: vpc-fa2e0792
           subnet-ids: "subnet-890877f3,subnet-be093ad7,subnet-3524a679"
           ssl-certificate-arn: arn:aws:acm:eu-west-2:061126312678:certificate/3ac6d121-aed6-48a7-af80-6a021e05167c
-          instance-type: t3.small
+          instance-type: t3a.small
           domain: "dev.wcivf.club"
           requires:
           - build_and_test
@@ -225,7 +225,7 @@ workflows:
           vpc-id: vpc-69cef901
           subnet-ids: "subnet-e2b4f198,subnet-5a911a16,subnet-818bb2e8"
           ssl-certificate-arn: arn:aws:acm:eu-west-2:897471774344:certificate/a448e49a-5f47-41a3-a3d8-b6cc88781235
-          instance-type: t3.small
+          instance-type: t3a.medium
           domain: "wcivf.club"
           requires:
           - build_and_test
@@ -251,7 +251,7 @@ workflows:
           vpc-id: vpc-0d23d243e8bff4415
           subnet-ids: "subnet-04caf1309c0ab8f94,subnet-06475e48c36b4aece,subnet-0895b7d4795fbb1f4"
           ssl-certificate-arn: arn:aws:acm:eu-west-2:705594574410:certificate/4cee2a82-405a-42bd-b14a-4ea6bc63e36c
-          instance-type: t3.small
+          instance-type: t3a.medium
           domain: "whocanivotefor.co.uk"
           requires:
           - build_and_test

--- a/deployscripts/create_deployment_group.py
+++ b/deployscripts/create_deployment_group.py
@@ -1,3 +1,4 @@
+import os
 import boto3
 from botocore.exceptions import ClientError
 import time
@@ -57,7 +58,14 @@ def create_default_asg():
         HealthCheckType="ELB",
         HealthCheckGracePeriod=300,
         TargetGroupARNs=[target_group_arn],
-        Tags=[{"Key": "CodeDeploy"}],
+        Tags=[
+            {"Key": "CodeDeploy"},
+            {"Key": "dc-product", "Value": "wcivf"},
+            {
+                "Key": "dc-environmnet",
+                "Value": os.environ.get("DC_ENVIRONMENT"),
+            },
+        ],
         TerminationPolicies=[
             "OldestLaunchConfiguration",
             "ClosestToNextInstanceHour",

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -79,6 +79,10 @@ Resources:
           SENTRY_DSN: !Ref AppSentryDsn
           SECRET_KEY: !Ref AppSecretKey
           DC_ENVIRONMENT: !Ref AppDcEnvironment
+      Tags:
+        dc-environment: !Ref AppDcEnvironment
+        dc-product: wcivf
+        CreatedVia: CloudFormation
       Events:
         ImportPeopleRecentlyUpdated:
           Type: Schedule # More info about API Event Source: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
@@ -121,6 +125,7 @@ Resources:
     Properties:
       ApplicationName: WCIVFCodeDeploy
       ComputePlatform: Server
+      # cannot apply tags without recreating - applied in console
 
   ElbHTTPSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -137,6 +142,14 @@ Resources:
           IpProtocol: tcp
           ToPort: 443
       VpcId: !Ref VpcIdParameter
+      Tags:
+        - Key: dc-environment
+          Value: !Ref AppDcEnvironment
+        - Key: dc-product
+          Value: wcivf
+        - Key: CreatedVia
+          Value: CloudFormation
+
   InstanceHTTPSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -152,6 +165,14 @@ Resources:
           SourceSecurityGroupId: !Ref ElbHTTPSecurityGroup
           ToPort: 443
       VpcId: !Ref VpcIdParameter
+      Tags:
+        - Key: dc-environment
+          Value: !Ref AppDcEnvironment
+        - Key: dc-product
+          Value: wcivf
+        - Key: CreatedVia
+          Value: CloudFormation
+
   WCIVFTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
     Properties:
@@ -170,7 +191,13 @@ Resources:
       VpcId: !Ref VpcIdParameter
       Name: "wcivf-alb-tg"
       HealthCheckEnabled: true
-
+      Tags:
+        - Key: dc-environment
+          Value: !Ref AppDcEnvironment
+        - Key: dc-product
+          Value: wcivf
+        - Key: CreatedVia
+          Value: CloudFormation
 
   ApplicationLoadBalancer:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
@@ -182,6 +209,14 @@ Resources:
         - !Ref ElbHTTPSecurityGroup
       IpAddressType: "ipv4"
       Subnets: !Ref SubnetIdsParameter
+      Tags:
+        - Key: dc-environment
+          Value: !Ref AppDcEnvironment
+        - Key: dc-product
+          Value: wcivf
+        - Key: CreatedVia
+          Value: CloudFormation
+
 
   HTTPSListener:
     Type: "AWS::ElasticLoadBalancingV2::Listener"
@@ -305,6 +340,15 @@ Resources:
           aAogICAgc3NoLWF1dGhvcml6ZWQta2V5czoKICAgICAgLSAic3NoLWVkMjU1MTkgQUFBQUMzTnph
           QzFsWkRJMU5URTVBQUFBSUxHenpBM1hIK1JNcUVlOGpEbnovVHZmRGRpY2QxdDJvQmVSUDBDQWV1
           Q1kgbWljaGFlbEBtYWNib29rcHJvMjAyMSIK
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: dc-environment
+              Value: !Ref AppDcEnvironment
+            - Key: dc-product
+              Value: wcivf
+            - Key: CreatedVia
+              Value: CloudFormation
 
 Outputs:
   WCIVFControllerFunctionArn:

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -276,7 +276,7 @@ Resources:
         # TODO create new role without packer permissions
         IamInstanceProfile:
           Name: 'CodeDeploy-EC2-Instance-Profile'
-        ImageId: 'ami-0d1c7effdb01881f2' # AMI number
+        ImageId: 'ami-08e5184df40ad86ba' # AMI number
         InstanceType: !Ref InstanceType
         UserData: |
           I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGFzaAogICAgc3VkbzogQUxMPShBTEwpIE5P


### PR DESCRIPTION
- t3a.small for dev
- t3a.medium for staging and production
- Use new AMI build which uses more gunicorn workers