### PR TITLE
Display metadata title and description

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load i18n %}
 
-{% if not object.contested %}
+{% if not object.contested and not object.metadata.cancelled_election %}
     {% comment %} Case 1: Election cancelled, uncontested, number of candidates equal seats, no metadata{% endcomment %}
     {% if object.winner_count == object.people.count %}
         <h4>{% trans "Uncontested Election" %}</h4>
@@ -49,8 +49,14 @@
     {% endif %}
     {% comment %} Case 4: Contested but cancelled for other reasons {% endcomment %}
 {% else %}
-    <h4>{% trans "Cancelled Election" %}</h4>
-    <p>{% trans "This election was cancelled." %}</p>
+    {% if object.metadata.cancelled_election %}
+        <h4>{{ object.metadata.cancelled_election.title }}</h4>
+        <p>{{ object.metadata.cancelled_election.detail }}</p>
+    {% else %}
+        <h4>{% trans "Cancelled Election" %}</h4>
+        <p>{% trans "This election was cancelled." %}</p>
+    {% endif %}
+
 {% endif %}
 
 <p>
@@ -69,11 +75,4 @@
         <a href="{{ object.metadata.cancelled_election.url }}">{% trans "Read more" %}</a>
     {% endif %}
 </p>
-{% comment %} Metadata should not repeat the pre-formatted messages below,
-but rather provide extra information that is not already present in the logic
-{% endcomment %}
-<p>
-    {% if object.metadata.cancelled_election.detail %}
-        {{ object.metadata.cancelled_election.detail }}
-    {% endif %}
-</p>
+


### PR DESCRIPTION
Ref https://trello.com/c/xJEReIxB/3334-%E2%98%B9-countermanded-poll-issues-%E2%98%B9

> Death of candidate message has broken on WCIVF (shows correctly elsewhere). Raised by the council in question https://whocanivotefor.co.uk/elections/local.west-lancashire.rural-south.2023-05-04/rural-south/

> This is possibly a case we hadn't considered when we drew up the (uncontested) scenarios - the candidate died after they submitted nomination papers, but before the nominations were published.

<img width="980" alt="Screenshot 2023-04-18 at 5 17 05 PM" src="https://user-images.githubusercontent.com/7017118/232840336-25e74639-02d8-4dd1-aba4-8ab377676e3e.png">


To test, run the local server and visit http://localhost:8000/elections/local.west-lancashire.rural-south.2023-05-04/rural-south/

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
