### PR TITLE
Fix use of 's when person's name ends with s

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -353,6 +353,17 @@ class Person(models.Model):
         intro = intro.strip()
         return " ".join(intro.split())
 
+    @property
+    def name_endswith_s(self):
+        """
+        If the person's name ends with s, return True, else return False,
+        for the purpose of determining possessive noun formatting
+        """
+        if self.name.endswith("s"):
+            return True
+        else:
+            return False
+
 
 class AssociatedCompany(models.Model):
     person = models.ForeignKey(Person, on_delete=models.CASCADE)

--- a/wcivf/apps/people/templates/people/email_person.html
+++ b/wcivf/apps/people/templates/people/email_person.html
@@ -28,8 +28,16 @@
                 {% include "people/_person_email_form.html" %}
             {% else %}
                 <p>
-                    {% blocktrans trimmed with person_name=object.name edit_profile_url=object.get_ynr_url %}
-                        We don't know {{ person_name }}'s email address.
+                    {% if object.name_endswith_s %}
+                        {% blocktrans trimmed with person_name=object.name %}
+                            We don't know {{ person_name }}' email address.
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans trimmed with person_name=object.name %}
+                            We don't know {{ person_name }}'s email address.
+                        {% endblocktrans %}
+                    {% endif %}
+                    {% blocktrans trimmed with edit_profile_url=object.get_ynr_url %}
                         <a href="{{ edit_profile_url }}">Can you add it?</a>
                     {% endblocktrans %}
                 </p>

--- a/wcivf/apps/people/templates/people/includes/_person_contact_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_contact_card.html
@@ -113,7 +113,17 @@
                 </div>
             {% else %}
                 <div>
-                    {% blocktrans with person_name=object.name %}<dt>We don't know {{ person_name }}'s email address.</dt>{% endblocktrans %}
+                    <dt>
+                        {% if object.name_endswith_s %}
+                            {% blocktrans trimmed with person_name=object.name %}
+                                We don't know {{ person_name }}' email address.
+                            {% endblocktrans %}
+                        {% else %}
+                            {% blocktrans trimmed with person_name=object.name %}
+                                We don't know {{ person_name }}'s email address.
+                            {% endblocktrans %}
+                        {% endif %}
+                    </dt>
                     <dd>
                         <a href="{{ object.get_ynr_url }}">{% trans "Can you add it?" %}</a>
                     </dd>

--- a/wcivf/apps/people/templates/people/includes/_person_contact_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_contact_card.html
@@ -11,14 +11,26 @@
                     <div>
                         {% if object.facebook_personal_url %}
                             <dd>
-                                <a href="{{ object.facebook_personal_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s personal Facebook{% endblocktrans%}">
+                                <a href="{{ object.facebook_personal_url }}" title="
+                                    {% if object.name_endswith_s %}
+                                        {% blocktrans with person_name=object.name %}{{ person_name }}' personal Facebook{% endblocktrans %}
+                                    {% else %}
+                                        {% blocktrans with person_name=object.name %}{{ person_name }}'s personal Facebook{% endblocktrans %}
+                                    {% endif %}
+                                    ">
                                     {{ object.facebook_personal_username }}
                                 </a><br />
                             </dd>
                         {% endif %}
                         {% if object.facebook_page_url %}
                             <dd>
-                                <a href="{{ object.facebook_page_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s Facebook page{% endblocktrans%}">
+                                <a href="{{ object.facebook_page_url }}" title="
+                                    {% if object.name_endswith_s %}
+                                        {% blocktrans with person_name=object.name %}{{ person_name }}' Facebook page{% endblocktrans %}
+                                    {% else %}
+                                        {% blocktrans with person_name=object.name %}{{ person_name }}'s Facebook page{% endblocktrans %}
+                                    {% endif %}
+                                    ">
                                     {{ object.facebook_username}}
                                 </a>
                             </dd>
@@ -31,7 +43,7 @@
                 <div>
                     <dt>{% trans "LinkedIn" %}</dt>
                     <dd>
-                        <a href="{{ object.linkedin_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s LinkedIn profile{% endblocktrans%}">
+                        <a href="{{ object.linkedin_url }}" title="{% blocktrans with person_name=object.name %}LinkedIn profile for {{ person_name }}{% endblocktrans %}">
                             {{ object.linkedin_username}}
                         </a>
                     </dd>
@@ -42,7 +54,7 @@
                 <div>
                     <dt>{% trans "Home page" %}</dt>
                     <dd>
-                        <a href="{{ object.homepage_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s home page{% endblocktrans%}">
+                        <a href="{{ object.homepage_url }}" title="{% blocktrans with person_name=object.name %}Home page for {{ person_name }}{% endblocktrans %}">
                             {{ object.homepage_url }}
                         </a>
                     </dd>
@@ -53,8 +65,18 @@
                 <div>
                     <dt>{% trans "Blog" %}</dt>
                     <dd>
-                        <a href="{{ object.blog_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}">
-                            {% blocktrans with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}
+                        <a href="{{ object.blog_url }}" title="
+                            {% if object.name_endswith_s %}
+                                {% blocktrans with person_name=object.name %}{{ person_name }}' blog{% endblocktrans %}
+                            {% else %}
+                                {% blocktrans with person_name=object.name %}{{ person_name }}'s blog{% endblocktrans %}
+                            {% endif %}
+                            ">
+                            {% if object.name_endswith_s %}
+                                {% blocktrans with person_name=object.name %}{{ person_name }}' blog{% endblocktrans %}
+                            {% else %}
+                                {% blocktrans with person_name=object.name %}{{ person_name }}'s blog{% endblocktrans %}
+                            {% endif %}
                         </a>
                     </dd>
                 </div>
@@ -64,7 +86,7 @@
                 <div>
                     <dt>{% trans "Instagram" %}</dt>
                     <dd>
-                        <a href="{{ object.instagram_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s Instagram{% endblocktrans%}">
+                        <a href="{{ object.instagram_url }}" title="{% blocktrans with person_name=object.name %}Instagram account of {{ person_name }}{% endblocktrans %}">
                             {{ object.instagram_username }}
                         </a>
                     </dd>
@@ -75,7 +97,7 @@
                 <div>
                     <dt>{% trans "YouTube" %}</dt>
                     <dd>
-                        <a href="{{ object.youtube_profile }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s YouTube{% endblocktrans%}">
+                        <a href="{{ object.youtube_profile }}" title="{% blocktrans with person_name=object.name %}YouTube profile for {{ person_name }}{% endblocktrans %}">
                             {{ object.youtube_username }}
                         </a>
                     </dd>
@@ -86,7 +108,7 @@
                 <div>
                     <dt>Wikipedia</dt>
                     <dd>
-                        <a href="{{ object.wikipedia_url }}" title="{{ person_name }}'s Wikipedia">
+                        <a href="{{ object.wikipedia_url }}" title="{% blocktrans with person_name=object.name %}Wikipedia article for {{ person_name }}{% endblocktrans %}">
                             {{ object.wikipedia_url }}
                         </a>
                     </dd>
@@ -97,7 +119,7 @@
                 <div>
                     <dt>{% trans "The party's candidate page for this person" %}</dt>
                     <dd>
-                        <a href="{{ object.party_ppc_page_url }}" title="{% blocktrans with person_name=object.name%}Party page for {{ person_name }}{% endblocktrans%}">
+                        <a href="{{ object.party_ppc_page_url }}" title="{% blocktrans with person_name=object.name %}Party page for {{ person_name }}{% endblocktrans %}">
                             {{ object.party_ppc_page_url }}
                         </a>
                     </dd>
@@ -108,7 +130,7 @@
                 <div>
                     <dt>{% trans "Email" %}</dt>
                     <dd>
-                        <a href="mailto:{{ object.email }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s email{% endblocktrans%}">{{ object.email }}</a>
+                        <a href="mailto:{{ object.email }}" title="{% blocktrans with person_name=object.name %}Email address for {{ person_name }}{% endblocktrans %}">{{ object.email }}</a>
                     </dd>
                 </div>
             {% else %}

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -147,3 +147,11 @@ class TestPersonModel(TestCase):
             expected = candidacy[1]
             with self.subTest(msg=candidacy[1]):
                 self.assertEqual(person.intro_template, expected)
+
+    def test_name_endswith_s_true(self):
+        self.person.name = "John Richards"
+        self.assertTrue(self.person.name_endswith_s)
+
+    def test_name_endswith_s_false(self):
+        self.person.name = "John Smith"
+        self.assertFalse(self.person.name_endswith_s)


### PR DESCRIPTION
I was browsing a local candidate's page when I noticed her name ended with **s**, and messages displayed like `Names's email address`.

I added a boolean property to the `Person` model to understand whether strings about this person should use `'s` or `'`, and implemented this in a few places on the contact card and other pages.

Inspired by the existing party text, in the contact card I also opted to reformat some of the messages so that they didn't require this additional property check, rewording from "X's whatever" to "whatever of X" in the places where that made sense.

It's also worth noting that this fixes a bug where the hovertext for the Wikipedia link didn't include the person's name.

I also added two model tests to verify this behaviour, but I wasn't able to run the tests locally (see #1223). I've verified the behaviour locally on a few candidates pages.

**Updated text when we don't know the person's email address**
![image](https://user-images.githubusercontent.com/12038840/167197296-a758dc3b-0568-4e36-b393-da8355fb70e6.png)

**Hovertext**
![image](https://user-images.githubusercontent.com/12038840/167197346-09022760-7c13-4c6c-8b8a-7d15cbce0907.png)

![image](https://user-images.githubusercontent.com/12038840/167197384-c730db93-46ac-4103-9cdf-ae233713ab69.png)
