### PR TITLE
Display elections on home page

### DIFF
--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -86,7 +86,6 @@ class HomePageView(PostcodeFormView):
             .select_related("election", "post")
             .order_by("election__election_date")
         )
-        context["upcoming_elections"] = None
         polls_open = timezone.make_aware(
             datetime.datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
         )


### PR DESCRIPTION
Reverting [the revert](https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1622). Still, a small number of cases may be missing which needs further investigation. 

<img width="948" alt="Screenshot 2023-07-07 at 1 23 47 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/cc90818b-8cd4-4d18-8ede-162bab0d8043">
