### PR TITLE
Add sources to fieldnames

### DIFF
--- a/wcivf/apps/feedback/management/commands/feedback_export_csv.py
+++ b/wcivf/apps/feedback/management/commands/feedback_export_csv.py
@@ -27,7 +27,13 @@ class Command(BaseCommand):
             date = timezone.make_aware(date, timezone.get_current_timezone())
             feedback_to_export = feedback_to_export.filter(created__gte=date)
 
-        fieldnames = ["created", "found_useful", "comments", "source_url"]
+        fieldnames = [
+            "created",
+            "found_useful",
+            "sources",
+            "comments",
+            "source_url",
+        ]
         out = csv.DictWriter(self.stdout, fieldnames=fieldnames)
         out.writeheader()
         for feedback in feedback_to_export:


### PR DESCRIPTION
The `feedback_to_csv` was missing `sources` from the `fieldnames` causing an error when the command was run.