### PR TITLE
Retry compilemssages on deploy

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -82,6 +82,9 @@ hooks:
     - location: deployscripts/collectstatic.sh
       timeout: 300
       runas: wcivf
+    - location: deployscripts/compilemessages.sh
+      timeout: 300
+      runas: wcivf
 # During the ApplicationStart deployment lifecycle event, run the commands
 #   in the script specified in "location".
   ApplicationStart:

--- a/deployscripts/compilemessages.sh
+++ b/deployscripts/compilemessages.sh
@@ -2,4 +2,5 @@
 set -xeE
 
 source /var/www/wcivf/env/bin/activate
-python /var/www/wcivf/code/manage.py compilemessages
+cd /var/www/wcivf/code/
+python manage.py compilemessages


### PR DESCRIPTION
- Attempt to run compilemessages from project directory so that it
does not include files from other dirs e.g. /var/, /opt/