### PR TITLE
Bump uk-election-timetables to 2.4.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,6 +26,6 @@ djangorestframework-jsonp==1.0.2
 feedparser==6.0.10
 
 sentry-sdk==1.13.0
-uk-election-timetables==2.3.0
+uk-election-timetables==2.4.0
 django-dotenv==1.4.2
 python-akismet==0.4.3


### PR DESCRIPTION
This should resolve the issue Peter highlighted with RTV deadlines as the current version (2.3.0) does not include the additional bank holiday for the 8th May coronation.