### PR TITLE
Don't show people list or link to candidate list for cancelled ballots

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -122,7 +122,7 @@
                 </p>
             {% endif %}
 
-            {% if postelection.people %}
+            {% if postelection.people and not postelection.cancelled %}
                 {% if postelection.display_as_party_list %}
                     {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
                 {% else %}
@@ -130,7 +130,7 @@
                 {% endif %}
             {% endif %}
 
-            {% if postelection.should_display_sopn_info %}
+            {% if postelection.should_display_sopn_info and not postelection.cancelled %}
                 <p>
                     {% if postelection.locked %}
                         {% blocktrans trimmed with sopn_url=postelection.ynr_sopn_link %}


### PR DESCRIPTION
Ref https://trello.com/c/xJEReIxB/3334-%E2%98%B9-countermanded-poll-issues-%E2%98%B9

Before: https://whocanivotefor.co.uk/elections/SR1%201AE/

After:
![Screenshot 2023-04-25 at 6 28 25 PM](https://user-images.githubusercontent.com/7017118/234356536-966774c2-fcdd-4be9-9a9c-35efd033c6b8.png)

To test, make sure you have imported live site data and visit the page above in your local host. 

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
```
