### PR TITLE
Revert "Return an empty queryset for "upcoming elections""

### DIFF
--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -85,7 +85,6 @@ class HomePageView(PostcodeFormView):
             .exclude(election__election_date=may_election_day_this_year())
             .select_related("election", "post")
             .order_by("election__election_date")
-            .none()
         )
 
         polls_open = timezone.make_aware(


### PR DESCRIPTION
This reverts commit 28628cc91834a5f30e8f441bf46e3f1594195299.

This will reenable the "Upcoming elections" block on the WCIVF homepage