### PR TITLE
Add a note to start the postgresql server

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,10 @@ By default WhoCanIVoteFor uses PostgreSQL with the PostGIS extension. To set thi
 
     sudo apt-get install postgresql postgis
 
+Start the PostgreSQL server with:
+
+    /etc/init.d/postgresql start
+
 Then create, for example, a `wcivf` user:
 
     sudo -u postgres createuser -P wcivf


### PR DESCRIPTION
I just followed `INSTALL.md` and this step is necessary before creating a user. I thought it might be helpful to call it out explicitly.