### PR TITLE
Add --no-input as a separate list item

### DIFF
--- a/.circleci/tests/test_deploy.py
+++ b/.circleci/tests/test_deploy.py
@@ -1,8 +1,8 @@
-import boto3
 import json
 import os
-import pytest
 
+import boto3
+import pytest
 from tomlkit.toml_file import TOMLFile
 
 
@@ -92,7 +92,7 @@ def test_makemigrations_check_succeeds(
     response = lambda_client.invoke(
         FunctionName=lambda_function_arn,
         InvocationType="RequestResponse",
-        Payload='{"command": "makemigrations", "args": ["--check --no-input", "--dry-run"]}',
+        Payload='{"command": "makemigrations", "args": ["--check", "--no-input", "--dry-run"]}',
     )
     payload = json.loads(response["Payload"].read())
     assert payload.get("errorMessage") is None


### PR DESCRIPTION
Fixes formatting following 95a4469c2a211942b5cbc42b24548e6c260522e8.