### PR TITLE
Pad last updated timestamp by an hour in import_people

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -205,7 +205,10 @@ class YNRBallotImporter:
     @time_function_length
     def get_last_updated(self):
         try:
-            return PostElection.objects.last_updated_in_ynr().ynr_modified
+            last_updated = (
+                PostElection.objects.last_updated_in_ynr().ynr_modified
+            )
+            return last_updated - timezone.timedelta(hours=1)
         except PostElection.DoesNotExist:
             # default before changes were added to YNR
             return timezone.datetime(2021, 10, 27, tzinfo=timezone.utc)


### PR DESCRIPTION
There are some people updates in YNR slipping that are failing to
update in WCIVF. From checking the logs I am able to see that the
timestamps being used in some import runs are causing this, however
I cant figure out what is causing this. As an example:
- In YNR person 73150 was updated at 2022-03-17T08:11:38.691627
- However from checking cloudwatch logs I can see that the next
import_people run uses timestamp 2022-03-17+08:14:45.891015+00:00.
- Therefore the changes made are missed by the importer.

I cant see what is causing this timestamp to be used, however for now
I am padding the timestamp by minus one hour. This will mean that for
an hour people are repeatedly imported, however hopefully also means
that updates are not missed.