### PR TITLE
Display cancelled election title from metadata

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -5,7 +5,7 @@
 
 {% comment %}Case 1: Cancelled election and Metadata is set in EE {% endcomment %}
 {% if object.metadata.cancelled_election.title %}
-    <h4>{{ title }}</h4>
+    <h4>{{ object.metadata.cancelled_election.title }}</h4>
 {% else %}
     {% if not object.contested %}
         {% comment %} Case 2: Election cancelled, uncontested, number of candidates equal seats, no metadata{% endcomment %}


### PR DESCRIPTION
Fixes bug displaying cancelled election title from metadata

<img width="1552" alt="Screenshot 2022-04-27 at 16 55 23" src="https://user-images.githubusercontent.com/15347726/165560568-3222e25a-6fa2-442d-8f96-76e5aff00dab.png">
