### PR TITLE
Add in missing div tags

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -25,6 +25,8 @@
                     {% else %}
                         <img src="{% static '/people/images/blank-avatar.png' %}" alt="Blank Head icons created by Freepik - Flaticon" style="background-color: #ddd;">
                     {% endif %}
+                </div>
+            </div>
         {% endfor %}
     {% else %}
         <div>


### PR DESCRIPTION
We found a hilarious bug caused by an earlier "fix" I made which scrambled everything underneath the indie candidate. This turned out to be due to missing div tags, not introduced by my changes but revealed by them.

Video of it being not scrambled:

https://user-images.githubusercontent.com/9531063/227576853-b041136a-cee8-4402-8fd9-06bd39ae15bb.mov
