### PR TITLE
Handle attribute error with division_suffix

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -326,7 +326,10 @@ class Post(models.Model):
         """
         Returns last word of the division_description
         """
-        return self.division_description.split(" ")[-1].lower()
+        description = self.division_description
+        if not description:
+            return ""
+        return description.split(" ")[-1].lower()
 
     @property
     def full_label(self):


### PR DESCRIPTION
Ref https://democracy-club-gp.sentry.io/issues/3801672829/?project=1426221&query=is%3Aunresolved&referrer=issue-stream&stream_index=8

Handles attribute errors when `division_suffix` does not exist.

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail

```

