### PR TITLE
Add leaflets and hustsings to API

### DIFF
--- a/wcivf/apps/api/serializers.py
+++ b/wcivf/apps/api/serializers.py
@@ -30,8 +30,7 @@ class PersonSerializer(serializers.ModelSerializer):
     leaflets = serializers.SerializerMethodField(allow_null=True)
 
     def get_leaflets(self, obj: Person):
-        # TODO: prefetch this somehow
-        leaflets = obj.leaflet_set.latest_four()
+        leaflets = obj.ordered_leaflets[:4]
         if leaflets:
             return LeafletSerializer(leaflets, many=True, read_only=True).data
 

--- a/wcivf/apps/api/serializers.py
+++ b/wcivf/apps/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from elections.models import VotingSystem
+from leaflets.api.serializers import LeafletSerializer
 from people.models import Person, PersonPost
 from parties.models import Party
 
@@ -17,7 +18,22 @@ class PersonSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Person
-        fields = ("ynr_id", "name", "absolute_url", "email", "photo_url")
+        fields = (
+            "ynr_id",
+            "name",
+            "absolute_url",
+            "email",
+            "photo_url",
+            "leaflets",
+        )
+
+    leaflets = serializers.SerializerMethodField(allow_null=True)
+
+    def get_leaflets(self, obj: Person):
+        # TODO: prefetch this somehow
+        leaflets = obj.leaflet_set.latest_four()
+        if leaflets:
+            return LeafletSerializer(leaflets, many=True, read_only=True).data
 
 
 class PartySerializer(serializers.HyperlinkedModelSerializer):

--- a/wcivf/apps/api/tests/test_api.py
+++ b/wcivf/apps/api/tests/test_api.py
@@ -81,6 +81,7 @@ class TestAPISearchViews(APITestCase):
                             "name": "Candidate 0",
                             "email": None,
                             "photo_url": None,
+                            "leaflets": None,
                         },
                     }
                 ],
@@ -90,14 +91,14 @@ class TestAPISearchViews(APITestCase):
     @vcr.use_cassette("fixtures/vcr_cassettes/test_postcode_view.yaml")
     def test_candidates_for_postcode_view(self):
         url = reverse("api:candidates-for-postcode-list")
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             req = self.client.get("{}?postcode=EC1A4EU".format(url))
         assert req.status_code == 200
         assert req.json() == self.expected_response
 
     def test_candidates_for_ballots(self):
         url = reverse("api:candidates-for-ballots-list")
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             req = self.client.get(
                 "{}?ballot_ids=parl.cities-of-london-and-westminster.2017-06-08".format(
                     url

--- a/wcivf/apps/api/tests/test_api.py
+++ b/wcivf/apps/api/tests/test_api.py
@@ -68,6 +68,7 @@ class TestAPISearchViews(APITestCase):
                 "organisation_type": "local-authority",
                 "voting_system": {"name": "", "slug": ""},
                 "ballot_locked": False,
+                "hustings": None,
                 "candidates": [
                     {
                         "list_position": None,
@@ -91,14 +92,14 @@ class TestAPISearchViews(APITestCase):
     @vcr.use_cassette("fixtures/vcr_cassettes/test_postcode_view.yaml")
     def test_candidates_for_postcode_view(self):
         url = reverse("api:candidates-for-postcode-list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             req = self.client.get("{}?postcode=EC1A4EU".format(url))
         assert req.status_code == 200
         assert req.json() == self.expected_response
 
     def test_candidates_for_ballots(self):
         url = reverse("api:candidates-for-ballots-list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             req = self.client.get(
                 "{}?ballot_ids=parl.cities-of-london-and-westminster.2017-06-08".format(
                     url

--- a/wcivf/apps/api/views.py
+++ b/wcivf/apps/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.views import APIView
 from api import serializers
 from api.serializers import VotingSystemSerializer
 from core.helpers import clean_postcode
+from hustings.api.serializers import HustingSerializer
 
 from people.models import Person
 from elections.views import mixins
@@ -45,6 +46,15 @@ class BaseCandidatesAndElectionsViewSet(
     @abc.abstractmethod
     def get_ballots(self, request):
         pass
+
+    def add_hustings(self, postelection: PostElection):
+        hustings = None
+        hustings_qs = postelection.husting_set.all()
+        if hustings_qs:
+            hustings = HustingSerializer(
+                hustings_qs, many=True, read_only=True
+            ).data
+        return hustings
 
     def list(self, request, *args, **kwargs):
         results = []
@@ -86,6 +96,7 @@ class BaseCandidatesAndElectionsViewSet(
                 ).data,
                 "seats_contested": postelection.winner_count,
                 "organisation_type": postelection.post.organization_type,
+                "hustings": self.add_hustings(postelection),
             }
             if postelection.replaced_by:
                 election[

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -151,9 +151,7 @@
             {% endif %}
 
 
-            {% if postelection.husting_set.displayable %}
-                {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
-            {% endif %}
+
 
             {% if postelection.ballotnewsarticle_set.exists %}
                 {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}
@@ -171,4 +169,7 @@
             {% include "elections/includes/_ld_election.html" with election=postelection %}
         </div>
     </div>
+    {% if postelection.husting_set.displayable %}
+        {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
+    {% endif %}
 </div>

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -110,10 +110,9 @@ class PostelectionsToPeopleMixin(object):
         people_for_post = people_for_post.select_related(
             "post", "election", "person", "party"
         )
-        if not compact:
 
+        if not compact:
             people_for_post = people_for_post.prefetch_related(
-                # "person__leaflet_set",
                 "person__pledges"
             )
         cache.set(key, people_for_post)

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -76,8 +76,7 @@ class PostcodeToPostsMixin(object):
         pes = pes.select_related("election__voting_system")
         pes = pes.select_related("referendum")
 
-        if not compact:
-            pes = pes.prefetch_related("husting_set")
+        pes = pes.prefetch_related("husting_set")
         pes = pes.order_by(
             "past_date", "election__election_date", "-election__election_weight"
         )

--- a/wcivf/apps/hustings/api/serializers.py
+++ b/wcivf/apps/hustings/api/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from hustings.models import Husting
+
+
+class HustingSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Husting
+        fields = (
+            "title",
+            "url",
+            "starts",
+            "ends",
+            "location",
+            "postevent_url",
+        )

--- a/wcivf/apps/leaflets/api/serializers.py
+++ b/wcivf/apps/leaflets/api/serializers.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+from leaflets.models import Leaflet
+
+
+class LeafletSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Leaflet
+        fields = ("leaflet_id", "thumb_url", "leaflet_url")
+
+    leaflet_url = serializers.SerializerMethodField()
+
+    def get_leaflet_url(self, obj: Leaflet):
+        return f"https://electionleaflets.org/leaflets/{obj.leaflet_id}/"


### PR DESCRIPTION
TODO on this: optimize the leaflets query. We're currently making one query per person on the returned. We want to only return the latest 4 leaflets for a person, but I couldn't figure out a good way to do this. 

At the moment the top priority is to get this deployed so people can use it, and we can do a later PR to optimise the queries.