### PR TITLE
Add vars for voter id and results messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,15 @@ For hustings edit https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wc
 
 Commit, PR, merge, deploy.
 
+If you want to show the GB voter ID messaging, set `SHOW_GB_ID_MESSAGING = True` in `settings/base.py`
+
+## Post-Election Tasks
+
+When we've got some results to show, you'll want to update `SHOW_RESULTS_CHART = True` in `settings/base.py`.
+You'll also need to grab the Flourish chart info and replace it in `/templates/home.html`. It should live inside the `{% if show_results_chart %}` block.
+
 ## Deployments
 
 Deployments are triggered by Circle CI. Take a look at `.circleci/config.yml` to see details of the deployment workflow.
 
 To increase the number of EC2 instances for an environment (e.g. during busy times around elections) increase the `min-size`, `max-size` and `desired-capacity` variables found in the `code_deploy` jobs in the `config.yml` file. For further details, see notes about scaling [scaling](/docs/troubleshooting.md#scaling).
-
-

--- a/local.example
+++ b/local.example
@@ -30,6 +30,9 @@ DEBUG = True
 
 EMAIL_SIGNUP_BACKEND = "local_db"
 
+# SHOW_GB_ID_MESSAGING = False
+# SHOW_RESULTS_CHART = False
+
 # These example paths should only be necessary for M1 Mac users
 
 # GDAL_LIBRARY_PATH = "/opt/homebrew/Cellar/gdal/3.5.1_3/lib/libgdal.dylib"

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -99,6 +99,12 @@ class HomePageView(PostcodeFormView):
         context["poll_date"] = "on Thursday 12 December"
         if polls_open < now and polls_close > now:
             context["poll_date"] = "today"
+        context["show_gb_id_messaging"] = getattr(
+            settings, "SHOW_GB_ID_MESSAGING", False
+        )
+        context["show_results_chart"] = getattr(
+            settings, "SHOW_RESULTS_CHART", False
+        )
 
         return context
 

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -173,6 +173,9 @@ USE_I18N = True
 
 USE_TZ = True
 
+# Homepage feature switches
+SHOW_GB_ID_MESSAGING = True
+SHOW_RESULTS_CHART = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/

--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -25,20 +25,27 @@
             </div>
         </div>
     </div>
-    <div class="ds-card">
-        <div class="ds-card-body ds-text-centered">
-            <h2>
-                <span aria-hidden="true">ℹ️</span>
-                {% trans "Photographic identification" %}
-            </h2>
-            <p>{% trans "Photographic identification will be required to vote in English local elections, and parliamentary elections across the UK, on and after 4 May 2023." %}</p>
-            <p><a href="https://www.electoralcommission.org.uk/i-am-a/voter/voter-id" aria-label="{% trans 'Learn more about photographic identification for voters on the website of the Electoral Commission.' %}">{% trans "Learn more on the website of the Electoral Commission." %}</a></p>
-
-            <p>{% trans "You can apply for a free 'Voter Authority Certificate' if you do not already possess a valid ID." %}</p>
-            <p><a href="https://www.gov.uk/apply-for-photo-id-voter-authority-certificate">{% trans "Apply for free voter ID." %}</a></p>
-            <p>{% trans "You do not need photo ID to vote by post." %}</p>
+    {% if show_results_chart %}
+        <div class="flourish-embed flourish-chart" data-src="visualisation/13653636">
+            <script src="https://public.flourish.studio/resources/embed.js"></script>
         </div>
-    </div>
+    {% endif %}
+    {% if show_gb_id_messaging %}
+        <div class="ds-card">
+            <div class="ds-card-body ds-text-centered">
+                <h2>
+                    <span aria-hidden="true">ℹ️</span>
+                    {% trans "Photographic identification" %}
+                </h2>
+                <p>{% trans "Photographic identification will be required to vote in English local elections, and parliamentary elections across the UK, on and after 4 May 2023." %}</p>
+                <p><a href="https://www.electoralcommission.org.uk/i-am-a/voter/voter-id" aria-label="{% trans 'Learn more about photographic identification for voters on the website of the Electoral Commission.' %}">{% trans "Learn more on the website of the Electoral Commission." %}</a></p>
+
+                <p>{% trans "You can apply for a free 'Voter Authority Certificate' if you do not already possess a valid ID." %}</p>
+                <p><a href="https://www.gov.uk/apply-for-photo-id-voter-authority-certificate">{% trans "Apply for free voter ID." %}</a></p>
+                <p>{% trans "You do not need photo ID to vote by post." %}</p>
+            </div>
+        </div>
+    {% endif %}
     {% if upcoming_elections %}
         <div class="ds-card">
             <div class="ds-card-body">


### PR DESCRIPTION
Now that the English elections are over, we want to hide the GB voter ID messaging. 

The changes look a bit bigger than they are because I ran djhtml on it.

I've implemented this as an env var feature switch so that it can easily be toggled on/off as and when we want to display that messaging. Homepage template has been updated to leverage this, and I've set it to `False` for now (with a default of `False` too). 

I've also added a feature switch for showing the results chart on the front page. I chose to do this over just temporarily changing the homepage content because it'll require less intervention. This is set to `True` for now because Peter has already sent me the Flourish embed.

<img width="931" alt="Screenshot 2023-05-05 at 12 11 23" src="https://user-images.githubusercontent.com/9531063/236444541-1bfdf08d-0f0e-4bf4-ac4d-ce342c81a0a5.png">

Docs have been updated to add instructions for both of these. They both play nicely together so if we're ever in a situation where we want both of these active at once they'll both show up. 

To test locally:
- Run the project
- The homepage shouldn't have any additional cards about ID messaging
- The homepage should have a (blank) chart
- Set `SHOW_GB_ID_MESSAGING` to `True` in your `local.py`
- Set `SHOW_RESULTS_CHART` to `False` in your `local.py`
- Reload the homepage
- You should see ID messaging
- You should not see the chart


```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Did I explain all possible solutions and why I chose the one I did?
- [x] Update any documentation
```
