### PR TITLE
Add decorator to help debug lambda import timeouts

### DIFF
--- a/wcivf/apps/elections/management/commands/import_ballots.py
+++ b/wcivf/apps/elections/management/commands/import_ballots.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from elections.import_helpers import YNRBallotImporter, EEHelper
 from elections.models import Election
+from wcivf.apps.elections.import_helpers import time_function_length
 
 
 class Command(BaseCommand):
@@ -34,6 +35,7 @@ class Command(BaseCommand):
             help="Only import ballots updated since the last known update",
         )
 
+    @time_function_length
     def populate_any_non_by_elections_field(self):
         qs = Election.objects.all().prefetch_related("postelection_set")
         for election in qs:
@@ -45,6 +47,7 @@ class Command(BaseCommand):
             election.any_non_by_elections = any_non_by_elections
             election.save()
 
+    @time_function_length
     def delete_deleted_elections(self):
         """
         Deletes elections that are marked as deleted in Every Election and any

--- a/wcivf/apps/people/management/commands/import_people.py
+++ b/wcivf/apps/people/management/commands/import_people.py
@@ -17,6 +17,7 @@ from core.helpers import show_data_on_error
 from elections.import_helpers import YNRBallotImporter
 from people.models import Person
 from elections.models import PostElection
+from wcivf.apps.elections.import_helpers import time_function_length
 from wcivf.apps.people.import_helpers import YNRPersonImporter
 
 
@@ -132,6 +133,7 @@ class Command(BaseCommand):
             self.save_page(next_page, page)
             next_page = results.get("next")
 
+    @time_function_length
     @transaction.atomic
     def add_people(self, results):
         for person in results["results"]:
@@ -205,6 +207,7 @@ class Command(BaseCommand):
     def import_ballots_for_date(self, date):
         self.ballot_importer.do_import(params={"election_date": date})
 
+    @time_function_length
     def delete_merged_people(self):
         url = (
             settings.YNR_BASE
@@ -221,6 +224,7 @@ class Command(BaseCommand):
             url = page.get("next")
         Person.objects.filter(ynr_id__in=merged_ids).delete()
 
+    @time_function_length
     def delete_orphaned_people(self):
         """
         Delete all people without candidacies


### PR DESCRIPTION
Still trying to get to the bottom of why in the dev/stage environments the lambda import jobs are often timing out. I still think there is likely to be some operations in functions that are blocking others from running/completing. So this adds some extra debug logging to help find out which methods in the `import_people` and `import_ballots` import runs are taking the longest, or perhaps identify where the importers often fail to complete