### PR TITLE
Hotfix/handle non int types

### DIFF
--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -536,6 +536,13 @@ class PersonViewTests(TestCase):
         expected = f"{self.person.name} is a {local_party.label} candidate."
         self.assertContains(response, expected)
 
+    def test_person_detail_404_with_string_pk(self):
+        """
+        Regression test to ensure non-int person IDs raise a 404 not a 500
+        """
+        req = self.client.get("/person/partywebsite.org/")
+        self.assertEqual(req.status_code, 404)
+
 
 class TestPersonViewUnitTests:
     @pytest.fixture

--- a/wcivf/apps/people/urls.py
+++ b/wcivf/apps/people/urls.py
@@ -13,8 +13,8 @@ urlpatterns = [
         EmailPersonView.as_view(),
         name="email_person_view",
     ),
-    re_path(
-        r"^(?P<pk>[^/]+)/(?P<ignored_slug>.*)$",
+    path(
+        "<int:pk>/<slug:ignored_slug>",
         PersonView.as_view(),
         name="person_view",
     ),


### PR DESCRIPTION
Ref https://democracy-club-gp.sentry.io/issues/3931234028/?project=1426221&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=7

This change handles a `pk` when it's not an integer with the new url processor feature available in Django 4.2.
https://docs.djangoproject.com/en/4.2/topics/http/urls/#example