### PR TITLE
Remove inaccurate postal vote messaging for NI

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -77,9 +77,11 @@
                     {% endif %}
                 </p>
             {% endif %}
-            <p>
-                {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
-            </p>
+            {% if not postcode|ni_postcode %}
+                <p>
+                    {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
+                </p>
+            {% endif %}
 
 
         {% else %}


### PR DESCRIPTION
Found this bug which relates to one that Sym reported on Where earlier. Voters in NI cannot hand in their postal ballots at a polling station.

To test:
- Make sure you've got NI election locally
- Search for an NI postcode you know to have an election
- You should not see the message "If you have a postal vote, you can hand it in at this polling station on election day up to 10pm"

```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally

```
