### PR TITLE
Add timeouts to ballots and polling station requests

### DIFF
--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -42,7 +42,7 @@ class PostcodeToPostsMixin(object):
             url = "{0}/api/elections?postcode={1}&current=1".format(
                 settings.EE_BASE, postcode
             )
-            req = requests.get(url)
+            req = requests.get(url, timeout=30.0)
 
             # Don't cache bad postcodes
             from ..models import InvalidPostcodeError
@@ -153,7 +153,7 @@ class PollingStationInfoMixin(object):
         if token:
             url = f"{url}?auth_token={token}"
         try:
-            req = requests.get(url)
+            req = requests.get(url, timeout=30.0)
         except:
             return info
         if req.status_code != 200:


### PR DESCRIPTION
Working theory that sometimes requests to EE are taking too long
which causes the gunicorn workers to die. If this happens to too many
workers it may be killing the instance, leading to site downtime. By
default when using requests there is no timeout, so this adds them
to the calls to EE and WDIV.

The hope is that this still gives 'good' requests time to complete
but kills off 'bad' ones before it kills the gunicorn workers.