### PR TITLE
Hotfix/dc utils not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ workflows:
       - sam_build:
           requires:
           - build_and_test
+          context: [slack-secrets]
 
       - sam_deploy:
           name: sam_deploy_development
@@ -281,7 +282,7 @@ workflows:
           requires:
           - build_and_test
           - sam_build
-          context: [ deployment-development-wcivf ]
+          context: [ deployment-development-wcivf]
           filters: { branches: { only: [ main, master, staging ] } }
           
       - code_deploy:
@@ -294,7 +295,7 @@ workflows:
           - build_and_test
           - sam_build
           - sam_deploy_development
-          context: [ deployment-development-wcivf ]
+          context: [ deployment-development-wcivf]
           filters: { branches: { only: [ main, master, staging ] } }
 
       - sam_deploy:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ dealer==2.1.0
 
 https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.3.tar.gz
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.3.tar.gz
+https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.5.tar.gz
 git+https://github.com/DemocracyClub/dc_logging.git@0.0.9
 
 djangorestframework-jsonp==1.0.2


### PR DESCRIPTION
This change attempts to solve the error finding `dc_utils` in the deploy by clearing the cache with a new version. I've also added the step of collecting slack related context variables earlier in the process to ensure they are available for deploy later on. 