### PR TITLE
Fixes bug where hustings were not displayed on candidate page

### DIFF
--- a/wcivf/apps/hustings/templates/hustings/includes/_person.html
+++ b/wcivf/apps/hustings/templates/hustings/includes/_person.html
@@ -2,6 +2,6 @@
     <div class="ds-card-body">
         <h3>Election events</h3>
         <p>You can meet candidates and question them at online events (often known as 'hustings'). Here are some events where {{ person.name }} may be appearing:</p>
-        {% include "hustings/includes/_list.html" with hustings=object.postelection.husting_set.displayable %}
+        {% include "hustings/includes/_list.html" with hustings=hustings %}
     </div>
 </section>

--- a/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_hustings_card.html
@@ -1,3 +1,6 @@
-{% if object.featured_candidacy.post_election.husting_set.displayable and object.current_or_future_candidacies %}
-    {% include "hustings/includes/_person.html" with hustings=object.postelection.husting_set.displayable person=object %}
-{% endif %}
+
+{% with hustings=object.featured_candidacy.post_election.husting_set.displayable %}
+    {% if hustings and object.current_or_future_candidacies %}
+        {% include "hustings/includes/_person.html" with hustings=hustings person=object %}
+    {% endif %}
+{% endwith %}


### PR DESCRIPTION
Hustings will appear on a candidate profile page as below:
![Screenshot 2022-02-24 at 13 03 56](https://user-images.githubusercontent.com/15347726/155529487-912c5071-509c-4a30-a6c8-2dc36942570e.png)

