### PR TITLE
Set ID feature switch to false

### DIFF
--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -174,7 +174,7 @@ USE_I18N = True
 USE_TZ = True
 
 # Homepage feature switches
-SHOW_GB_ID_MESSAGING = True
+SHOW_GB_ID_MESSAGING = False
 SHOW_RESULTS_CHART = True
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Had this set incorrectly in the previous PR. This fix will remove ID messaging form the homepage.
