### PR TITLE
Fix slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,10 +206,9 @@ jobs:
             make lambda-migrate
       # In the event the deployment has failed, alert the dev team
       - slack/notify:
-            event: fail
-            template: basic_fail_1
-            channel: $SLACK_DEFAULT_CHANNEL
-
+          event: fail
+          channel: $SLACK_DEFAULT_CHANNEL
+          template: basic_fail_1
   code_deploy:
     docker:
       - image: cimg/python:3.10.4
@@ -255,13 +254,12 @@ jobs:
           no_output_timeout: 15m # TODO reduce/discuss what is suitable?
       # In the event the deployment has failed, alert the dev team
       - slack/notify:
-            event: fail
-            template: basic_fail_1
-            channel: $SLACK_DEFAULT_CHANNEL
+          event: fail
+          template: basic_fail_1
+          channel: $SLACK_DEFAULT_CHANNEL
             
       
 workflows:
-
   main:
     jobs:
       - build_and_test:


### PR DESCRIPTION
I missed a step in my previous, related PR of adding the bot to the default slack channel which was causing the channel not to be found. This PR also corrects the indentation which was causing arguments to be missed.  I tested a passing config in the `sam_build` step to confirm the API is working as expected. 

<img width="849" alt="Screenshot 2023-02-16 at 3 58 30 PM" src="https://user-images.githubusercontent.com/7017118/219419866-75aecb35-11cb-4ac9-84f5-3da50ecd06f0.png">
