### PR TITLE
Add previous party affiliation to templates

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -240,12 +240,12 @@ msgstr "(Wedi marw)"
 msgid "Elected"
 msgstr "Etholwyd"
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:31
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:30
 #, python-format
 msgid "%(votes_cast)s votes"
 msgstr "%(votes_cast)s pleidlais"
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:39
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:38
 #, python-format
 msgid "Photo of %(person_name)s"
 msgstr "Llun o %(person_name)s"
@@ -461,6 +461,19 @@ msgstr ""
 #: wcivf/templates/home.html:23
 msgid "Find your candidates"
 msgstr "Dod o hyd i'ch ymgeiswyr"
+
+#: wcivf/apps/elections/templates/elections/includes/_previous_party_affiliations.html:7
+#, python-format
+msgid ""
+"%(person_name)s has declared their affiliation with the following party in "
+"the past 12 months:"
+msgid_plural ""
+"%(person_name)s has declared their affiliation with the following parties in "
+"the past 12 months:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
 #: wcivf/apps/elections/templates/elections/includes/_registration_details.html:9
 msgid "Register to vote"
@@ -1257,7 +1270,7 @@ msgstr ""
 msgid "is %(a_or_an)s %(party_name)s candidate in the following elections:"
 msgstr "yw %(a_or_an)s ymgeisydd y %(party_name)s yn yr etholiadau canlynol:"
 
-#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:22
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:23
 #, python-format
 msgid "%(election)s for"
 msgstr "%(election)s ar gyfer"
@@ -1271,7 +1284,7 @@ msgstr "%(num_votes)s pleidlais"
 msgid "(elected)"
 msgstr "(etholwyd)"
 
-#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:46
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:51
 #, python-format
 msgid "profile photo of %(person)s"
 msgstr "Llun proffil %(person)s"
@@ -1456,26 +1469,26 @@ msgstr "Canlyniadau"
 msgid "%(message)s %(message)s %(message)s"
 msgstr "%(message)s %(message)s %(message)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:25
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
 #, python-format
 msgid "%(post_label)s: %(election)s"
 msgstr "%(post_label)s: %(election)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:31
 #, python-format
 msgid "%(num_votes)s votes (elected)"
 msgstr "%(num_votes)s pleidlais (etholwyd)"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:31
 msgid "Elected unopposed"
 msgstr "Etholwyd yn ddiwrthwynebiad"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:33
 #, python-format
 msgid "%(num_votes)s votes (not elected)"
 msgstr "%(num_votes)s pleidlais (heb ei ethol)"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:33
 msgid "Vote count not available"
 msgstr "Nid yw'r cyfrif pleidleisiau ar gael"
 
@@ -1843,3 +1856,14 @@ msgstr "Etholiadau i ddod"
 #: wcivf/templates/mailing_list.html:8
 msgid "Join our mailing list"
 msgstr "Ymunwch â'n rhestr bostio"
+msgstr ""
+
+#, fuzzy
+#~| msgid "All Elections"
+#~ msgid "Previous Elections"
+#~ msgstr "Pob Etholiad"
+
+#, fuzzy
+#~| msgid "All Elections"
+#~ msgid "Election"
+#~ msgstr "Pob Etholiad"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-21 08:23+0000\n"
+"POT-Creation-Date: 2022-04-21 16:29+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -181,6 +181,7 @@ msgid "Home"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:9
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:9
 msgid "Elections"
 msgstr ""
 
@@ -212,12 +213,12 @@ msgstr ""
 msgid "Elected"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:31
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:30
 #, python-format
 msgid "%(votes_cast)s votes"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:39
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:38
 #, python-format
 msgid "Photo of %(person_name)s"
 msgstr ""
@@ -246,7 +247,6 @@ msgid "Advance voting station opening times"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:36
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:12
 msgid "Date"
 msgstr ""
 
@@ -401,6 +401,17 @@ msgstr ""
 #: wcivf/templates/home.html:23
 msgid "Find your candidates"
 msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_previous_party_affiliations.html:7
+#, python-format
+msgid ""
+"%(person_name)s has declared their affiliation with the following party in "
+"the past 12 months:"
+msgid_plural ""
+"%(person_name)s has declared their affiliation with the following parties in "
+"the past 12 months:"
+msgstr[0] ""
+msgstr[1] ""
 
 #: wcivf/apps/elections/templates/elections/includes/_registration_details.html:9
 msgid "Register to vote"
@@ -1102,7 +1113,7 @@ msgstr ""
 msgid "is %(a_or_an)s %(party_name)s candidate in the following elections:"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:22
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:23
 #, python-format
 msgid "%(election)s for"
 msgstr ""
@@ -1116,7 +1127,7 @@ msgstr ""
 msgid "(elected)"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:46
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:51
 #, python-format
 msgid "profile photo of %(person)s"
 msgstr ""
@@ -1250,47 +1261,31 @@ msgstr ""
 msgid "their speeches, voting history and more"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:9
-msgid "Previous Elections"
-msgstr ""
-
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:13
-msgid "Election"
-msgstr ""
-
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:14
-msgid "Party"
-msgstr ""
-
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:15
-msgid "Results"
-msgstr ""
-
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:19
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:22
 #, python-format
 msgid "%(message)s %(message)s %(message)s"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:25
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
 #, python-format
 msgid "%(post_label)s: %(election)s"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:31
 #, python-format
 msgid "%(num_votes)s votes (elected)"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:28
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:31
 msgid "Elected unopposed"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:33
 #, python-format
 msgid "%(num_votes)s votes (not elected)"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:33
 msgid "Vote count not available"
 msgstr ""
 

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -25,8 +25,7 @@
         {% endif %}
 
         {% if not person_post.list_position or not postelection.display_as_party_list %}
-            <p>
-                {{ person_post.party_name }}
+            <p>{{ person_post.party_name }}
                 {% if person_post.votes_cast %}
                     <br><strong>{% blocktrans with votes_cast=person_post.votes_cast|intcomma%}{{ votes_cast }} votes{% endblocktrans %}</strong>
                 {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_previous_party_affiliations.html
+++ b/wcivf/apps/elections/templates/elections/includes/_previous_party_affiliations.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% load static %}
+{% load humanize %}
+
+<p>
+    {% for candidacy in candidacies %}
+        {% blocktrans trimmed with person_name=person.name count counter=candidacy.previous_party_affiliations.count %}
+            {{ person_name }} has declared their affiliation with the following party in the past 12 months:
+        {% plural %}
+            {{ person_name}} has declared their affiliation with the following parties in the past 12 months:
+        {% endblocktrans %}
+        {% for previous_party in candidacy.previous_party_affiliations.all %}
+            {{ previous_party.party_name }}{% if forloop and not forloop.last %}, {% endif %}
+        {% endfor %}
+    {% endfor %}
+</p>

--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -19,25 +19,30 @@
 
             {% for candidacy in object.current_or_future_candidacies %}
                 <ul>
-                    <li>{% blocktrans with election=candidacy.election.name %}{{ election }} for{% endblocktrans %}
+                    <li>
+                        {% blocktrans with election=candidacy.election.name %}{{ election }} for{% endblocktrans %}
                         <a href="{{ candidacy.post_election.get_absolute_url }}">
                             {{ candidacy.post_election.friendly_name }}
                         </a>
+                        {% if candidacy.votes_cast %}
+                            {% blocktrans trimmed with num_votes=candidacy.votes_cast|intcomma %}
+                                {{ num_votes }} votes
+                            {% endblocktrans %}
+                        {% endif %}
+                        {% if candidacy.elected %}
+                            {% trans "(elected)" %}
+                        {% endif %}
                     </li>
-                    {% if candidacy.votes_cast %}
-                        {% blocktrans trimmed with num_votes=candidacy.votes_cast|intcomma %}
-                            {{ num_votes }} votes
-                        {% endblocktrans %}
-                    {% endif %}
-                    {% if candidacy.elected %}
-                        {% trans "(elected)" %}
-                    {% endif %}
                 </ul>
+
             {% endfor %}
         {% else %}
             <p>
                 {{ object.intro|safe }}
             </p>
+        {% endif %}
+        {% if object.previous_party_count %}
+            {% include "elections/includes/_previous_party_affiliations.html" with person=object candidacies=object.current_or_future_candidacies %}
         {% endif %}
     </div>
 

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -1,21 +1,24 @@
 {% load humanize %}
 {% load i18n %}
 
-{% if object.past_not_current_candidacies %}
+{% if object.personpost_set.exists %}
     <section class="ds-card">
         <div class="ds-table">
             <table>
                 <caption style="font-style: normal;">
-                    <h3 class="ds-padded">{% trans "Previous Elections" %}</h3>
+                    <h3 class="ds-padded">{{ object.name }}'s {% trans "Elections" %}</h3>
                 </caption>
                 <tr>
-                    <th>{% trans "Date" %}</th>
-                    <th>{% trans "Election" %}</th>
-                    <th>{% trans "Party" %}</th>
-                    <th>{% trans "Results" %}</th>
+                    <th>Date</th>
+                    <th>Election</th>
+                    <th>Party</th>
+                    <th>Results</th>
+                    {% if object.previous_party_count %}
+                        <th>Other party affiliations in the past 12 months</th>
+                    {% endif %}
                 </tr>
                 <tr>
-                    {% for person_post in object.past_not_current_candidacies %}
+                    {% for person_post in object.personpost_set.all %}
                         {% blocktrans trimmed with message=person_post.post_election.short_cancelled_message_html %}
                             {{ message }}
                             {{ message }}
@@ -29,8 +32,16 @@
                         {% else %}
                             <td>{% if person_post.votes_cast %}{% blocktrans with num_votes=person_post.votes_cast|intcomma %}{{ num_votes }} votes (not elected){% endblocktrans %}{% else %}{% trans "Vote count not available" %}{% endif %}</td>
                         {% endif %}
+                        {% if object.previous_party_count %}
+                            <td>
+                                {% for previous_party_affiliation in person_post.previous_party_affiliations.all %}
+                                    {{ previous_party_affiliation.party_name }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            </td>
+                        {% endif %}
                         </tr>
                     {% endfor %}
+
                 </table>
             </div>
         </section>


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1077 and closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1144

Display previous party affiliations relating to all elections on the (revised) elections table
<img width="961" alt="Screen Shot 2022-04-21 at 10 06 33 AM" src="https://user-images.githubusercontent.com/7017118/164420951-a8aac42d-781e-4abf-b0fd-b1a6c4cf93a2.png">


Display previous party affiliations in the person intro card 1 vs 2+ parties
![Screen Shot 2022-04-14 at 7 08 29 PM](https://user-images.githubusercontent.com/7017118/163464445-f52b5b08-02d9-499e-8979-ec202c33787f.png)
![Screen Shot 2022-04-14 at 7 20 32 PM](https://user-images.githubusercontent.com/7017118/163464450-8d13d021-634e-493f-99ff-04e90ba2215a.png)

