### PR TITLE
Ensure instances are running before deploying

### DIFF
--- a/deployscripts/create_deployment_group.py
+++ b/deployscripts/create_deployment_group.py
@@ -12,10 +12,39 @@ def check_deployment_group():
     TODO allow this to accept args
     """
     client = session.client("codedeploy")
-    return client.get_deployment_group(
+    deployment_group = client.get_deployment_group(
         applicationName="WCIVFCodeDeploy",
         deploymentGroupName="WCIVFDefaultDeploymentGroup",
     )
+    asg_name = deployment_group["deploymentGroupInfo"]["autoScalingGroups"][0][
+        "name"
+    ]
+    autoscale_client = session.client(
+        "autoscaling", region_name=os.environ.get("AWS_REGION")
+    )
+    autoscale_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[asg_name]
+    )["AutoScalingGroups"][0]
+    asg_info = autoscale_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[asg_name]
+    )["AutoScalingGroups"][0]
+    instance_count = len(asg_info["Instances"])
+
+    if not instance_count:
+        # There's no instances in this ASG, so we need to start one
+        # before we can deploy
+        autoscale_client.set_desired_capacity(
+            AutoScalingGroupName=asg_name, DesiredCapacity=1
+        )
+        while instance_count < 1:
+            time.sleep(5)
+            print("Checking for ASG instances")
+            asg_info = autoscale_client.describe_auto_scaling_groups(
+                AutoScalingGroupNames=[asg_name]
+            )["AutoScalingGroups"][0]
+            instance_count = len(asg_info["Instances"])
+
+    print("ASG now has an instance running. Continuing with deploy")
 
 
 def get_subnet_ids():


### PR DESCRIPTION
This work addresses a [deploy fail](https://app.circleci.com/pipelines/github/DemocracyClub/WhoCanIVoteFor/2586/workflows/eb86c364-a7ed-485a-bdda-7ade197b88dc/jobs/6262) caused by setting the desired instances to 0 (manually). This change adds additional checks before attempting to deploy.

Output when run locally: 

```
(env) virginiadooley@virginias-mbp WhoCanIVoteFor % python deployscripts/create_deployment_group.py
Checking for ASG instances
Checking for ASG instances
Checking for ASG instances
ASG now has an instance running. Continuing with deploy
```