### PR TITLE
Bump uk-election-timetables from 2.2.3 to 2.2.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,6 +25,6 @@ djangorestframework-jsonp==1.0.2
 feedparser==6.0.8
 
 sentry-sdk==1.5.10
-uk-election-timetables==2.2.3
+uk-election-timetables==2.2.4
 django-dotenv==1.4.2
 python-akismet==0.4.3


### PR DESCRIPTION
This is to include the most recent dates published by .gov