### PR TITLE
Increase feedback to be sent hourly

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -132,7 +132,7 @@ Resources:
             Schedule: cron(0 9 ? * 6 *) # using the ? as you cannot use * wildcard for both day-of-month and day-of-week field. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions
             Name: batch-feedback-to-slack
             Description: Send feedback entries for the last week to slack
-            Input: '{"command": "batch_feedback_to_slack", "args": ["--hours=168"]}'
+            Input: '{"command": "batch_feedback_to_slack", "args": ["--hours=1"]}'
         ImportHustings:
           Type: Schedule
           Properties:


### PR DESCRIPTION
Ref https://trello.com/c/TzIX7WUq/3317-post-wcivf-slack-feedback-more-often
This work increases the frequency of slack feedback posts during election season. 

To test, complete the feedback form on the bottom of any current election page. Then follow the instructions on how to [Test Feedback Form changes to Slack Webhooks](https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/INSTALL.md#test-feedback-form-changes-to-slack-webhooks)

<img width="754" alt="Screenshot 2023-03-28 at 11 08 50 AM" src="https://user-images.githubusercontent.com/7017118/228203471-f59089b1-befa-49a3-bca5-fd911971a9a0.png">


```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
```
