### PR TITLE
Feature/Update uncontested explanation

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -315,8 +315,9 @@ class YNRBallotImporter:
                 "locked": ballot_dict["candidates_locked"],
             }
 
-            if ballot_dict["candidates_locked"] and ballot_dict["winner_count"]:
-                defaults["contested"] = not ballot_dict["uncontested"]
+            if ballot_dict["candidates_locked"] or ballot_dict["cancelled"]:
+                if ballot_dict["winner_count"]:
+                    defaults["contested"] = not ballot_dict["uncontested"]
 
             # only update this when using the recently_updated flag as otherwise
             # the timestamp will only be the modifed timestamp on the ballot

--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -315,7 +315,7 @@ class YNRBallotImporter:
                 "locked": ballot_dict["candidates_locked"],
             }
 
-            if ballot_dict["candidates_locked"]:
+            if ballot_dict["candidates_locked"] and ballot_dict["winner_count"]:
                 defaults["contested"] = (
                     len(ballot_dict["candidacies"])
                     > ballot_dict["winner_count"]

--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -315,6 +315,12 @@ class YNRBallotImporter:
                 "locked": ballot_dict["candidates_locked"],
             }
 
+            if ballot_dict["candidates_locked"]:
+                defaults["contested"] = (
+                    len(ballot_dict["candidacies"])
+                    > ballot_dict["winner_count"]
+                )
+
             # only update this when using the recently_updated flag as otherwise
             # the timestamp will only be the modifed timestamp on the ballot
             # see BallotSerializer.get_last_updated in YNR

--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -316,10 +316,7 @@ class YNRBallotImporter:
             }
 
             if ballot_dict["candidates_locked"] and ballot_dict["winner_count"]:
-                defaults["contested"] = (
-                    len(ballot_dict["candidacies"])
-                    > ballot_dict["winner_count"]
-                )
+                defaults["contested"] = not ballot_dict["uncontested"]
 
             # only update this when using the recently_updated flag as otherwise
             # the timestamp will only be the modifed timestamp on the ballot

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -220,7 +220,7 @@ class Election(models.Model):
     @cached_property
     def pluralized_division_name(self):
         """
-        Returns a string for the pluarlized divison name for the posts in the
+        Returns a string for the pluralised divison name for the posts in the
         election
         """
         pluralise = {

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -27,9 +27,6 @@
             {{ object.replaced_by.election.election_date|date:"j F Y" }}
         </a>
     {% endif %}
-    {% if object.metadata.cancelled_election.detail %}
-        {{ object.metadata.cancelled_election.detail }}
-    {% endif %}
     {% if object.metadata.cancelled_election.url %}
         <a href="{{ object.metadata.cancelled_election.url }}">Read more</a>
     {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -10,7 +10,7 @@
             <b>Uncontested Election</b>
 
             <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
-                There is{{ object.winner_count|pluralize:"are" }} {{ object.winner_count|apnumber }}
+                There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
                 seat{{ object.winner_count|pluralize }} in this ward/division, and only
                 {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
@@ -21,7 +21,7 @@
                 <b>Uncontested and Rescheduled Election</b>
 
                 <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
-                    There is{{ object.winner_count|pluralize:"are"}} {{ object.winner_count|apnumber }}
+                    There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
                     seat{{ object.winner_count|pluralize }} in this ward/division, and only
                     {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -15,7 +15,16 @@
                 {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
             <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
-                the winner{{ object.people|pluralize }}.
+                the winner{{ object.people|pluralize }}.</p>
+
+            {% if postelection.people %}
+                {% if postelection.display_as_party_list %}
+                    {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
+                {% else %}
+                    {% include "elections/includes/_people_list.html" with people=postelection.people %}
+                {% endif %}
+            {% endif %}
+
         {% else %}
             {% if object.people.count >= 1 %}
                 <b>Uncontested and Rescheduled Election</b>
@@ -30,6 +39,13 @@
                     winner{{ object.people|pluralize }}.
                     A new election to fill the unclaimed seat{{ object.people|pluralize }}
                     will be held within 35 working days of the original election date.</p>
+                {% if postelection.people %}
+                    {% if postelection.display_as_party_list %}
+                        {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
+                    {% else %}
+                        {% include "elections/includes/_people_list.html" with people=postelection.people %}
+                    {% endif %}
+                {% endif %}
             {% else %}
                 <b>Rescheduled Election</b>
 

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -2,10 +2,12 @@
 {% load humanize %}
 {% load static %}
 
+{% comment %}Case 1: Cancelled election and Metadata is set in EE {% endcomment %}
 {% if object.metadata.cancelled_election.title %}
     <h4>{{ object.metadata.cancelled_election.title }}</h4>
 {% else %}
     {% if not object.contested %}
+        {% comment %} Case 2: Election cancelled, uncontested, number of candidates equal seats, no metadata{% endcomment %}
         {% if object.winner_count == object.people.count %}
             <h4>Uncontested Election</h4>
 
@@ -22,19 +24,21 @@
             {% else %}
                 {% include "elections/includes/_people_list.html" with people=object.people %}
             {% endif %}
-
+            {% comment %} Case 3: Election cancelled, uncontested and there are fewer candidates than seats, no metadata {% endcomment %}
         {% elif object.winner_count > object.people.count %}
+
+            <h4>Uncontested and Rescheduled Election</h4>
+
+            <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
+                There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
+                seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and
+                {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
+            {% comment %} Case 4: Election cancelled, uncontested and zero candidates, no metadata {% endcomment %}
             {% if object.people %}
-                <h4>Uncontested and Rescheduled Election</h4>
-
-                <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
-                    There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
-                    seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
-                    {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
-
                 <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
                     ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
                     winner{{ object.people|pluralize }}.
+
                     A new election to fill the unclaimed seat{{ object.people|pluralize }}
                     will be held within 35 working days of the original election date.</p>
 
@@ -43,11 +47,9 @@
                 {% else %}
                     {% include "elections/includes/_people_list.html" with people=object.people %}
                 {% endif %}
-            {% elif object.people.count > object.winner_count %}
-                <h4>Cancelled Election</h4>
-                <p>This election was cancelled.</p>
             {% endif %}
         {% endif %}
+        {% comment %} Case 5: Contested but cancelled for other reasons {% endcomment %}
     {% else %}
         <h4>Cancelled Election</h4>
         <p>This election was cancelled.</p>
@@ -70,7 +72,6 @@
     {% if object.metadata.cancelled_election.url %}
         <a href="{{ object.metadata.cancelled_election.url }}">Read more</a>
     {% endif %}
-
 </p>
 
 <p>

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -1,22 +1,46 @@
 {% load markdown_deux_tags %}
+{% load humanize %}
+{% load static %}
+
 {% if object.metadata.cancelled_election.title %}
     <h2>{{ object.metadata.cancelled_election.title }}</h2>
 {% else %}
-    <h2>Cancelled Election</h2>
+    <div>
+        {% if object.winner_count == object.people.count %}
+            <b>Uncontested Election</b>
+
+            <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
+                There is{{ object.winner_count|pluralize:"are" }} {{ object.winner_count|apnumber }}
+                seat{{ object.winner_count|pluralize }} in this ward/division, and only
+                {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
+
+            <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
+                the winner{{ object.people|pluralize }}.
+        {% else %}
+            {% if object.people.count >= 1 %}
+                <b>Uncontested and Rescheduled Election</b>
+
+                <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
+                    There is{{ object.winner_count|pluralize:"are"}} {{ object.winner_count|apnumber }}
+                    seat{{ object.winner_count|pluralize }} in this ward/division, and only
+                    {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
+
+                <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
+                    ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
+                    winner{{ object.people|pluralize }}.
+                    A new election to fill the unclaimed seat{{ object.people|pluralize }}
+                    will be held within 35 working days of the original election date.</p>
+            {% else %}
+                <b>Rescheduled Election</b>
+
+                <p>This election will not take place because <a href="{{ object.ynr_link }}">no candidates have been nominated to stand</a>.
+                    A new election to fill the unclaimed seat{{ object.winner_count|pluralize }} will be held within 35 working days of the original election date.</p>
+            {% endif %}
+        {% endif %}
+    </div>
 {% endif %}
+
 <p>
-    The poll for {{ object.post.label }} in the {{ object.election.name }}
-    {% if object.election.in_past %}was{% else %}has been{% endif %}
-    {% if object.replaced_by %}rescheduled{% else %}cancelled{% endif %}.
-
-    {% if not object.replaced_by %}
-        <p>This election {% if object.election.in_past %}will{% else %}did{% endif %}
-            not take place because <a href="{{ object.ynr_sopn_link }}">no candidates</a> have been
-            nominated to stand. A new election to fill the unclaimed seat{{ object.people|pluralize }}
-            {% if object.election.in_past %}will be{% else %}was{% endif %}
-            held within 35 working days of the original election date.</p>
-    {% endif %}
-
     {% if object.replaced_by %}
         {% if object.election.in_past %}
             It was rescheduled for
@@ -24,10 +48,20 @@
             It will now take place on
         {% endif %}
         <a href="{{ object.replaced_by.get_absolute_url }}">
-            {{ object.replaced_by.election.election_date|date:"j F Y" }}
+            {{ object.replaced_by.election.election_date|date:"j F Y" }}.
         </a>
     {% endif %}
+
+
     {% if object.metadata.cancelled_election.url %}
         <a href="{{ object.metadata.cancelled_election.url }}">Read more</a>
     {% endif %}
+
 </p>
+
+<p>
+    {% if object.metadata.cancelled_election.detail %}
+        {{ object.metadata.cancelled_election.detail }}
+    {% endif %}
+</p>
+

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -5,37 +5,17 @@
 {% if object.metadata.cancelled_election.title %}
     <h4>{{ object.metadata.cancelled_election.title }}</h4>
 {% else %}
-    {% if object.winner_count == object.people.count %}
-        <h4>Uncontested Election</h4>
+    {% if not object.contested %}
+        {% if object.winner_count == object.people.count %}
+            <h4>Uncontested Election</h4>
 
-        <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
-            There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
-            seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
-            {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
-
-        <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below ha{{ object.winner_count|pluralize:"s,ve" }} been automatically declared
-            the winner{{ object.people|pluralize }}.</p>
-
-        {% if object.display_as_party_list %}
-            {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
-        {% else %}
-            {% include "elections/includes/_people_list.html" with people=object.people %}
-        {% endif %}
-
-    {% else %}
-        {% if object.people %}
-            <h4>Uncontested and Rescheduled Election</h4>
-
-            <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
-                There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
+            <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
+                There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
                 seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
                 {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
-            <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
-                ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
-                winner{{ object.people|pluralize }}.
-                A new election to fill the unclaimed seat{{ object.people|pluralize }}
-                will be held within 35 working days of the original election date.</p>
+            <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below ha{{ object.winner_count|pluralize:"s,ve" }} been automatically declared
+                the winner{{ object.people|pluralize }}.</p>
 
             {% if object.display_as_party_list %}
                 {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
@@ -43,12 +23,34 @@
                 {% include "elections/includes/_people_list.html" with people=object.people %}
             {% endif %}
 
-        {% else %}
-            <h4>Rescheduled Election</h4>
+        {% elif object.winner_count > object.people.count %}
+            {% if object.people %}
+                <h4>Uncontested and Rescheduled Election</h4>
 
-            <p>This election will not take place because <a href="{{ object.ynr_link }}">no candidates have been nominated to stand</a>.
-                A new election to fill the unclaimed seat{{ object.winner_count|pluralize }} will be held within 35 working days of the original election date.</p>
+                <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
+                    There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
+                    seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
+                    {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
+
+                <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
+                    ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
+                    winner{{ object.people|pluralize }}.
+                    A new election to fill the unclaimed seat{{ object.people|pluralize }}
+                    will be held within 35 working days of the original election date.</p>
+
+                {% if object.display_as_party_list %}
+                    {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+                {% else %}
+                    {% include "elections/includes/_people_list.html" with people=object.people %}
+                {% endif %}
+            {% elif object.people.count > object.winner_count %}
+                <h4>Cancelled Election</h4>
+                <p>This election was cancelled.</p>
+            {% endif %}
         {% endif %}
+    {% else %}
+        <h4>Cancelled Election</h4>
+        <p>This election was cancelled.</p>
     {% endif %}
 {% endif %}
 

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -8,6 +8,15 @@
     The poll for {{ object.post.label }} in the {{ object.election.name }}
     {% if object.election.in_past %}was{% else %}has been{% endif %}
     {% if object.replaced_by %}rescheduled{% else %}cancelled{% endif %}.
+
+    {% if not object.replaced_by %}
+        <p>This election {% if object.election.in_past %}will{% else %}did{% endif %}
+            not take place because <a href="{{ object.ynr_sopn_link }}">no candidates</a> have been
+            nominated to stand. A new election to fill the unclaimed seat{{ object.people|pluralize }}
+            {% if object.election.in_past %}will be{% else %}was{% endif %}
+            held within 35 working days of the original election date.</p>
+    {% endif %}
+
     {% if object.replaced_by %}
         {% if object.election.in_past %}
             It was rescheduled for

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -10,10 +10,10 @@
 
         <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
             There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
-            seat{{ object.winner_count|pluralize }} in this ward/division, and only
+            seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
             {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
-        <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
+        <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below ha{{ object.winner_count|pluralize:"s,ve" }} been automatically declared
             the winner{{ object.people|pluralize }}.</p>
 
         {% if object.display_as_party_list %}
@@ -28,7 +28,7 @@
 
             <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
                 There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
-                seat{{ object.winner_count|pluralize }} in this ward/division, and only
+                seat{{ object.winner_count|pluralize }} in {{ object.post.full_label }}, and only
                 {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
             <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -17,12 +17,10 @@
             <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
                 the winner{{ object.people|pluralize }}.</p>
 
-            {% if postelection.people %}
-                {% if postelection.display_as_party_list %}
-                    {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
-                {% else %}
-                    {% include "elections/includes/_people_list.html" with people=postelection.people %}
-                {% endif %}
+            {% if object.display_as_party_list %}
+                {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+            {% else %}
+                {% include "elections/includes/_people_list.html" with people=object.people %}
             {% endif %}
 
         {% else %}
@@ -39,13 +37,13 @@
                     winner{{ object.people|pluralize }}.
                     A new election to fill the unclaimed seat{{ object.people|pluralize }}
                     will be held within 35 working days of the original election date.</p>
-                {% if postelection.people %}
-                    {% if postelection.display_as_party_list %}
-                        {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
-                    {% else %}
-                        {% include "elections/includes/_people_list.html" with people=postelection.people %}
-                    {% endif %}
+
+                {% if object.display_as_party_list %}
+                    {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+                {% else %}
+                    {% include "elections/includes/_people_list.html" with people=object.people %}
                 {% endif %}
+
             {% else %}
                 <b>Rescheduled Election</b>
 

--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -3,19 +3,39 @@
 {% load static %}
 
 {% if object.metadata.cancelled_election.title %}
-    <h2>{{ object.metadata.cancelled_election.title }}</h2>
+    <h4>{{ object.metadata.cancelled_election.title }}</h4>
 {% else %}
-    <div>
-        {% if object.winner_count == object.people.count %}
-            <b>Uncontested Election</b>
+    {% if object.winner_count == object.people.count %}
+        <h4>Uncontested Election</h4>
 
-            <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
-                There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
+        <p>This election was uncontested because the number of candidates who stood was equal to the number of available seats.
+            There {{ object.winner_count|pluralize:"is,are" }} {{ object.winner_count|apnumber }}
+            seat{{ object.winner_count|pluralize }} in this ward/division, and only
+            {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
+
+        <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
+            the winner{{ object.people|pluralize }}.</p>
+
+        {% if object.display_as_party_list %}
+            {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+        {% else %}
+            {% include "elections/includes/_people_list.html" with people=object.people %}
+        {% endif %}
+
+    {% else %}
+        {% if object.people %}
+            <h4>Uncontested and Rescheduled Election</h4>
+
+            <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
+                There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
                 seat{{ object.winner_count|pluralize }} in this ward/division, and only
                 {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
 
-            <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below have been automatically declared
-                the winner{{ object.people|pluralize }}.</p>
+            <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
+                ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
+                winner{{ object.people|pluralize }}.
+                A new election to fill the unclaimed seat{{ object.people|pluralize }}
+                will be held within 35 working days of the original election date.</p>
 
             {% if object.display_as_party_list %}
                 {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
@@ -24,34 +44,12 @@
             {% endif %}
 
         {% else %}
-            {% if object.people.count >= 1 %}
-                <b>Uncontested and Rescheduled Election</b>
+            <h4>Rescheduled Election</h4>
 
-                <p>This election was uncontested because the number of candidates who stood was fewer than the number of available seats.
-                    There {{ object.winner_count|pluralize:"is,are"}} {{ object.winner_count|apnumber }}
-                    seat{{ object.winner_count|pluralize }} in this ward/division, and only
-                    {{ object.people.count|apnumber }} candidate{{ object.people|pluralize }}.</p>
-
-                <p>No votes will be cast, and the candidate{{ object.people|pluralize }} below
-                    ha{{ object.people|pluralize:"s,ve" }} been automatically declared the
-                    winner{{ object.people|pluralize }}.
-                    A new election to fill the unclaimed seat{{ object.people|pluralize }}
-                    will be held within 35 working days of the original election date.</p>
-
-                {% if object.display_as_party_list %}
-                    {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
-                {% else %}
-                    {% include "elections/includes/_people_list.html" with people=object.people %}
-                {% endif %}
-
-            {% else %}
-                <b>Rescheduled Election</b>
-
-                <p>This election will not take place because <a href="{{ object.ynr_link }}">no candidates have been nominated to stand</a>.
-                    A new election to fill the unclaimed seat{{ object.winner_count|pluralize }} will be held within 35 working days of the original election date.</p>
-            {% endif %}
+            <p>This election will not take place because <a href="{{ object.ynr_link }}">no candidates have been nominated to stand</a>.
+                A new election to fill the unclaimed seat{{ object.winner_count|pluralize }} will be held within 35 working days of the original election date.</p>
         {% endif %}
-    </div>
+    {% endif %}
 {% endif %}
 
 <p>

--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -1,4 +1,6 @@
-{% if postelection.people|length %}
+{% if postelection.cancelled %}
+    {{ object.election.name }}: This election has been cancelled.
+{% elif postelection.people|length %}
     {% autoescape off %}
         See all {{ postelection.people|length }} candidates in the {{ object.election.name }} on {{ object.election.election_date }}:
         {% for pp in postelection.people %}

--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_title.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_title.html
@@ -1,5 +1,9 @@
-{% if postelection.people|length %}
-    {{ object.election.name }}: The {{ postelection.people|length }} candidates in {{ object.post.label }}
+{% if postelection.cancelled %}
+    {{ object.election.name }}: This election has been cancelled.
 {% else %}
-    {{ object.election.name }}: No candidates known yet.
+    {% if postelection.people|length %}
+        {{ object.election.name }}: The {{ postelection.people|length }} candidates in {{ object.post.label }}
+    {% else %}
+        {{ object.election.name }}: No candidates known yet.
+    {% endif %}
 {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -6,43 +6,46 @@
     <div class="ds-card" id="election_{{ postelection.election.slug }}">
         <div class="ds-card-body">
 
-            {% if postelection.cancelled %}
-                {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
-            {% else %}
+            <h2>
+                <span aria-hidden="true">🗳️</span>
+                {{ postelection.election.name_without_brackets }}
+            </h2>
 
-                <h2>
-                    <span aria-hidden="true">🗳️</span>
-                    {{ postelection.election.name_without_brackets }}
-                </h2>
+            {% if not postelection.is_pcc and not postelection.is_mayoral %}
+                <h3>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
+            {% endif %}
 
-                {% if not postelection.is_pcc and not postelection.is_mayoral %}
-                    <h3>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
+            {% if postelection.metadata.coronavirus_message %}
+                <div style="border:1px solid red;margin:1em 0;padding:1em">
+                    <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
+                </div>
+            {% endif %}
+
+            <p>
+                This election
+                {% if postelection.election.is_election_day %}
+                    <strong>is being held today</strong>.
+                    Polls are open from {{ postelection.election.polls_open|time:"ga" }} till {{ postelection.election.polls_close|time:"ga" }}
+                {% else %}
+                    {{ postelection.election.in_past|yesno:"was,will be" }} held
+                    <strong>{{ postelection.election.election_date|naturalday:"\o\n l j F Y" }}</strong>.
                 {% endif %}
+            </p>
 
-                {% if postelection.metadata.coronavirus_message %}
-                    <div style="border:1px solid red;margin:1em 0;padding:1em">
-                        <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
-                    </div>
-                {% endif %}
+            {% if object.election.slug == "europarl.2019-05-23"%}
+                {% include "elections/includes/eu_results.html" with card=0 %}
+            {% endif %}
 
-                <p>
-                    This election
-                    {% if postelection.election.is_election_day %}
-                        <strong>is being held today</strong>.
-                        Polls are open from {{ postelection.election.polls_open|time:"ga" }} till {{ postelection.election.polls_close|time:"ga" }}
-                    {% else %}
-                        {{ postelection.election.in_past|yesno:"was,will be" }} held
-                        <strong>{{ postelection.election.election_date|naturalday:"\o\n l j F Y" }}</strong>.
-                    {% endif %}
-                </p>
-
-                {% if object.election.slug == "europarl.2019-05-23"%}
-                    {% include "elections/includes/eu_results.html" with card=0 %}
-                {% endif %}
-
-                <p>
-                    {% if postelection.election.in_past %}
-                        <strong>{{ postelection.people|length }} candidates</strong> stood in the {{ postelection.friendly_name }}.
+            <p>
+                {% if postelection.election.in_past %}
+                    <strong>{{ postelection.people|length }} candidates</strong> stood in the {{ postelection.friendly_name }}.
+                {% else %}
+                    {# Display different messages depending on the number of candidates #}
+                    {# Case: No candidates for a contested election #}
+                    {% if not postelection.people and postelection.contested %}
+                        We don't know of any candidates standing yet.
+                        You can help improve this page: <a href="{{ postelection.ynr_link }}">
+                            add information about candidates to our database</a>.
                     {% else %}
                         {# Display different messages depending on the number of candidates #}
                         {# Case: No candidates for a contested election #}
@@ -51,103 +54,98 @@
                             You can help improve this page: <a href="{{ postelection.ynr_link }}">
                                 add information about candidates to our database</a>.
                         {% else %}
-                            {# Display different messages depending on the number of candidates #}
-                            {# Case: No candidates for a contested election #}
-                            {% if not postelection.people and postelection.contested %}
-                                We don't know of any candidates standing yet.
+                            {% if postelection.locked %}
+                                {# Case: Candidates and the post is locked #}
+                                {% if postelection.get_voting_system.slug == "PR-CL" %}
+                                    You will have one vote, and can vote for a single party list or independent candidate.
+                                {% else %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
+                                        You will have {{ postelection.winner_count|apnumber }} vote{{ postelection.winner_count|pluralize }},
+                                        and can choose from <strong>{{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}</strong>.
+                                    {% endif %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
+                                        You will have one vote, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
+                                        in the {{ postelection.friendly_name }}.
+                                    {% endif %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
+                                        You will have two votes, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
+                                        in the {{ postelection.friendly_name }}.
+                                    {% endif %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'STV' %}
+                                        You can choose from <strong>{{ postelection.party_ballot_count }}</strong>.
+                                    {% endif %}
+                                {% endif %}
+
+                                {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
+
+                            {% else %}
+                                {# Case: Candidates and the post is NOT locked (add CTA) #}
+                                The official candidate list has not yet been published.
+                                However, we expect at least <strong>{{ postelection.party_ballot_count }}</strong>
+                                in the {{ postelection.friendly_name }}.
+
                                 You can help improve this page: <a href="{{ postelection.ynr_link }}">
                                     add information about candidates to our database</a>.
-                            {% else %}
-                                {% if postelection.locked %}
-                                    {# Case: Candidates and the post is locked #}
-                                    {% if postelection.get_voting_system.slug == "PR-CL" %}
-                                        You will have one vote, and can vote for a single party list or independent candidate.
-                                    {% else %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
-                                            You will have {{ postelection.winner_count|apnumber }} vote{{ postelection.winner_count|pluralize }},
-                                            and can choose from <strong>{{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}</strong>.
-                                        {% endif %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
-                                            You will have one vote, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
-                                            in the {{ postelection.friendly_name }}.
-                                        {% endif %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
-                                            You will have two votes, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
-                                            in the {{ postelection.friendly_name }}.
-                                        {% endif %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'STV' %}
-                                            You can choose from <strong>{{ postelection.party_ballot_count }}</strong>.
-                                        {% endif %}
-                                    {% endif %}
-
-                                    {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
-
-                                {% else %}
-                                    {# Case: Candidates and the post is NOT locked (add CTA) #}
-                                    The official candidate list has not yet been published.
-                                    However, we expect at least <strong>{{ postelection.party_ballot_count }}</strong>
-                                    in the {{ postelection.friendly_name }}.
-
-                                    You can help improve this page: <a href="{{ postelection.ynr_link }}">
-                                        add information about candidates to our database</a>.
-                                {% endif %}
-
                             {% endif %}
+
                         {% endif %}
+                    {% endif %}
+                {% endif %}
+            </p>
+
+            {% if postelection.cancelled %}
+                {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
+            {% endif %}
+            {% if postelection.people %}
+                {% if postelection.display_as_party_list %}
+                    {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
+                {% else %}
+                    {% include "elections/includes/_people_list.html" with people=postelection.people %}
+                {% endif %}
+            {% endif %}
+
+
+            {% if postelection.should_display_sopn_info %}
+                <p>
+                    {% if postelection.locked %}
+                        The <a href="{{ postelection.ynr_sopn_link }}">official candidate list</a> has been published.
+                    {% else %}
+                        The official candidate list should
+                        {% if postelection.past_expected_sopn_day %}
+                            have been
+                        {% else %}
+                            be
+                        {% endif %}
+                        published on {{ postelection.expected_sopn_date|date:"j F Y" }}.
                     {% endif %}
                 </p>
+            {% endif %}
 
-                {% if postelection.people %}
-                    {% if postelection.display_as_party_list %}
-                        {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
-                    {% else %}
-                        {% include "elections/includes/_people_list.html" with people=postelection.people %}
-                    {% endif %}
-                {% endif %}
+            {% if postelection.election.election_booklet %}
+                <h4><a href="{% static postelection.election.election_booklet %}">
+                    Read the official candidate booklet for this election.</a></h4>
+            {% endif %}
 
+            {% if postelection.election.description %}
+                {{ postelection.election.description|markdown }}
+            {% endif %}
 
-                {% if postelection.should_display_sopn_info %}
-                    <p>
-                        {% if postelection.locked %}
-                            The <a href="{{ postelection.ynr_sopn_link }}">official candidate list</a> has been published.
-                        {% else %}
-                            The official candidate list should
-                            {% if postelection.past_expected_sopn_day %}
-                                have been
-                            {% else %}
-                                be
+            {% if postelection.election.voter_age %}
+                <ul class="ds-details">
+                    <li>
+                        <details>
+                            <summary>Can you vote in this election?</summary>
+                            <h5>Age</h5>
+                            <p>You need to be over {{ postelection.election.voter_age }} on the
+                                {{ postelection.election.election_date|date:"jS" }}
+                                of {{ postelection.election.election_date|date:"F Y" }} in order to vote in this election</p>
+                            {% if postelection.election.voter_citizenship %}
+                                <h5>Citizenship</h5>
+                                {{ postelection.election.voter_citizenship|markdown }}
                             {% endif %}
-                            published on {{ postelection.expected_sopn_date|date:"j F Y" }}.
-                        {% endif %}
-                    </p>
-                {% endif %}
-
-                {% if postelection.election.election_booklet %}
-                    <h4><a href="{% static postelection.election.election_booklet %}">
-                        Read the official candidate booklet for this election.</a></h4>
-                {% endif %}
-
-                {% if postelection.election.description %}
-                    {{ postelection.election.description|markdown }}
-                {% endif %}
-
-                {% if postelection.election.voter_age %}
-                    <ul class="ds-details">
-                        <li>
-                            <details>
-                                <summary>Can you vote in this election?</summary>
-                                <h5>Age</h5>
-                                <p>You need to be over {{ postelection.election.voter_age }} on the
-                                    {{ postelection.election.election_date|date:"jS" }}
-                                    of {{ postelection.election.election_date|date:"F Y" }} in order to vote in this election</p>
-                                {% if postelection.election.voter_citizenship %}
-                                    <h5>Citizenship</h5>
-                                    {{ postelection.election.voter_citizenship|markdown }}
-                                {% endif %}
-                            </details>
-                        </li>
-                    </ul>
-                {% endif %}
+                        </details>
+                    </li>
+                </ul>
             {% endif %}
 
 

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -6,46 +6,43 @@
     <div class="ds-card" id="election_{{ postelection.election.slug }}">
         <div class="ds-card-body">
 
-            <h2>
-                <span aria-hidden="true">🗳️</span>
-                {{ postelection.election.name_without_brackets }}
-            </h2>
+            {% if postelection.cancelled %}
+                {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
+            {% else %}
 
-            {% if not postelection.is_pcc and not postelection.is_mayoral %}
-                <h3>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
-            {% endif %}
+                <h2>
+                    <span aria-hidden="true">🗳️</span>
+                    {{ postelection.election.name_without_brackets }}
+                </h2>
 
-            {% if postelection.metadata.coronavirus_message %}
-                <div style="border:1px solid red;margin:1em 0;padding:1em">
-                    <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
-                </div>
-            {% endif %}
-
-            <p>
-                This election
-                {% if postelection.election.is_election_day %}
-                    <strong>is being held today</strong>.
-                    Polls are open from {{ postelection.election.polls_open|time:"ga" }} till {{ postelection.election.polls_close|time:"ga" }}
-                {% else %}
-                    {{ postelection.election.in_past|yesno:"was,will be" }} held
-                    <strong>{{ postelection.election.election_date|naturalday:"\o\n l j F Y" }}</strong>.
+                {% if not postelection.is_pcc and not postelection.is_mayoral %}
+                    <h3>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
                 {% endif %}
-            </p>
 
-            {% if object.election.slug == "europarl.2019-05-23"%}
-                {% include "elections/includes/eu_results.html" with card=0 %}
-            {% endif %}
+                {% if postelection.metadata.coronavirus_message %}
+                    <div style="border:1px solid red;margin:1em 0;padding:1em">
+                        <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
+                    </div>
+                {% endif %}
 
-            <p>
-                {% if postelection.election.in_past %}
-                    <strong>{{ postelection.people|length }} candidate{{ postelection.people|pluralize }}</strong> stood in the {{ postelection.friendly_name }}.
-                {% else %}
-                    {# Display different messages depending on the number of candidates #}
-                    {# Case: No candidates for a contested election #}
-                    {% if not postelection.people and postelection.contested %}
-                        We don't know of any candidates standing yet.
-                        You can help improve this page: <a href="{{ postelection.ynr_link }}">
-                            add information about candidates to our database</a>.
+                <p>
+                    This election
+                    {% if postelection.election.is_election_day %}
+                        <strong>is being held today</strong>.
+                        Polls are open from {{ postelection.election.polls_open|time:"ga" }} till {{ postelection.election.polls_close|time:"ga" }}
+                    {% else %}
+                        {{ postelection.election.in_past|yesno:"was,will be" }} held
+                        <strong>{{ postelection.election.election_date|naturalday:"\o\n l j F Y" }}</strong>.
+                    {% endif %}
+                </p>
+
+                {% if object.election.slug == "europarl.2019-05-23"%}
+                    {% include "elections/includes/eu_results.html" with card=0 %}
+                {% endif %}
+
+                <p>
+                    {% if postelection.election.in_past %}
+                        <strong>{{ postelection.people|length }} candidate{{ postelection.people|pluralize }}</strong> stood in the {{ postelection.friendly_name }}.
                     {% else %}
                         {# Display different messages depending on the number of candidates #}
                         {# Case: No candidates for a contested election #}
@@ -54,98 +51,97 @@
                             You can help improve this page: <a href="{{ postelection.ynr_link }}">
                                 add information about candidates to our database</a>.
                         {% else %}
-                            {% if postelection.locked %}
-                                {# Case: Candidates and the post is locked #}
-                                {% if postelection.get_voting_system.slug == "PR-CL" %}
-                                    You will have one vote, and can vote for a single party list or independent candidate.
-                                {% else %}
-                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
-                                        You will have {{ postelection.winner_count|apnumber }} vote{{ postelection.winner_count|pluralize }},
-                                        and can choose from <strong>{{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}</strong>.
-                                    {% endif %}
-                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
-                                        You will have one vote, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
-                                        in the {{ postelection.friendly_name }}.
-                                    {% endif %}
-                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
-                                        You will have two votes, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
-                                        in the {{ postelection.friendly_name }}.
-                                    {% endif %}
-                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'STV' %}
-                                        You can choose from <strong>{{ postelection.party_ballot_count }}</strong>.
-                                    {% endif %}
-                                {% endif %}
-
-                                {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
-
-                            {% else %}
-                                {# Case: Candidates and the post is NOT locked (add CTA) #}
-                                The official candidate list has not yet been published.
-                                However, we expect at least <strong>{{ postelection.party_ballot_count }}</strong>
-                                in the {{ postelection.friendly_name }}.
-
+                            {# Display different messages depending on the number of candidates #}
+                            {# Case: No candidates for a contested election #}
+                            {% if not postelection.people and postelection.contested %}
+                                We don't know of any candidates standing yet.
                                 You can help improve this page: <a href="{{ postelection.ynr_link }}">
                                     add information about candidates to our database</a>.
+                            {% else %}
+                                {% if postelection.locked %}
+                                    {# Case: Candidates and the post is locked #}
+                                    {% if postelection.get_voting_system.slug == "PR-CL" %}
+                                        You will have one vote, and can vote for a single party list or independent candidate.
+                                    {% else %}
+                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
+                                            You will have {{ postelection.winner_count|apnumber }} vote{{ postelection.winner_count|pluralize }},
+                                            and can choose from <strong>{{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}</strong>.
+                                        {% endif %}
+                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
+                                            You will have one vote, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
+                                            in the {{ postelection.friendly_name }}.
+                                        {% endif %}
+                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
+                                            You will have two votes, and can choose from <strong>{{ postelection.party_ballot_count }}</strong>
+                                            in the {{ postelection.friendly_name }}.
+                                        {% endif %}
+                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'STV' %}
+                                            You can choose from <strong>{{ postelection.party_ballot_count }}</strong>.
+                                        {% endif %}
+                                    {% endif %}
+
+                                    {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
+
+                                {% else %}
+                                    {# Case: Candidates and the post is NOT locked (add CTA) #}
+                                    The official candidate list has not yet been published.
+                                    However, we expect at least <strong>{{ postelection.party_ballot_count }}</strong>
+                                    in the {{ postelection.friendly_name }}.
+
+                                    You can help improve this page: <a href="{{ postelection.ynr_link }}">
+                                        add information about candidates to our database</a>.
+                                {% endif %}
+
                             {% endif %}
-
                         {% endif %}
-                    {% endif %}
-                {% endif %}
-            </p>
-
-            {% if postelection.cancelled %}
-                {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
-            {% endif %}
-            {% if postelection.people %}
-                {% if postelection.display_as_party_list %}
-                    {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
-                {% else %}
-                    {% include "elections/includes/_people_list.html" with people=postelection.people %}
-                {% endif %}
-            {% endif %}
-
-
-            {% if postelection.should_display_sopn_info %}
-                <p>
-                    {% if postelection.locked %}
-                        The <a href="{{ postelection.ynr_sopn_link }}">official candidate list</a> has been published.
-                    {% else %}
-                        The official candidate list should
-                        {% if postelection.past_expected_sopn_day %}
-                            have been
-                        {% else %}
-                            be
-                        {% endif %}
-                        published on {{ postelection.expected_sopn_date|date:"j F Y" }}.
                     {% endif %}
                 </p>
-            {% endif %}
 
-            {% if postelection.election.election_booklet %}
-                <h4><a href="{% static postelection.election.election_booklet %}">
-                    Read the official candidate booklet for this election.</a></h4>
-            {% endif %}
 
-            {% if postelection.election.description %}
-                {{ postelection.election.description|markdown }}
-            {% endif %}
 
-            {% if postelection.election.voter_age %}
-                <ul class="ds-details">
-                    <li>
-                        <details>
-                            <summary>Can you vote in this election?</summary>
-                            <h5>Age</h5>
-                            <p>You need to be over {{ postelection.election.voter_age }} on the
-                                {{ postelection.election.election_date|date:"jS" }}
-                                of {{ postelection.election.election_date|date:"F Y" }} in order to vote in this election</p>
-                            {% if postelection.election.voter_citizenship %}
-                                <h5>Citizenship</h5>
-                                {{ postelection.election.voter_citizenship|markdown }}
+
+                {% if postelection.should_display_sopn_info %}
+                    <p>
+                        {% if postelection.locked %}
+                            The <a href="{{ postelection.ynr_sopn_link }}">official candidate list</a> has been published.
+                        {% else %}
+                            The official candidate list should
+                            {% if postelection.past_expected_sopn_day %}
+                                have been
+                            {% else %}
+                                be
                             {% endif %}
-                        </details>
-                    </li>
-                </ul>
+                            published on {{ postelection.expected_sopn_date|date:"j F Y" }}.
+                        {% endif %}
+                    </p>
+                {% endif %}
+
+                {% if postelection.election.election_booklet %}
+                    <h4><a href="{% static postelection.election.election_booklet %}">
+                        Read the official candidate booklet for this election.</a></h4>
+                {% endif %}
+
+                {% if postelection.election.description %}
+                    {{ postelection.election.description|markdown }}
+                {% endif %}
+
+                {% if postelection.election.voter_age %}
+                    <ul class="ds-details">
+                        <li>
+                            <details>
+                                <summary>Can you vote in this election?</summary>
+                                <h5>Age</h5>
+                                <p>You need to be over {{ postelection.election.voter_age }} on the
+                                    {{ postelection.election.election_date|date:"jS" }}
+                                    of {{ postelection.election.election_date|date:"F Y" }} in order to vote in this election</p>
+                                {% if postelection.election.voter_citizenship %}
+                                    <h5>Citizenship</h5>
+                                    {{ postelection.election.voter_citizenship|markdown }}
+                                {% endif %}
+                            </details>
+                        </li>
+                    </ul>
+                {% endif %}
             {% endif %}
 
 

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -38,7 +38,7 @@
 
             <p>
                 {% if postelection.election.in_past %}
-                    <strong>{{ postelection.people|length }} candidates</strong> stood in the {{ postelection.friendly_name }}.
+                    <strong>{{ postelection.people|length }} candidate{{ postelection.people|pluralize }}</strong> stood in the {{ postelection.friendly_name }}.
                 {% else %}
                     {# Display different messages depending on the number of candidates #}
                     {# Case: No candidates for a contested election #}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -98,10 +98,12 @@
                     {% endif %}
                 </p>
 
-                {% if object.display_as_party_list %}
-                    {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
-                {% else %}
-                    {% include "elections/includes/_people_list.html" with people=object.people %}
+                {% if postelection.people %}
+                    {% if object.display_as_party_list %}
+                        {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+                    {% else %}
+                        {% include "elections/includes/_people_list.html" with people=object.people %}
+                    {% endif %}
                 {% endif %}
 
                 {% if postelection.should_display_sopn_info %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -97,8 +97,11 @@
                     {% endif %}
                 </p>
 
-
-
+                {% if object.display_as_party_list %}
+                    {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+                {% else %}
+                    {% include "elections/includes/_people_list.html" with people=object.people %}
+                {% endif %}
 
                 {% if postelection.should_display_sopn_info %}
                     <p>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -99,8 +99,13 @@
 
                 {% if not postelection.contested %}
                     <div>
-                        This election isn't contested. That means that there are the same number of candidates nominated
-                        as there are seats up for election, so they all get positions without an election taking place.
+                        <p><b>Uncontested Election</b></p>
+
+                        <p>This election was uncontested because the number of candidates who stood was {% if postelection.party_ballot_count == postelection.people.count %}less than{% else %}equal to{%endif%} the number of available seats.
+                            There are {{ postelection.party_ballot_count }} seat{{ postelection.people|pluralize }} in this ward/division, and only {{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}.</p>
+
+                        <p>No votes will be cast, and the candidate{{ postelection.people|pluralize }} below ha{{ postelection.people|pluralize:"s,ve" }} been automatically declared the winner{{ postelection.people|pluralize }}.
+                            A new election to fill the unclaimed seat{{ postelection.people|pluralize }} will be held within 35 working days of the original election date.</p>
                     </div>
                 {% endif %}
 

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -97,18 +97,6 @@
                     {% endif %}
                 </p>
 
-                {% if not postelection.contested %}
-                    <div>
-                        <p><b>Uncontested Election</b></p>
-
-                        <p>This election was uncontested because the number of candidates who stood was {% if postelection.party_ballot_count == postelection.people.count %}less than{% else %}equal to{%endif%} the number of available seats.
-                            There are {{ postelection.party_ballot_count }} seat{{ postelection.people|pluralize }} in this ward/division, and only {{ postelection.people.count|apnumber }} candidate{{ postelection.people|pluralize }}.</p>
-
-                        <p>No votes will be cast, and the candidate{{ postelection.people|pluralize }} below ha{{ postelection.people|pluralize:"s,ve" }} been automatically declared the winner{{ postelection.people|pluralize }}.
-                            A new election to fill the unclaimed seat{{ postelection.people|pluralize }} will be held within 35 working days of the original election date.</p>
-                    </div>
-                {% endif %}
-
                 {% if postelection.people %}
                     {% if postelection.display_as_party_list %}
                         {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -6,14 +6,15 @@
     <div class="ds-card" id="election_{{ postelection.election.slug }}">
         <div class="ds-card-body">
 
+            <h2>
+                <span aria-hidden="true">🗳️</span>
+                {{ postelection.election.name_without_brackets }}
+            </h2>
+
+
             {% if postelection.cancelled %}
                 {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
             {% else %}
-
-                <h2>
-                    <span aria-hidden="true">🗳️</span>
-                    {{ postelection.election.name_without_brackets }}
-                </h2>
 
                 {% if not postelection.is_pcc and not postelection.is_mayoral %}
                     <h3>{% if postelection.is_london_assembly_additional %}Additional members{% else %}{{ postelection.friendly_name }}{% endif %}</h3>

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -61,9 +61,11 @@
             {% include 'referendums/includes/_list.html' with referendums=referendums %}
         {% endif %}
 
-        <p>There may also be parish, town or
-            community council elections in some areas.
-        </p>
+        {% if not ballot.election.contested and not ballot.election.ynr_sopn_link %}
+            <p>There may also be parish, town or
+                community council elections in some areas.
+            </p>
+        {% endif %}
 
         <p><a href='#where'>Where do I vote?</a></p>
 

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -23,8 +23,8 @@
                 <div class="ds-card-body">
                     <h3>Next election</h3>
                     <p>
-                        The <a href="{{ postelection.next_ballot.get_absolute_url }}">next election for {{ postelection.friendly_name
-                            }}</a> is
+                        The <a href="{{ postelection.next_ballot.get_absolute_url }}">next election for
+                            {{ postelection.friendly_name}}</a> is
                         {% if postelection.next_ballot.election.is_election_day %}
                             <strong>being held today</strong>.
                         {% else %}

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -264,15 +264,7 @@ class ElectionPostViewTests(TestCase):
         self.assertTemplateUsed(
             response, "elections/includes/_cancelled_election.html"
         )
-        self.assertContains(
-            response,
-            "Rescheduled Election",
-        )
-        self.assertContains(response, "This election will not take place")
-        self.assertContains(
-            response,
-            "A new election to fill the unclaimed seats will be held within 35 working days of the original election date.",
-        )
+        self.assertContains(response, "This election has been cancelled")
 
 
 @pytest.mark.django_db

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -348,9 +348,10 @@ class TestYNRImporterAddBallots:
             "ballot_paper_id": "local.sheffield.fulwood.2021-05-06",
             "winner_count": 1,
             "cancelled": False,
-            "candidates_locked": True,
+            "candidates_locked": False,
             "replaces": "local.sheffield.fulwood.2020-05-07",
             "last_updated": "2021-10-12T00:00:00+00:00",
+            "candidacies": [],
         }
 
     @pytest.fixture
@@ -416,7 +417,7 @@ class TestYNRImporterAddBallots:
                 "post": post,
                 "winner_count": 1,
                 "cancelled": False,
-                "locked": True,
+                "locked": False,
                 "ynr_modified": "2021-10-12T00:00:00+00:00",
             },
         )

--- a/wcivf/apps/parishes/templates/parishes/includes/_card.html
+++ b/wcivf/apps/parishes/templates/parishes/includes/_card.html
@@ -26,7 +26,8 @@
             <p><a href="{{ parish_council_election.sopn }}">View the official list of candidates (PDF).</a></p>
         {% elif parish_council_election.is_uncontested %}
             <p>
-                This election was uncontested because not enough candidates came forward to stand for it.
+                This election was uncontested because only one candidate came forward to stand for each available seat.
+                No votes will be cast, and the candidate/s below has/have been automatically declared the winner/s.
                 {% if parish_council_election.sopn %}<a href="{{ parish_council_election.sopn }}">See who was elected</a>.{% endif %}
             </p>
         {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -22,7 +22,7 @@
                         <td>{{ person_post.post.label }}: {{ person_post.election }}</td>
                         <td>{{ person_post.party_name }}</td>
                         {% if person_post.elected %}
-                            <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (elected){% else %}Vote count not available (elected){% endif %}</td>
+                            <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (elected){% else %}Elected unopposed{% endif %}</td>
                         {% else %}
                             <td>{% if person_post.votes_cast %}{{ person_post.votes_cast|intcomma }} votes (not elected){% else %}Vote count not available{% endif %}</td>
                         {% endif %}


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/931 and https://github.com/DemocracyClub/WhoCanIVoteFor/issues/884

This PR includes text and logic updates for greater clarity on uncontested, cancelled, & rescheduled elections. 

In the case of fewer candidates than seats but where number of candidates is one or more  (when no metadata in EE):
![Screen Shot 2022-01-18 at 12 24 16 PM](https://user-images.githubusercontent.com/7017118/149937099-7fdee8cd-0671-4c77-af90-000b751780d4.png)

When there are equal candidates to seats  (and no metadata in EE) 
![Screen Shot 2022-01-17 at 12 07 50 PM](https://user-images.githubusercontent.com/7017118/149767056-1d34f82a-8757-47b1-bf2c-a1b4a375ae3e.png)

If metadata exists, it overrides the above text:
<img width="954" alt="Screen Shot 2022-01-20 at 11 28 18 AM" src="https://user-images.githubusercontent.com/7017118/150330459-3919f54e-27b1-4971-881f-e943f049fec3.png">

If no one shows up:
<img width="960" alt="Screen Shot 2022-01-20 at 11 27 00 AM" src="https://user-images.githubusercontent.com/7017118/150330234-dfd764da-1ba2-4520-afb9-d19e06270fc2.png">

Cancelled for any other reasons
![Screen Shot 2022-01-18 at 12 27 11 PM](https://user-images.githubusercontent.com/7017118/149937317-e8ddf31c-2196-43ef-bd12-e8721801df49.png)
