### PR TITLE
Dependabot will ignore boto3 patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
   ignore:
     - dependency-name: django
       versions: [">=3.0", "<4.2"]
+    # ignore all boto3 patch updates
+    - dependency-name: boto3
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
AWS releases patch versions of `boto3` on a daily basis, but we don't need to incorporate these changes on the same schedule. This work ensures a dependabot PR will not be raised for patched versions. 

More info https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/