### PR TITLE
Add gevent to production requirements

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-gunicorn==20.1.0
+gunicorn[gevent]==20.1.0
 ec2_tag_conditional==0.1.2


### PR DESCRIPTION
Allows us to run gunicorn workers with gevent. This is a change to try
to help with traffic spikes and requests to EE/WDIV timing out