### PR TITLE
Only add token if not None

### DIFF
--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -139,11 +139,13 @@ class PollingStationInfoMixin(object):
 
         info = {}
         base_url = settings.WDIV_BASE + settings.WDIV_API
-        url = "{}/postcode/{}.json?auth_token={}".format(
+        url = "{}/postcode/{}.json".format(
             base_url,
             postcode,
-            getattr(settings, "WDIV_API_KEY", "DCINTERNAL-WHO"),
         )
+        token = getattr(settings, "WDIV_API_KEY", "DCINTERNAL-WHO")
+        if token:
+            url = f"{url}?auth_token={token}"
         try:
             req = requests.get(url)
         except:


### PR DESCRIPTION
Previously the default was to return None, and then we were passing the
invalid API key None to the API. The API works with no API key passed
(rate limited), so it's better to just not pass a key