### PR TITLE
Hide all upcoming elections

### DIFF
--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -79,9 +79,10 @@ class HomePageView(PostcodeFormView):
             PostElection.objects.filter(
                 election__election_date__gte=today,
                 election__election_date__lte=cut_off_date,
+                # Temporarily removed following May elections #
+                # election__any_non_by_elections=False,
             )
             .exclude(election__election_date=may_election_day_this_year())
-            .exclude(ballot_paper_id__contains=".by.")
             .select_related("election", "post")
             .order_by("election__election_date")
         )

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -85,6 +85,7 @@ class HomePageView(PostcodeFormView):
             .exclude(election__election_date=may_election_day_this_year())
             .select_related("election", "post")
             .order_by("election__election_date")
+            .none()
         )
 
         polls_open = timezone.make_aware(


### PR DESCRIPTION
Reverts previous attempt to hide upcoming elections, which still resulted in Alderman elections being displayed.
Then in separate commit uses `none()` to return an empty query set. This can then be reverted after May 5th to return to our usual display.