### PR TITLE
Swap subscribe links

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -951,14 +951,11 @@ msgstr ""
 "y we."
 
 #: wcivf/apps/elections/templates/elections/postcode_view.html:66
+
 msgid ""
-"Enter <a href=\"https://calendar.google.com/calendar/u/0/embed?"
-"src=tm55j9m2lict2h021b3479gpntshunvd@import.calendar.google.com&ctz=Europe/"
-"London\">this URL</a> and save"
+"Enter this URL and save"
 msgstr ""
-"Rhowch <a href=\"https://calendar.google.com/calendar/u/0/embed?"
-"src=tm55j9m2lict2h021b3479gpntshunvd@import.calendar.google.com&ctz=Europe/"
-"London\">yr URL hwn</a> a'i arbed "
+"Rhowch yr URL hwn a'i arbed"
 
 #: wcivf/apps/feedback/models.py:6 wcivf/apps/feedback/models.py:7
 msgid "Yes"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -860,9 +860,7 @@ msgstr ""
 
 #: wcivf/apps/elections/templates/elections/postcode_view.html:66
 msgid ""
-"Enter <a href=\"https://calendar.google.com/calendar/u/0/embed?"
-"src=tm55j9m2lict2h021b3479gpntshunvd@import.calendar.google.com&ctz=Europe/"
-"London\">this URL</a> and save"
+"Enter this URL and save"
 msgstr ""
 
 #: wcivf/apps/feedback/models.py:6 wcivf/apps/feedback/models.py:7

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -53,7 +53,7 @@
                         {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
                     </h4>
                     <p>
-                        <a href="webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}">{% trans "Subscribe to the iCal feed" %}</a>
+                        <a href="https://calendar.google.com/calendar/u/0/embed?src=tm55j9m2lict2h021b3479gpntshunvd@import.calendar.google.com&ctz=Europe/London">{% trans "Subscribe to the iCal feed" %}</a>
                         <p>{% trans "Or manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>
                         <ol>
                             <li>
@@ -63,7 +63,7 @@
                                 {% trans "If presented with the option to choose a calendar type, choose web calendar." %}
                             </li>
                             <li>
-                                {% blocktrans %}Enter <a href="https://calendar.google.com/calendar/u/0/embed?src=tm55j9m2lict2h021b3479gpntshunvd@import.calendar.google.com&ctz=Europe/London">this URL</a> and save{% endblocktrans %}.
+                                {% trans 'Enter this URL and save' %}: webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}
                             </li>
                         </ol>
                     </p>


### PR DESCRIPTION
The subscribe link and the manual add link were incorrectly assigned. This PR swaps links, simplifies instructions and translation. 

![Screen Shot 2022-09-27 at 12 59 51 PM](https://user-images.githubusercontent.com/7017118/192519555-4afdf087-5a05-46aa-9b34-a5df84c2b914.png)


<img width="895" alt="Screen Shot 2022-09-27 at 1 00 25 PM" src="https://user-images.githubusercontent.com/7017118/192519644-177126f3-acca-4059-be8d-38a63a187312.png">
