### PR TITLE
Center site title in footer

### DIFF
--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -176,12 +176,14 @@
                                 <img src="{% static "images/logo_icon.svg" %}" alt="" />
                                 <span class="ds-text-left">
                                     {% trans "democracy" %}<br>{% trans "club" %}
-                                    {% get_current_language as LANGUAGE_CODE %}
-                                    {% if LANGUAGE_CODE != "en" %}
-                                        <em lang="cy">{% language "cy" %}{% trans "Who Can I Vote For?" %}{% endlanguage %}</em>
-                                    {% endif %}
                                 </span>
                             </a>
+                            <p>
+                                {% get_current_language as LANGUAGE_CODE %}
+                                {% if LANGUAGE_CODE != "en" %}
+                                    <em lang="cy">{% language "cy" %}{% trans "Who Can I Vote For?" %}{% endlanguage %}</em>
+                                {% endif %}
+                            </p>
                             {% now "Y" as current_year %}
                             <p>{% blocktrans %}Copyright &copy; {{ current_year }}{% endblocktrans %}</p>
                             <p>{% trans "Democracy Club Community Interest Company" %}</p>


### PR DESCRIPTION
After the change to max-width in the `.ds-party p` in the design system, the site title was still throwing the footer off center. This work fixes that by moving the site title out of the `<span>` and into its own `<p>` block. Further centering relies on https://github.com/DemocracyClub/design-system/pull/56 and https://github.com/DemocracyClub/design-system/issues/57

![Screen Shot 2022-04-07 at 9 35 10 AM](https://user-images.githubusercontent.com/7017118/162158423-9e400398-6b7d-40b5-b2cb-f027e0edbb74.png)
