### PR TITLE
Feat/party pages non party

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-24 15:09+0100\n"
+"POT-Creation-Date: 2023-04-26 14:23+0100\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -221,7 +221,9 @@ msgstr "Rydych chi yma"
 
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:6
 #: wcivf/apps/elections/templates/elections/includes/_postcode_breadcrumbs.html:5
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:17
 #: wcivf/apps/parties/templates/parties/party_detail.html:17
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:17
 #: wcivf/apps/people/templates/people/person_detail.html:27
 #: wcivf/templates/base.html:100
 msgid "Home"
@@ -1110,47 +1112,66 @@ msgstr "Gweld y rhestr swyddogol o ymgeiswyr (PDF)."
 msgid "See who was elected"
 msgstr "Gweld pwy gafodd eu hethol"
 
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:20
 #: wcivf/apps/parties/templates/parties/party_detail.html:20
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:20
 msgid "Parties"
 msgstr "Pleidiau"
 
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:22
 #: wcivf/apps/parties/templates/parties/party_detail.html:22
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:22
 #, python-format
 msgid "Current: %(party_name)s"
 msgstr "Ar hyn o bryd: %(party_name)s"
 
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:30
 #: wcivf/apps/parties/templates/parties/party_detail.html:35
-#: wcivf/apps/parties/templates/parties/party_detail.html:48
+#: wcivf/apps/parties/templates/parties/party_detail.html:51
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:30
 #, fuzzy, python-format
 #| msgid "%(num_candidates)s candidate%(pluralize_candidates)s"
 msgid "%(num_candidates)s candidate%(pluralize_candidates)s in our database."
 msgstr "%(num_candidates)s ymgeisydd%(pluralize_candidates)s"
 
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:36
+msgid "Independent candidates are unaffiliated with any political party."
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/independent_candidate.html:37
+#, python-format
+msgid ""
+"An independent candidate may appear on the ballot paper as "
+"\"%(ballot_name)s\", or with no description at all."
+msgstr ""
+
 #: wcivf/apps/parties/templates/parties/party_detail.html:40
-#: wcivf/apps/parties/templates/parties/party_detail.html:53
+#: wcivf/apps/parties/templates/parties/party_detail.html:56
 msgid "Read more on wikipedia"
 msgstr "Darllenwch fwy ar wikipedia"
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:56
+#: wcivf/apps/parties/templates/parties/party_detail.html:43
+#: wcivf/apps/parties/templates/parties/party_detail.html:59
 #, python-format
 msgid ""
 "This political party was deregistered on %(dereg_date)s, and can no longer "
 "field candidates. "
 msgstr ""
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:62
+#: wcivf/apps/parties/templates/parties/party_detail.html:65
 #, fuzzy, python-format
 #| msgid "This election was held <strong>%(election_date)s</strong>."
-msgid "<p>This party is on the <strong>%(register)s</strong> register.</p>"
+msgid ""
+"<p>This party %(was_is)s on the <strong>%(register)s</strong> register.</p>"
 msgstr "Cynhaliwyd yr etholiad hwn <strong>%(election_date)s</strong>"
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:73
+#: wcivf/apps/parties/templates/parties/party_detail.html:76
 #, fuzzy
 #| msgid " %(description)s "
 msgid "Joint description"
 msgstr " %(description)s "
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:76
+#: wcivf/apps/parties/templates/parties/party_detail.html:79
 #, fuzzy, python-format
 #| msgid ""
 #| "\n"
@@ -1164,28 +1185,30 @@ msgstr ""
 "\n"
 "                                        %(num_votes)s pleidlais (etholwyd)\n"
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:85
+#: wcivf/apps/parties/templates/parties/party_detail.html:88
 #, python-format
 msgid ""
 "View the entry for the %(party_name)s in the register of political parties."
 msgstr ""
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:95
+#: wcivf/apps/parties/templates/parties/party_detail.html:98
 msgid "View this party's entry in the register of political parties."
 msgstr ""
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:102
+#: wcivf/apps/parties/templates/parties/party_detail.html:105
 #, fuzzy
 #| msgid " %(description)s "
 msgid "Ballot descriptions"
 msgstr " %(description)s "
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:103
+#: wcivf/apps/parties/templates/parties/party_detail.html:106
+#, python-format
 msgid ""
-"This party may appear on the ballot paper under any of the following names:"
+"This party may appear on the ballot paper as \"%(ballot_name)s\", or any of "
+"the following names:"
 msgstr ""
 
-#: wcivf/apps/parties/templates/parties/party_detail.html:112
+#: wcivf/apps/parties/templates/parties/party_detail.html:115
 #, fuzzy
 #| msgid "emblem"
 msgid "Emblems"
@@ -1242,6 +1265,31 @@ msgstr "Fersiwn PDF"
 #: wcivf/apps/parties/templates/parties/single_manifesto.html:21
 msgid "Easy Read version"
 msgstr "Fersiwn Hawdd ei Darllen"
+
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:36
+msgid ""
+"The Speaker of the House of Commons stands in general elections under the "
+"banner"
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:37
+msgid ""
+"They are not affiliated with any political party, nor do they campaign on "
+"any political issues."
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:38
+msgid "The Speaker generally runs unopposed by the major parties."
+msgstr ""
+
+#: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:39
+msgid ""
+"Find out more about <a href=\"https://www.parliament.uk/mps-lords-and-"
+"offices/offices/commons/speakers-office/\">The Speaker</a> and <a "
+"href=\"https://www.parliament.uk/about/living-heritage/evolutionofparliament/"
+"parliamentwork/offices-and-ceremonies/overview/the-speaker/elections/"
+"\">their role in elections</a> on the parliament.uk website."
+msgstr ""
 
 #: wcivf/apps/people/models.py:75
 msgid "Elected unopposed"

--- a/wcivf/apps/parties/templates/parties/independent_candidate.html
+++ b/wcivf/apps/parties/templates/parties/independent_candidate.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% load markdown_filter %}
+{% load humanize %}
+{% load i18n %}
+
+{% block og_image %}{% if object.emblem_url %}{{ CANONICAL_URL }}{{ object.emblem_url }}{% endif %}{% endblock og_image %}
+{% block og_title_content %}{{ object.party_name }}{% endblock og_title_content %}
+{% block page_title %}{{ object.party_name }}{% endblock page_title %}
+{% block og_description_content %}{{ object.personpost_set.all.count }} candidates{% endblock og_description_content %}
+
+
+{% block content %}
+    <nav class="ds-breadcrumbs ds-stack" aria-label="You are here: {{ request.path }}">
+        <ol>
+            <li>
+                <a href="{% url 'home_view' %}">{% trans "Home" %}</a>
+            </li>
+            <li>
+                <a href="{% url 'parties_view' %}">{% trans "Parties" %}</a>
+            </li>
+            <li>{% blocktrans trimmed with party_name=object.party_name %}Current: {{ party_name }}{% endblocktrans %}</li>
+        </ol>
+    </nav>
+
+    <div class="ds-stack-smaller">
+
+        <div>
+            <h2>{{ object.format_name }}</h2>
+            <p>{% blocktrans trimmed with num_candidates=object.personpost_set.all.count|intcomma pluralize_candidates=object.personpost_set.all.count|pluralize %}{{ num_candidates }} candidate{{ pluralize_candidates }} in our database.{% endblocktrans %}</p>
+            {% if object.description %}
+                {{ object.description|markdown }}
+            {% endif %}
+        </div>
+
+        <p>{% trans "Independent candidates are unaffiliated with any political party." %}</p>
+        <p>{% blocktrans trimmed with ballot_name=object.party_name %}An independent candidate may appear on the ballot paper as "{{ ballot_name }}", or with no description at all.{% endblocktrans %}</p>
+
+    </div>
+
+{% endblock content %}

--- a/wcivf/apps/parties/templates/parties/party_detail.html
+++ b/wcivf/apps/parties/templates/parties/party_detail.html
@@ -31,13 +31,16 @@
                         <img src="{{ party.emblem_url }}" alt="{{ party_name }} emblem">
                     </div>
                     <div class="ds-not-sidebar">
-                        <h2>{{ party.party_name }}</h2>
+                        <h2>{{ object.format_name }}</h2>
                         <p>{% blocktrans with num_candidates=object.personpost_set.all.count|intcomma pluralize_candidates=object.personpost_set.all.count|pluralize %}{{ num_candidates }} candidate{{ pluralize_candidates }} in our database.{% endblocktrans %}</p>
                         {% if object.description %}
                             {{ object.description|markdown }}
                         {% endif %}
                         {% if object.wikipedia_url %}
                             <p><a href="{{ object.wikipedia_url }}">{% trans "Read more on wikipedia" %}</a></p>
+                        {% endif %}
+                        {% if object.is_deregistered %}
+                            <p>{% blocktrans with dereg_date=object.date_deregistered %}This political party was deregistered on {{ dereg_date }}, and can no longer field candidates. {% endblocktrans %}</p>
                         {% endif %}
                     </div>
                 </div>
@@ -59,8 +62,8 @@
         {% endif %}
 
         {% if object.register %}
-            {% blocktrans trimmed with register=object.format_register %}
-                <p>This party is on the <strong>{{ register }}</strong> register.</p>
+            {% blocktrans trimmed with register=object.format_register was_is=object.is_deregistered|yesno:"was,is" %}
+                <p>This party {{ was_is }} on the <strong>{{ register }}</strong> register.</p>
             {% endblocktrans %}
         {% endif %}
 
@@ -100,7 +103,7 @@
 
         {% if object.party_descriptions.all %}
             <h3>{% trans "Ballot descriptions" %}</h3>
-            <p>{% trans "This party may appear on the ballot paper under any of the following names:" %}</p>
+            <p>{% blocktrans trimmed with ballot_name=object.party_name %} This party may appear on the ballot paper as "{{ ballot_name }}", or any of the following names:{% endblocktrans %}</p>
             <ul>
                 {% for description in object.party_descriptions.all %}
                     <li>{{ description.description }}</li>

--- a/wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html
+++ b/wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% load markdown_filter %}
+{% load humanize %}
+{% load i18n %}
+
+{% block og_image %}{% if object.emblem_url %}{{ CANONICAL_URL }}{{ object.emblem_url }}{% endif %}{% endblock og_image %}
+{% block og_title_content %}{{ object.party_name }}{% endblock og_title_content %}
+{% block page_title %}{{ object.party_name }}{% endblock page_title %}
+{% block og_description_content %}{{ object.personpost_set.all.count }} candidates{% endblock og_description_content %}
+
+
+{% block content %}
+    <nav class="ds-breadcrumbs ds-stack" aria-label="You are here: {{ request.path }}">
+        <ol>
+            <li>
+                <a href="{% url 'home_view' %}">{% trans "Home" %}</a>
+            </li>
+            <li>
+                <a href="{% url 'parties_view' %}">{% trans "Parties" %}</a>
+            </li>
+            <li>{% blocktrans trimmed with party_name=object.party_name %}Current: {{ party_name }}{% endblocktrans %}</li>
+        </ol>
+    </nav>
+
+    <div class="ds-stack-smaller">
+
+        <div>
+            <h2>{{ object.format_name }}</h2>
+            <p>{% blocktrans trimmed with num_candidates=object.personpost_set.all.count|intcomma pluralize_candidates=object.personpost_set.all.count|pluralize %}{{ num_candidates }} candidate{{ pluralize_candidates }} in our database.{% endblocktrans %}</p>
+            {% if object.description %}
+                {{ object.description|markdown }}
+            {% endif %}
+        </div>
+    </div>
+    <p>{% trans "The Speaker of the House of Commons stands in general elections under the banner" %} "{{ object.format_name }}"</p>
+    <p>{% trans "They are not affiliated with any political party, nor do they campaign on any political issues." %}</p>
+    <p>{% trans "The Speaker generally runs unopposed by the major parties." %}</p>
+    <p>{% blocktrans trimmed %} Find out more about <a href="https://www.parliament.uk/mps-lords-and-offices/offices/commons/speakers-office/">The Speaker</a> and <a href="https://www.parliament.uk/about/living-heritage/evolutionofparliament/parliamentwork/offices-and-ceremonies/overview/the-speaker/elections/">their role in elections</a> on the parliament.uk website.{% endblocktrans %}</p>
+
+{% endblock content %}

--- a/wcivf/apps/parties/views.py
+++ b/wcivf/apps/parties/views.py
@@ -8,4 +8,15 @@ class PartiesView(ListView):
 
 
 class PartyView(DetailView):
+    def get_template_names(self):
+        party_id = self.object.party_id
+
+        if party_id == "ynmp-party:2":
+            return ["parties/independent_candidate.html"]
+
+        if party_id == "ynmp-party:12522":
+            return ["parties/speaker_seeking_reelection.html"]
+
+        return ["parties/party_detail.html"]
+
     queryset = Party.objects.all()

--- a/wcivf/assets/scss/style.scss
+++ b/wcivf/assets/scss/style.scss
@@ -107,10 +107,6 @@ $scope: false;
     background-color: white;
 }
 
-main {
-    padding: 0 0 !important;
-}
-
 input[type=radio] {
     visibility: hidden;
 }


### PR DESCRIPTION
The final phase of the Party Pages MVP 🏁 [Trello](https://trello.com/c/dVLjcV1A/3225-wcivf-political-party-pages)

Ref #1200 

This work adds special templates for Independent (as a "party") and the Speaker, an override to the `get_template_names` method on the `PartyView` to control which template to use, as well as some miscellaneous bug fixes.

Regarding the change to the view, we chose to go explicit rather than take a more flexible approach partially because of extra fiddling that would have to happen due to colons in party IDs and partially because we don't have any current plans to extend the list of exceptional cases.

Misc bug fixes/QOL improvements:
1. Deregistered parties with emblems weren't displaying as "deregistered"
2. Tenses weren't accounted for when referring to deregistered parties in the "This party __ on the __ register" sentence
3. The party name is now featured in the "Ballot descriptions" section before the bullet list
4. The pages had no padding which looked rubbish on mobile

I appreciate that because of all the miscellaneous fixes there's a lot of test cases here, but they are all pretty quick checks.

### To test locally
Part 1, the Speaker page:
- Run the project
- Go to /parties/ynmp-party:12522/
- You should see this content
<img width="878" alt="Screenshot 2023-04-26 at 14 34 45" src="https://user-images.githubusercontent.com/9531063/234592337-f8c513cd-ab69-4a68-b172-16aba1b01c7d.png">


Part 2, the Independent page:
- Go to /parties/ynmp-party:2/
- You should see this content
<img width="812" alt="Screenshot 2023-04-26 at 14 33 39" src="https://user-images.githubusercontent.com/9531063/234592017-b35ad726-21cb-49bc-9d41-5282c1c26019.png">

Part 3, deregistered party bug **and** past-tense registration text :
- Go to any deregistered party who has an emblem (e.g. `/parties/party:491/`)
- They should have `(Deregistered)` after their party name 
- The sentence below should read "This political party was deregistered on {deregistered date}, and can no longer field candidates" (note the past tense)
Example:
<img width="938" alt="Screenshot 2023-04-26 at 14 37 30" src="https://user-images.githubusercontent.com/9531063/234593088-446ac084-a8c4-4dd4-b185-1d14f09f3227.png">

Part 4, ballot descriptions including party name:
- Go to any party page who has descriptions 
- In the `Ballot descriptions` section, the text should now read "This party may appear on the ballot paper as "{party name}", or any of the following names:"
Example:
<img width="848" alt="Screenshot 2023-04-26 at 14 43 53" src="https://user-images.githubusercontent.com/9531063/234594865-f7921879-cbba-483e-af0f-bbcb186f3b1a.png">

Part 5, padding:
- Go to any party page who has an emblem
- In your browser's dev tools device toolbar, use a mobile view
- Confirm that the emblem isn't butted right up against the side of the screen 
- You may want to have a bit of a poke around the rest of the site too to make sure that nothing looks off. It's quite a broad change to the padding rule that will have a wide-ranging effect, but I didn't notice anything looking weird.
Example:
<img width="408" alt="Screenshot 2023-04-26 at 14 46 45" src="https://user-images.githubusercontent.com/9531063/234595580-178b5779-737e-4645-a554-47fbd37f525c.png">


```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] If any new text is added, it's internationalized
- [x] Did I use the clear and concise names for variables and functions?
- [x] Did I explain all possible solutions and why I chose the one I did?
- [x] Have I rebased with the latest version of master?
```
