### PR TITLE
Remove no-ID messaging for EN/CY

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -403,11 +403,6 @@ msgid "and"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:74
-#, fuzzy
-#| msgid "You don't need to take your poll card with you"
-msgid "You don't need to take your poll card or any identification with you."
-msgstr "Nid oes angen i chi ddod â'ch cerdyn pleidleisio gyda chi"
-
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:76
 #, fuzzy
 #| msgid "You don't need to take your poll card with you"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -351,9 +351,6 @@ msgid "and"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:74
-msgid "You don't need to take your poll card or any identification with you."
-msgstr ""
-
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:76
 msgid "You don't need to take your poll card with you."
 msgstr ""

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -71,7 +71,7 @@
             {% if not voter_id_required %}
                 <p>
                     {% if not postcode|ni_postcode %}
-                        {% trans "You don't need to take your poll card or any identification with you." %}
+                        {% trans "You don't need to take your poll card with you." %}
                     {% else %}
                         {% trans "You don't need to take your poll card with you." %}
                     {% endif %}


### PR DESCRIPTION
_I know the if/else now functionally does the same thing in either case, but I decided to leave the structure in place for when we revisit ID messaging - happy to remove it on request though!_
