### PR TITLE
Test big increase in production instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,9 +280,9 @@ workflows:
       - code_deploy:
           name: code_deploy_production
           dc-environment: production
-          min-size: 2
-          max-size: 2
-          desired-capacity: 2
+          min-size: 20
+          max-size: 25
+          desired-capacity: 22
           requires:
           - build_and_test
           - sam_deploy_staging


### PR DESCRIPTION
- RDS settings in AWS console have been updated to increase the
max_replication_slots number to 100, and max_wal_senders to 105.
- This should allow us to increase the number of instances much
higher if necessary, such as on election day.
- This tests the change by increasing the number of instances to 22,
which on election day 2022 failed and caused some downtime