### PR TITLE
How to Vote Translation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,4 +162,8 @@ Once you have pushed your latest changes to your branch:
 `git fetch origin` to get access to the development branch
 `git checkout development` 
 `git merge [YOUR BRANCH NAME]`
-`git push origin develop`
+`git push origin development`
+
+# Update Welsh Translations
+
+After adding new translation tags to a template, run `django-admin compilemessages` then ``django-admin makemessages -l cy --ignore='env*`` to generate matching translation strings to be translated.

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -326,10 +326,10 @@ msgid ""
 "official at your polling station.\n"
 "                "
 msgstr ""
-"Am fwy o wybodaeth, ewch i <href=\"https://www."
-"electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote\">\n"
-"Wefan y Comisiwn Etholiadol</a> neu gofynnwch i "
-"swyddog yn eich gorsaf bleidleisio."
+"Am fwy o wybodaeth, ewch i <href=\"https://www.electoralcommission.org.uk/i-"
+"am-a/voter/how-cast-your-vote\">\n"
+"Wefan y Comisiwn Etholiadol</a> neu gofynnwch i swyddog yn eich gorsaf "
+"bleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15
 msgid "Elected:"
@@ -749,7 +749,7 @@ msgstr[1] ""
 "Mae yna <strong>%(winner_count) seddi</strong> ar gael yn yr etholiad, a "
 "gallwch ddewis o <strong>%(num_ballots)</strong> ymgeiswyr."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:96
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
 #, python-format
 msgid ""
 "The official candidate list has not yet been published. However, we expect "
@@ -762,7 +762,7 @@ msgstr ""
 "helpu i wella'r dudalen hon: <a href=\"%(ynr_link)s\"> ychwanegwch wybodaeth "
 "am ymgeiswyr i'n cronfa ddata</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:122
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:124
 #, python-format
 msgid ""
 "The <a href=\"%(sopn_url)s\">official candidate list</a> has been published."
@@ -770,32 +770,32 @@ msgstr ""
 "Mae'r <a href=\"%(sopn_url)s\">rhestr swyddogol o ymgeiswyr</a> wedi'i "
 "chyhoeddi."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:127
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:129
 msgid "The official candidate list should have been published on"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr fod wedi'i chyhoeddi ar "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:129
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:131
 msgid "The official candidate list should be published on"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr gael ei chyhoeddi ar"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:138
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:140
 msgid "Read the official candidate booklet for this election."
 msgstr "Darllenwch y llyfryn ymgeiswyr swyddogol ar gyfer yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:142
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:144
 #, python-format
 msgid " %(description)s "
 msgstr " %(description)s "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:149
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:151
 msgid "Can you vote in this election?"
 msgstr "A allwch chi bleidleisio yn yr etholiad hwn?"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:150
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:152
 msgid "Age"
 msgstr "Oedran"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:152
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:154
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
@@ -804,16 +804,16 @@ msgstr ""
 "Mae angen i chi fod dros %(voter_age)s ar %(voter_age_date)s "
 "%(election_date)s i bleidleisio yn yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:157
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:159
 msgid "Citizenship"
 msgstr "Dinasyddiaeth"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:176
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:180
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:11
 msgid "Read more on Wikipedia"
 msgstr "Darllenwch fwy ar Wikipedia"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-01 18:05+0100\n"
+"POT-Creation-Date: 2022-06-22 14:02+0100\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -80,25 +80,21 @@ msgid ""
 msgstr ""
 "<a href=\"%(postelection_url)s\">%(post_label)s</a>%(cancelled_message)s"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:3
-#: wcivf/apps/elections/templates/elections/elections_view.html:4
+#: wcivf/apps/elections/templates/elections/elections_view.html:6
+#: wcivf/apps/elections/templates/elections/elections_view.html:7
 msgid "UK Elections"
 msgstr "Etholiadau'r DU"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:5
+#: wcivf/apps/elections/templates/elections/elections_view.html:8
 msgid "All Elections in the UK"
 msgstr "Pob Etholiad yn y DU"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:14
+#: wcivf/apps/elections/templates/elections/elections_view.html:17
 #: wcivf/templates/base.html:154
 msgid "All Elections"
 msgstr "Pob Etholiad"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:15
-msgid "Current Elections"
-msgstr "Etholiadau Presennol"
-
-#: wcivf/apps/elections/templates/elections/elections_view.html:16
+#: wcivf/apps/elections/templates/elections/elections_view.html:18
 msgid ""
 "This is a list of upcoming elections, and all elections Democracy Club has "
 "covered since 2010. The local election database was founded in 2016."
@@ -106,10 +102,6 @@ msgstr ""
 "Mae hon yn rhestr o'r etholiadau sydd i ddod, a phob etholiad y mae "
 "Democracy Club wedi'u cwmpasu oddi ar 2010. Sefydlwyd y gronfa ddata "
 "etholiadau lleol yn 2016."
-
-#: wcivf/apps/elections/templates/elections/elections_view.html:20
-msgid "Past Elections"
-msgstr "Etholiadau'r Gorffennol"
 
 #: wcivf/apps/elections/templates/elections/includes/_ams_breadcrumbs.html:7
 msgid "The Additional Member System"
@@ -220,7 +212,7 @@ msgstr "Etholiadau"
 
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:17
 msgid "How you vote"
-msgstr ""
+msgstr "Sut i bleidleisio"
 
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:20
 #, python-format
@@ -234,31 +226,36 @@ msgstr ""
 msgid "This election uses %(voting_system_name)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:32
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:86
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:33
 msgid ""
 "\n"
-"                        Mark an X in the box for your preferred candidate.\n"
-"                    "
-msgid_plural ""
+"                            Mark an X in the box for your preferred "
+"candidate.\n"
+"                        "
+msgstr ""
 "\n"
-"                        Mark an X in the box for your preferred candidates.\n"
-"                    "
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+"                            Nodwch X yn y blwch ar gyfer eich ymgeisydd "
+"dewisol. \n"
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:40
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:37
+msgid ""
+"\n"
+"                            Mark an X in the box for your preferred "
+"candidates.\n"
+"                        "
+msgstr ""
+"\n"
+"                            Nodwch X yn y blwch ar gyfer eich ymgeiswyr "
+"dewisol. \n"
+
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:44
 #, python-format
 msgid "You can mark up to %(winner_count)s candidate."
 msgid_plural "You can mark up to %(winner_count)s candidates."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+msgstr[0] "Gallwch nodi hyd at %(winner_count)s ymgeisydd."
+msgstr[1] "Gallwch nodi hyd at %(winner_count) o ymgeiswyr."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:51
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:55
 msgid ""
 "\n"
 "                        Rank the candidates by your preference: 1, 2, 3…\n"
@@ -266,8 +263,13 @@ msgid ""
 "must at least mark your first choice.\n"
 "                    "
 msgstr ""
+"\n"
+"                        Graddiwch yr ymgeiswyr yn ôl eich dewis: 1, 2, 3…\n"
+"                        Does dim rhaid i chi raddio'r holl ymgeiswyr, ond "
+"rhaid i chi o leiaf nodi eich dewis cyntaf.\n"
+" .                  "
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:60
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:64
 msgid ""
 "\n"
 "                        Mark an X in the first column for your first "
@@ -278,7 +280,7 @@ msgid ""
 "                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:70
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:74
 msgid ""
 "\n"
 "                        Mark an X in the box for one party or independent "
@@ -286,7 +288,7 @@ msgid ""
 "                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:78
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:82
 msgid ""
 "\n"
 "                        Mark an X in the box next to your preferred party or "
@@ -294,15 +296,28 @@ msgid ""
 "                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:92
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:90
+msgid ""
+"\n"
+"                        Mark an X in the box for your preferred candidate.\n"
+"                    "
+msgstr ""
+"\n"
+"                        Nodwch X yn y blwch ar gyfer eich ymgeisydd "
+"dewisol.\n"
+"                    "
+
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:96
 msgid ""
 "\n"
 "                Read the instructions at the top of your ballot paper "
 "carefully.\n"
 "            "
 msgstr ""
+"\n"
+"Darllenwch y cyfarwyddiadau ar frig eich papur pleidleisio yn ofalus.\n"
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:98
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:102
 msgid ""
 "\n"
 "                    For more information, visit <a href=\"https://www."
@@ -311,6 +326,10 @@ msgid ""
 "official at your polling station.\n"
 "                "
 msgstr ""
+"Am fwy o wybodaeth, ewch i <href=\"https://www."
+"electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote\">\n"
+"Wefan y Comisiwn Etholiadol</a> neu gofynnwch i "
+"swyddog yn eich gorsaf bleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15
 msgid "Elected:"
@@ -718,11 +737,17 @@ msgstr ""
 #| "You will have %(winner_count)s vote%(plural)s, and can choose from "
 #| "<strong>%(num_candidates)s candidate%(plural_candidates)s</strong>."
 msgid ""
-"There are <strong>%(winner_count)s seat%(plural)s</strong> up for election, "
-"and you can choose from <strong>%(num_ballots)s</strong>."
-msgstr ""
-"Bydd gennych %(winner_count)s bleidlais%(plural)s, a gallwch ddewis o "
-"<strong>%(num_candidates)s ymgeisydd%(plural_candidates)s</strong>."
+"There is <strong>%(winner_count)s seat</strong> up for election, and you can "
+"choose from <strong>%(num_ballots)s</strong>."
+msgid_plural ""
+"There are <strong>%(winner_count)s seats</strong> up for election, and you "
+"can choose from <strong>%(num_ballots)s</strong>."
+msgstr[0] ""
+"Mae yna <strong>%(winner_count)s sedd</strong> ar gael yn yr etholiad, a "
+"gallwch ddewis o %(num_ballots) <strong>ymgeisydd.</strong>"
+msgstr[1] ""
+"Mae yna <strong>%(winner_count) seddi</strong> ar gael yn yr etholiad, a "
+"gallwch ddewis o <strong>%(num_ballots)</strong> ymgeiswyr."
 
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:96
 #, python-format
@@ -1976,10 +2001,3 @@ msgstr "Etholiadau i ddod"
 #: wcivf/templates/mailing_list.html:8
 msgid "Join our mailing list"
 msgstr "Ymunwch â'n rhestr bostio"
-
-#, python-format
-#~ msgid "You can choose from <strong>%(num_ballots)s</strong>."
-#~ msgstr "Gallwch ddewis o <strong>%(num_ballots)s</strong>."
-
-#~ msgid "Previous Elections"
-#~ msgstr "Etholiadau blaenorol"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -29,6 +29,24 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
+#: wcivf/apps/elections/models.py:615
+msgid "First-past-the-post"
+msgstr "Y Cyntaf i’r Felin"
+
+#: wcivf/apps/elections/models.py:617
+#, fuzzy
+#| msgid "The Additional Member System"
+msgid "Additional Member System"
+msgstr "Y System Aelodau Ychwanegol"
+
+#: wcivf/apps/elections/models.py:619
+msgid "Supplementary Vote"
+msgstr "Pleidlais Atodol"
+
+#: wcivf/apps/elections/models.py:621
+msgid "Single Transferable Vote"
+msgstr "Pleidlais Sengl Drosglwyddadwy"
+
 #: wcivf/apps/elections/templates/elections/election_view.html:8
 #, python-format
 msgid "The %(election)s %(was_or_will_be)s held on %(date)s."
@@ -220,6 +238,8 @@ msgid ""
 "This election uses <a href=\"%(voting_system_url)s\">%(voting_system_name)s</"
 "a>."
 msgstr ""
+"Mae’r etholiad hwn yn defnyddio <a href=\"%(voting_system_url)s\">"
+"%(voting_system_name)s</a>"
 
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:24
 #, python-format

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-29 10:15+0000\n"
+"POT-Creation-Date: 2022-06-22 13:41+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,32 +68,24 @@ msgid ""
 "<a href=\"%(postelection_url)s\">%(post_label)s</a> %(cancelled_message)s"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:3
-#: wcivf/apps/elections/templates/elections/elections_view.html:4
+#: wcivf/apps/elections/templates/elections/elections_view.html:6
+#: wcivf/apps/elections/templates/elections/elections_view.html:7
 msgid "UK Elections"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:5
+#: wcivf/apps/elections/templates/elections/elections_view.html:8
 msgid "All Elections in the UK"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:14
+#: wcivf/apps/elections/templates/elections/elections_view.html:17
 #: wcivf/templates/base.html:154
 msgid "All Elections"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:15
-msgid "Current Elections"
-msgstr ""
-
-#: wcivf/apps/elections/templates/elections/elections_view.html:16
+#: wcivf/apps/elections/templates/elections/elections_view.html:18
 msgid ""
 "This is a list of upcoming elections, and all elections Democracy Club has "
 "covered since 2010. The local election database was founded in 2016."
-msgstr ""
-
-#: wcivf/apps/elections/templates/elections/elections_view.html:20
-msgid "Past Elections"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_ams_breadcrumbs.html:7
@@ -109,7 +101,7 @@ msgstr ""
 msgid ""
 "This election was uncontested because the number of candidates who stood was "
 "equal to the number of available seats. There %(is_or_are)s %(winner_count)s "
-"seat%(pluralise_seat)s in %(post_label)s, and only %(num_people)s candidate"
+"seat%(pluralise_seat)s in %(post)s, and only %(num_people)s candidate"
 "%(pluralise_candidates)s."
 msgstr ""
 
@@ -201,27 +193,30 @@ msgstr ""
 msgid "This election uses %(voting_system_name)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:32
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:86
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:33
 msgid ""
 "\n"
-"                        Mark an X in the box for your preferred candidate.\n"
-"                    "
-msgid_plural ""
-"\n"
-"                        Mark an X in the box for your preferred candidates.\n"
-"                    "
-msgstr[0] ""
-msgstr[1] ""
+"                            Mark an X in the box for your preferred "
+"candidate.\n"
+"                        "
+msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:40
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:37
+msgid ""
+"\n"
+"                            Mark an X in the box for your preferred "
+"candidates.\n"
+"                        "
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:44
 #, python-format
 msgid "You can mark up to %(winner_count)s candidate."
 msgid_plural "You can mark up to %(winner_count)s candidates."
 msgstr[0] ""
 msgstr[1] ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:51
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:55
 msgid ""
 "\n"
 "                        Rank the candidates by your preference: 1, 2, 3…\n"
@@ -230,33 +225,56 @@ msgid ""
 "                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:60
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:64
 msgid ""
-"Mark an X in the first column for your first choice."
-"Mark an X in the second column for your second choice."
-"You do not have to mark a second choice."
+"\n"
+"                        Mark an X in the first column for your first "
+"choice.\n"
+"                        Mark an X in the second column for your second "
+"choice.\n"
+"                        You do not have to mark a second choice.\n"
+"                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:70
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:74
 msgid ""
-"Mark an X in the box for one party or independent candidate."                    "
+"\n"
+"                        Mark an X in the box for one party or independent "
+"candidate.\n"
+"                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:78
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:82
 msgid ""
-"Mark an X in the box next to your preferred party or independent candidate."
+"\n"
+"                        Mark an X in the box next to your preferred party or "
+"independent candidate\n"
+"                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:92
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:90
 msgid ""
-"Read the instructions at the top of your ballot paper carefully."
+"\n"
+"                        Mark an X in the box for your preferred candidate.\n"
+"                    "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:98
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:96
 msgid ""
-"For more information, visit <a href=\"https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote\">\n"
-"The Electoral Commission's website</a> or ask an official at your polling station.\n"
+"\n"
+"                Read the instructions at the top of your ballot paper "
+"carefully.\n"
+"            "
+msgstr ""
 
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:102
+msgid ""
+"\n"
+"                    For more information, visit <a href=\"https://www."
+"electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote\">\n"
+"                        The Electoral Commission's website</a> or ask an "
+"official at your polling station.\n"
+"                "
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15
@@ -321,6 +339,7 @@ msgid "Advance voting station opening times"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:36
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:12
 msgid "Date"
 msgstr ""
 
@@ -541,7 +560,7 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:32
 #, python-format
 msgid ""
-"This election <strong>is being help today</strong>. Polls are open from "
+"This election <strong>is being held today</strong>. Polls are open from "
 "%(open_time)s till %(close_time)s"
 msgstr ""
 
@@ -605,11 +624,19 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:86
 #, python-format
 msgid ""
-"There are <strong>%(winner_count)s seat%(plural)s</strong> up for election, "
-"and you can choose from <strong>%(num_ballots)s</strong>."
-msgstr ""
+"There is <strong>%(winner_count)s seat</strong> up for election, and you can "
+"choose from <strong>%(num_ballots)s</strong>."
+msgid_plural ""
+"There are <strong>%(winner_count)s seats</strong> up for election, and you "
+"can choose from <strong>%(num_ballots)s</strong>."
+msgstr[0] ""
+"Mae yna <strong>%(winner_count)s sedd</strong> ar gael yn yr etholiad, a "
+"gallwch ddewis o <strong>%(num_ballots)s ymgeisydd.</strong>"
+msgstr[1] ""
+"Mae yna <strong>%(winner_count)s seddi</strong> ar gael yn yr etholiad, a "
+"gallwch ddewis o <strong>%(num_ballots)s ymgeiswyr.</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:96
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
 #, python-format
 msgid ""
 "The official candidate list has not yet been published. However, we expect "
@@ -618,54 +645,54 @@ msgid ""
 "candidates to our database</a>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:122
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:124
 #, python-format
 msgid ""
 "The <a href=\"%(sopn_url)s\">official candidate list</a> has been published."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:127
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:129
 msgid "The official candidate list should have been published on"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:129
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:131
 msgid "The official candidate list should be published on"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:138
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:140
 msgid "Read the official candidate booklet for this election."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:142
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:144
 #, python-format
 msgid " %(description)s "
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:149
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:151
 msgid "Can you vote in this election?"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:150
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:152
 msgid "Age"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:152
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:154
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
 "%(election_date)s in order to vote in this election."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:157
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:159
 msgid "Citizenship"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:176
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Wikipedia"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:180
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:11
 msgid "Read more on Wikipedia"
 msgstr ""
@@ -958,6 +985,14 @@ msgstr ""
 #: wcivf/apps/parties/templates/parties/party_detail.html:41
 #: wcivf/apps/parties/templates/parties/party_detail.html:55
 msgid "Read more on wikipedia"
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/party_detail.html:68
+msgid "Post"
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/party_detail.html:69
+msgid "Number of candidates"
 msgstr ""
 
 #: wcivf/apps/parties/templates/parties/party_detail.html:74
@@ -1337,6 +1372,22 @@ msgstr ""
 msgid "their speeches, voting history and more"
 msgstr ""
 
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:13
+msgid "Election"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:14
+msgid "Party"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:15
+msgid "Results"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:17
+msgid "Other party affiliations in the past 12 months"
+msgstr ""
+
 #: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:22
 #, python-format
 msgid "%(message)s %(message)s %(message)s"
@@ -1533,7 +1584,7 @@ msgstr ""
 #: wcivf/apps/referendums/templates/referendums/includes/_card.html:30
 #, python-format
 msgid ""
-"<h4>%(referendum_question)s</h4> <blockquote>%(referendum.answer_one)s</"
+"<h4>%(referendum_question)s</h4> <blockquote>%(referendum_answer_one)s</"
 "blockquote> or <blockquote>%(referendum_answer_two)s</blockquote>"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -22,6 +22,22 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr ""
 
+#: wcivf/apps/elections/models.py:615
+msgid "First-past-the-post"
+msgstr ""
+
+#: wcivf/apps/elections/models.py:617
+msgid "Additional Member System"
+msgstr ""
+
+#: wcivf/apps/elections/models.py:619
+msgid "Supplementary Vote"
+msgstr ""
+
+#: wcivf/apps/elections/models.py:621
+msgid "Single Transferable Vote"
+msgstr ""
+
 #: wcivf/apps/elections/templates/elections/election_view.html:8
 #, python-format
 msgid "The %(election)s %(was_or_will_be)s held on %(date)s."

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 
 import pytz
 from django.conf import settings
@@ -605,5 +606,18 @@ class VotingSystem(models.Model):
             return reverse("sv_voting_system_view")
         elif self.slug == "STV":
             return reverse("stv_voting_system_view")
+        else:
+            None
+
+    @property
+    def get_name(self):
+        if self.slug == "FPTP":
+            return _("First-past-the-post")
+        elif self.slug == "AMS":
+            return _("Additional Member System")
+        elif self.slug == "sv":
+            return _("Supplementary Vote")
+        elif self.slug == "STV":
+            return _("Single Transferable Vote")
         else:
             None

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -29,11 +29,15 @@ PR-CL: Closed List
 
             {% if voting_system.slug == "FPTP" %}
                 <p>
-                    {% blocktrans count counter=postelection.winner_count %}
-                        Mark an X in the box for your preferred candidate.
-                    {% plural %}
-                        Mark an X in the box for your preferred candidates.
-                    {% endblocktrans %}
+                    {% if postelection.winner_count > 1 %}
+                        {% blocktrans %}
+                            Mark an X in the box for your preferred candidate.
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans %}
+                            Mark an X in the box for your preferred candidates.
+                        {% endblocktrans %}
+                    {% endif %}
                 </p>
                 {% if postelection.people|length > 1 %}
                     <p>

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -17,11 +17,11 @@ PR-CL: Closed List
             <summary>{% trans 'How you vote' %}</summary>
             <p>
                 {% if voting_system.get_absolute_url %}
-                    {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.name%}
+                    {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.get_name %}
                         This election uses <a href="{{ voting_system_url }}">{{ voting_system_name }}</a>.
                     {% endblocktrans %}
                 {% else %}
-                    {% blocktrans trimmed with voting_system_name=voting_system.name %}
+                    {% blocktrans trimmed with voting_system_name=voting_system.get_name %}
                         This election uses {{ voting_system_name }}.
                     {% endblocktrans %}
                 {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -83,8 +83,10 @@
                                             {% endblocktrans %}
                                         {% endif %}
                                         {% if postelection.winner_count and postelection.get_voting_system.slug == 'STV' %}
-                                            {% blocktrans trimmed with num_ballots=postelection.party_ballot_count winner_count=postelection.winner_count plural=postelection.winner_count|pluralize %}
-                                                There are <strong>{{ winner_count }} seat{{ plural}}</strong> up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
+                                            {% blocktrans trimmed with num_ballots=postelection.party_ballot_count winner_count=postelection.winner_count|apnumber count counter=postelection.winner_count %}
+                                                There is <strong>{{ winner_count }} seat</strong> up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
+                                            {% plural %}
+                                                There are <strong>{{ winner_count }} seats</strong> up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
                                             {% endblocktrans %}
                                         {% endif %}
                                     {% endif %}


### PR DESCRIPTION
This work manually adds missing translations for how to vote guidance for each voting system. 
I've also: 
- refactored the sentence explaining the number of seats available to allow for simpler plural translations. 
- updated the install instructions with `compilemessages` guidance. 