### PR TITLE
Add token variable to deploy config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,8 @@ jobs:
                    AppSentryDsn='$SENTRY_DSN' \
                    AppSecretKey='$SECRET_KEY' \
                    AppSlackFeedbackWebhookUrl='$SLACK_FEEDBACK_WEBHOOK_URL' \
+                   AppSlackAccessToken = '$SLACK_ACCESS_TOKEN' \
+                   AppSlackDefaultChannel = '$SLACK_DEFAULT_CHANNEL' \
                    AppDcEnvironment='$DC_ENVIRONMENT' \
                    AppLoggerDbPassword='$LOGGER_DB_PASSWORD' \
                    AppLoggerDbHost='$LOGGER_DB_HOST' \

--- a/docs/circleci.md
+++ b/docs/circleci.md
@@ -17,7 +17,7 @@ You will need to create a new CircleCI deployment "Context". This is done in the
 
 A good initial topology is one Context per AWS account. The suggested naming convention for this project is `deployment-ENVIRONMENT-PROJECTNAME` e.g. `deployment-production-wcivf`.
 
-You will need to set a number of variables in the context so that these are used in the lambda function deploymenet. The variables to set are:
+You will need to set a number of variables in the context so that these are used in the lambda function deployment. The variables to set are:
 
 - `AWS_ACCESS_KEY_ID` - this the access key for the CircleCI user
 - `AWS_SECRET_ACCESS_KEY` - the secret accrss key of the CircleCI user

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -60,8 +60,12 @@ Parameters:
     Description: "The domain to be used"
     Type: String
 
-  AppSlackFeedbackWebhookUrl:
-    Description: "Webhook url used to send feeback entries to Slack"
+  AppSlackAccessToken:
+    Description: "The slack access token used to send messages to slack"
+    Type: String
+
+  AppSlackDefaultChannel:
+    Description: "Default channel to send Slack messages to"
     Type: String
 
   AppLoggerDbPassword:
@@ -91,6 +95,7 @@ Resources:
           SECRET_KEY: !Ref AppSecretKey
           DC_ENVIRONMENT: !Ref AppDcEnvironment
           SLACK_FEEDBACK_WEBHOOK_URL: !Ref AppSlackFeedbackWebhookUrl
+          SLACK_ACCESS_TOKEN: !Ref AppSlackAccessToken
           LOGGER_DB_PASSWORD: !Ref AppLoggerDbPassword
           LOGGER_DB_HOST: !Ref AppLoggerDbHost
       Tags:


### PR DESCRIPTION
After another attempt of adding context variables to the build process at an earlier stage in the CI process, they were still not available at deploy and therefore [the slack notification step has failed in CI](https://app.circleci.com/pipelines/github/DemocracyClub/WhoCanIVoteFor/2821/workflows/5f37ce03-805d-4f2b-b88c-8e1759c401c9/jobs/7180).  After reviewing the env variables in the CI sam deploy development step, I thought I would try to add the slack access tokens to the sam template alongside other redacted variables as a trial step to address the tokens not being found in the staging and prod deploy.