### PR TITLE
Add pk to DummyPostElection

### DIFF
--- a/wcivf/apps/elections/dummy_models.py
+++ b/wcivf/apps/elections/dummy_models.py
@@ -1,4 +1,5 @@
 from datetime import date
+from random import randint
 
 from elections.models import Election, Post, PostElection
 from people.dummy_models import DummyCandidacy, DummyPerson
@@ -15,6 +16,7 @@ class DummyPostElection(PostElection):
         slug="local.faketown.2022-05-05",
     )
     post = Post(label="Made-Up-Ward")
+    pk = randint(1, 100000)
 
     class Meta:
         proxy = True


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1406

`>>> DummyPostElection.__dict__
mappingproxy({'__module__': 'elections.dummy_models', 'party_ballot_count': 5, 'display_as_party_list': False, 'election': <Election: Llantalbot local election>, 'post': <Post: Made-Up-Ward ()>, 'pk': 95023, '__init__': <function DummyPostElection.__init__ at 0x105b9b9a0>, 'election_get_absolute_url': <function DummyPostElection.election_get_absolute_url at 0x105b9b760>, 'people': <function DummyPostElection.people at 0x105b9b880>, '__doc__': 'DummyPostElection(id, created, modified, ballot_paper_id, post, election, contested, winner_count, locked, cancelled, replaced_by, metadata, voting_system, wikipedia_url, wikipedia_bio, ynr_modified)', '_meta': <Options for DummyPostElection>, 'DoesNotExist': <class 'elections.dummy_models.DummyPostElection.DoesNotExist'>, 'MultipleObjectsReturned': <class 'elections.dummy_models.DummyPostElection.MultipleObjectsReturned'>})`