### PR TITLE
Set mailing list backend via a setting

### DIFF
--- a/local.example
+++ b/local.example
@@ -27,3 +27,5 @@ INTERNAL_IPS = ['127.0.0.1']
 SECRET_KEY = "not_for_production"
 
 DEBUG = True
+
+EMAIL_SIGNUP_BACKEND = "local_db"

--- a/wcivf/apps/mailing_list/urls.py
+++ b/wcivf/apps/mailing_list/urls.py
@@ -4,6 +4,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from dc_signup_form.forms import MailingListSignupForm
 from dc_signup_form.views import SignupFormView
+from django.conf import settings
 
 app_name = "mailing_list"
 
@@ -14,7 +15,7 @@ urlpatterns = [
             SignupFormView.as_view(
                 template_name="base.html",
                 form_class=MailingListSignupForm,
-                backend="local_db",
+                backend=settings.EMAIL_SIGNUP_BACKEND,
             )
         ),
         name="mailing_list_signup_view",

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -203,6 +203,7 @@ EMAIL_SIGNUP_ENDPOINT = (
     "https://democracyclub.org.uk/mailing_list/api_signup/v1/"
 )
 EMAIL_SIGNUP_API_KEY = os.environ.get("EMAIL_SIGNUP_API_KEY", "")
+EMAIL_SIGNUP_BACKEND = "remote_db"
 
 # DC Base Theme settings
 SITE_TITLE = "Who Can I Vote For?"


### PR DESCRIPTION
- Default to remote_db so that signup submissions are sent to the remote database rather than DB in ec2 instance. Attempt to fix
https://sentry.io/organizations/democracy-club-gp/issues/3011905897/?project=1426221&query=is%3Aunresolved
- Allows setting to be set in local.py settings file for local testing