### PR TITLE
Use correct context var name in template

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -99,10 +99,10 @@
                 </p>
 
                 {% if postelection.people %}
-                    {% if object.display_as_party_list %}
-                        {% include "elections/includes/_people_list_with_lists.html" with people=object.people %}
+                    {% if postelection.display_as_party_list %}
+                        {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
                     {% else %}
-                        {% include "elections/includes/_people_list.html" with people=object.people %}
+                        {% include "elections/includes/_people_list.html" with people=postelection.people %}
                     {% endif %}
                 {% endif %}
 


### PR DESCRIPTION
Fixes bug where candidates not listed on PostcodeView

Currently candidates not displayed https://whocanivotefor.co.uk/elections/SE24%209LA/

Screenshot after change:
(thumbnails missing as I dont have them locally)
![Screenshot 2022-02-01 at 17 28 48](https://user-images.githubusercontent.com/15347726/152019320-9722f152-af53-4198-aaf7-b0f3f638d653.png)

