### PR TITLE
Move logger DB migrate to code deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,3 @@ lambda-migrate:  ## Invoke lambda to migrate the database
 	--function-name WCIVFControllerFunction \
 	--payload '{ "command": "migrate" }' \
 	/dev/stdout
-	aws lambda invoke \
-	--function-name WCIVFControllerFunction \
-	--payload '{ "command": "migrate", "args": ["--database=logger"] }' \
-	/dev/stdout

--- a/appspec.yml
+++ b/appspec.yml
@@ -79,6 +79,9 @@ hooks:
     - location: deployscripts/write_envfile.sh
       timeout: 300
       runas: wcivf
+    - location: deployscripts/migrate_logger.sh
+      timeout: 300
+      runas: wcivf
     - location: deployscripts/collectstatic.sh
       timeout: 300
       runas: wcivf

--- a/deployscripts/migrate.sh
+++ b/deployscripts/migrate.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -xeE
-
-# could drop db and run DB replication script?
-source /var/www/wcivf/env/bin/activate
-python /var/www/wcivf/code/manage.py migrate --noinput

--- a/deployscripts/migrate_logger.sh
+++ b/deployscripts/migrate_logger.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -xeE
+
+source /var/www/wcivf/env/bin/activate
+python /var/www/wcivf/code/manage.py migrate --database=logger --noinput


### PR DESCRIPTION
    Previously logger DB was migrated via lambda, which meant that the
    application code was behind the database schema, and could lead to
    errors e.g. when a non-null field was added.
    This moves the migrate to the final stages of a deployment.
    I have also changed the dev/stage environmens to point at the dev RDS
    instance. This change was made by amending the variables set in
    parameter store.
