### PR TITLE
Bugfix/any non by elections

### DIFF
--- a/wcivf/apps/elections/tests/test_management_commands.py
+++ b/wcivf/apps/elections/tests/test_management_commands.py
@@ -1,0 +1,58 @@
+import pytest
+from elections.tests.factories import (
+    PostElectionFactory,
+    ElectionFactoryLazySlug,
+)
+from elections.management.commands.import_ballots import Command
+
+
+class TestPopulateAnyNonByElections:
+    @pytest.mark.django_db
+    def test_any_non_by_elections_true_with_mix(self):
+        """
+        When an election contains any non by-election ballots then
+        the Election.any_non_by_elections is True
+        """
+        election = ElectionFactoryLazySlug(any_non_by_elections=False)
+        PostElectionFactory.create_batch(
+            size=20,
+            election=election,
+        )
+        PostElectionFactory(
+            ballot_paper_id="foo.local.by.2021-05-06", election=election
+        )
+        cmd = Command()
+        cmd.populate_any_non_by_elections_field()
+        election.refresh_from_db()
+        assert election.any_non_by_elections is True
+
+    @pytest.mark.django_db
+    def test_any_non_by_elections_false(self):
+        """
+        When an election contains only by-election ballots then
+        the Election.any_non_by_elections is False
+        """
+        election = ElectionFactoryLazySlug(any_non_by_elections=False)
+        PostElectionFactory(
+            ballot_paper_id="foo.local.by.2021-05-06", election=election
+        )
+        cmd = Command()
+        cmd.populate_any_non_by_elections_field()
+        election.refresh_from_db()
+        assert election.any_non_by_elections is False
+
+    @pytest.mark.django_db
+    def test_any_non_by_elections_true_without_by_election(self):
+        """
+        When an election contains only non by-election ballots then
+        the Election.any_non_by_elections is True
+        """
+        election = ElectionFactoryLazySlug(any_non_by_elections=False)
+        PostElectionFactory.create_batch(
+            size=20,
+            election=election,
+        )
+        cmd = Command()
+        cmd.populate_any_non_by_elections_field()
+        election.refresh_from_db()
+        assert election.any_non_by_elections is True


### PR DESCRIPTION
Add regression test for populate_any_non_by_elections_field

Improve import ballots performance
- Use a QS update command query rather than looping through objects
when marking the any_non_by_elections field
- Attempt to help reduce number of timeouts running the importer in
lambda as logging shows this action was taking a long time
