### PR TITLE
Fix error formatting

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ dealer==2.1.0
 
 https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.3.tar.gz
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.2.tar.gz
+https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.3.tar.gz
 git+https://github.com/DemocracyClub/dc_logging.git@0.0.9
 
 djangorestframework-jsonp==1.0.2

--- a/wcivf/assets/scss/style.scss
+++ b/wcivf/assets/scss/style.scss
@@ -151,3 +151,8 @@ input[type=radio] {
 #language-label {
   font-family: Montserrat, sans-serif;
 }
+
+.ds-error {
+//  centers the error for the postcode lookup
+    margin: 1rem auto;
+}


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1505
Ref https://github.com/DemocracyClub/dc_django_utils/pull/49 

Recent changes to forms in `dc_utils`  broke some of the design system classes. This work integrates a new version of `dc_utils` which removes error classes from the form fields and places them outside of the form block. It also centers the form errors for postcode search forms. 
<img width="1002" alt="Screenshot 2023-02-14 at 1 39 10 PM" src="https://user-images.githubusercontent.com/7017118/218800175-b0b091b3-8a2e-4101-a43c-0307c31823e8.png">

