### PR TITLE
Update hustings urls to 2023 google sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,24 @@ Will try to render `foo_cy.html` first and if that doesn't exist it will
 render `foo.html`
 
 
+## Pre-Election Tasks
+
+# New WCIVF Google Sheets imports (Hustings, local parties)
+
+Peter will have set up some Google sheets in a known format. The CSV version of these sheets are imported in to WCIVF from time to time.
+
+Each election, we create a new set of sheets. These need to be added to the import jobs.
+
+Get the Sheet CSV URL (file -> share -> public to the web -> select sheet / csv > publish > copy URL)
+For local parties, edit https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wcivf/apps/parties/management/commands/import_local_parties.py#L23-L34
+For hustings edit https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wcivf/apps/hustings/management/commands/import_hustings.py#L60
+
+Commit, PR, merge, deploy.
+
 ## Deployments
 
 Deployments are triggered by Circle CI. Take a look at `.circleci/config.yml` to see details of the deployment workflow.
 
 To increase the number of EC2 instances for an environment (e.g. during busy times around elections) increase the `min-size`, `max-size` and `desired-capacity` variables found in the `code_deploy` jobs in the `config.yml` file. For further details, see notes about scaling [scaling](/docs/troubleshooting.md#scaling).
+
+

--- a/wcivf/apps/hustings/management/commands/import_hustings.py
+++ b/wcivf/apps/hustings/management/commands/import_hustings.py
@@ -59,11 +59,11 @@ class Command(BaseCommand):
 
     URLS = [
         # NI
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vT_VvyPiJA75yOCv7j_E0PjZe3yFy77C9RH9ucb1bM2_QBhSIWSRKsF3_qhcukrxQsRMu9SRyNXWX05/pub?gid=372490874&single=true&output=csv",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTnQcyfJHIDBhtJuuxQShQ0rjWKfv-zNW_fa0OyxQf3md4BHEwmwHmprRe-IOJYfIY8ZkKweY039F74/pub?gid=1940364340&single=true&output=csv",
         # ENG MAYORS
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vT_VvyPiJA75yOCv7j_E0PjZe3yFy77C9RH9ucb1bM2_QBhSIWSRKsF3_qhcukrxQsRMu9SRyNXWX05/pub?gid=1086162179&single=true&output=csv",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTnQcyfJHIDBhtJuuxQShQ0rjWKfv-zNW_fa0OyxQf3md4BHEwmwHmprRe-IOJYfIY8ZkKweY039F74/pub?gid=1517245531&single=true&output=csv",
         # ENG LOCALS
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vT_VvyPiJA75yOCv7j_E0PjZe3yFy77C9RH9ucb1bM2_QBhSIWSRKsF3_qhcukrxQsRMu9SRyNXWX05/pub?gid=1180606386&single=true&output=csv",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTnQcyfJHIDBhtJuuxQShQ0rjWKfv-zNW_fa0OyxQf3md4BHEwmwHmprRe-IOJYfIY8ZkKweY039F74/pub?gid=0&single=true&output=csv",
         # SCOT LOCALS
         "https://docs.google.com/spreadsheets/d/e/2PACX-1vT_VvyPiJA75yOCv7j_E0PjZe3yFy77C9RH9ucb1bM2_QBhSIWSRKsF3_qhcukrxQsRMu9SRyNXWX05/pub?gid=976193034&single=true&output=csv",
         # WALES LOCALS


### PR DESCRIPTION
Ref https://trello.com/c/3JGkW1oc/3302-hustings-parties-and-manifestos

This change updates the google urls for importing 2023 hustings info. 

To test: 

1. Make sure your db is up to date with current election info. 
2. Check that the google url corresponds to the correct election type. 
3. Run the `import_hustings` management command locally. 
4. Check an election from one of the hustings google sheets tab contains hustings data. 

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Have I rebased with the latest version of master?
- [x] Update any documentation
```
