### PR TITLE
Revert upcoming_elections on home page

### DIFF
--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -86,7 +86,7 @@ class HomePageView(PostcodeFormView):
             .select_related("election", "post")
             .order_by("election__election_date")
         )
-
+        context["upcoming_elections"] = None
         polls_open = timezone.make_aware(
             datetime.datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
         )


### PR DESCRIPTION
Reverting this change until we have more time time discuss this issue
@pmk01 
> Trying to get my head around this. It looks to me as though some elections are on the front of WCIVF but don't work on a postcode search, while others work on a postcode search but aren't on the front of WCIVF (see eg GU16 6LU).
> The elections which aren't on the front of WCIVF are NOT by-elections, which is an old problem which has evidently resurfaced when we put the list back on the front page.



```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [ ] References a specific issue or if not, describes the bug or feature in detail
- [ ] Note what card in Trello this work relates to
- [ ] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [ ] Screenshot of the feature/bug fix (if applicable)
- [ ] If any new text is added, it's internationalized
- [ ] Any new elements have aria labels
- [ ] No unintentional console.logs left behind after debugging
- [ ] Did I use the clear and concise names for variables and functions?
- [ ] Did I explain all possible solutions and why I chose the one I did?
- [ ] Added any comments to make new functions clearer
- [ ] Did I added or updated any new dependencies? Explain why.
- [ ] Did I update the package.json and/or Pipfile.lock version if relevant?
- [ ] Have I rebased with the latest version of master?
- [ ] Added PR labels
- [ ] Update any history/changelog file
- [ ] Update any documentation
- [ ] Update dev handbook
```
