### PR TITLE
Django upgrade 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
         environment:
           CIRCLECI: true
           PGHOST: 127.0.0.1
-      - image: cimg/postgres:11.17
+      - image: cimg/postgres:14.7
         environment:
           POSTGRES_USER: wcivf
           POSTGRES_DB: wcivf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,13 +148,6 @@ jobs:
           at: ~/repo/
       - run: echo <<parameters.instance-type>>
       - run:
-          name: install sam-cli
-          command: |
-            python -m venv .venv
-            . .venv/bin/activate
-            pip install --upgrade pip
-            pip install aws-sam-cli==1.91.0 awscli==1.29.5
-      - run:
           name: deploy
           command: |
             sam deploy \
@@ -179,6 +172,26 @@ jobs:
                    InstanceType='<<parameters.instance-type>>' \
                    Domain='<<parameters.domain>>'
                   "
+                  post_deploy_tests:
+  post_deploy_tests:
+    docker:
+      - image: cimg/python:3.10.4
+    working_directory: ~/repo
+    parameters:
+      dc-environment:
+        type: enum
+        enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: <<parameters.dc-environment>>
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v6-dependencies-{{ checksum "requirements/base.txt" }}-{{ checksum "requirements/testing.txt" }}
+      - attach_workspace:
+          at: ~/repo/
+      - run: printenv DC_ENVIRONMENT
+      - run: pip install awscli==1.29.5
       - run:
           name: post deploy tests
           command: |
@@ -267,7 +280,13 @@ workflows:
           - sam_build
           context: [ deployment-development-wcivf, slack-secrets ]
           filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
-
+      - post_deploy_tests:
+          name: post_deploy_tests_development
+          dc-environment: development
+          requires:
+            - sam_deploy_development
+          context: [ deployment-development-wcivf, slack-secrets ]
+          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
       - code_deploy:
           name: code_deploy_development
           dc-environment: development
@@ -275,12 +294,9 @@ workflows:
           max-size: 1
           desired-capacity: 1
           requires:
-          - build_and_test
-          - sam_build
-          - sam_deploy_development
+          - post_deploy_tests_development
           context: [ deployment-development-wcivf, slack-secrets ]
           filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
-
       - sam_deploy:
           name: sam_deploy_staging
           dc-environment: staging
@@ -295,7 +311,13 @@ workflows:
           - sam_build
           context: [ deployment-staging-wcivf, slack-secrets  ]
           filters: { branches: { only: [ main, master, staging ] } }
-
+      - post_deploy_tests:
+          name: post_deploy_tests_staging
+          dc-environment: staging
+          requires:
+            - sam_deploy_staging
+          context: [ deployment-staging-wcivf, slack-secrets ]
+          filters: { branches: { only: [ main, master, staging ] } }
       - code_deploy:
           name: code_deploy_staging
           dc-environment: staging
@@ -307,7 +329,6 @@ workflows:
           - sam_deploy_staging
           context: [ deployment-staging-wcivf, slack-secrets ]
           filters: { branches: { only: [ main, master, staging ] } }
-        
       - sam_deploy:
           name: sam_deploy_production
           dc-environment: production
@@ -323,13 +344,19 @@ workflows:
           - code_deploy_staging
           context: [ deployment-production-wcivf, slack-secrets  ]
           filters: { branches: { only: [ main, master ] } }
-
+      - post_deploy_tests:
+          name: post_deploy_tests_production
+          dc-environment: production
+          requires:
+            - sam_deploy_production
+          context: [ deployment-production-wcivf, slack-secrets ]
+          filters: { branches: { only: [ main, master, staging ] } }
       - code_deploy:
           name: code_deploy_production
           dc-environment: production
           min-size: 1
           max-size: 20
-          desired-capacity: 3
+          desired-capacity: 1
           requires:
           - build_and_test
           - sam_deploy_staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
             python -m venv .venv
             . .venv/bin/activate
             pip install --upgrade pip
-            pip install aws-sam-cli==1.89.0 awscli==1.28.0
+            pip install aws-sam-cli==1.91.0 awscli==1.29.5
             make build clean
       - persist_to_workspace:
           root: ~/repo/
@@ -157,7 +157,7 @@ jobs:
             python -m venv .venv
             . .venv/bin/activate
             pip install --upgrade pip
-            pip install aws-sam-cli==1.89.0 awscli==1.28.0
+            pip install aws-sam-cli==1.91.0 awscli==1.29.5
       - run:
           name: deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,10 +114,6 @@ jobs:
       - run:
           name: sam build
           command: |
-            python -m venv .venv
-            . .venv/bin/activate
-            pip install --upgrade pip
-            pip install aws-sam-cli==1.91.0 awscli==1.29.5
             make build clean
       - persist_to_workspace:
           root: ~/repo/
@@ -125,7 +121,7 @@ jobs:
 
   sam_deploy:
     docker:
-      - image: cimg/python:3.10.4
+      - image: public.ecr.aws/sam/build-python3.10:latest
     working_directory: ~/repo
     parameters:
       dc-environment:
@@ -161,7 +157,6 @@ jobs:
       - run:
           name: deploy
           command: |
-            . .venv/bin/activate
             sam deploy \
                 --no-confirm-changeset \
                 --config-file ~/repo/samconfig.toml \
@@ -271,7 +266,7 @@ workflows:
           - build_and_test
           - sam_build
           context: [ deployment-development-wcivf, slack-secrets ]
-          filters: { branches: { only: [ main, master, staging ] } }
+          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
 
       - code_deploy:
           name: code_deploy_development
@@ -284,7 +279,7 @@ workflows:
           - sam_build
           - sam_deploy_development
           context: [ deployment-development-wcivf, slack-secrets ]
-          filters: { branches: { only: [ main, master, staging ] } }
+          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
 
       - sam_deploy:
           name: sam_deploy_staging

--- a/deploy/create_deployment_group.py
+++ b/deploy/create_deployment_group.py
@@ -143,7 +143,6 @@ def create_deployment_group():
             deploymentGroupName=deployment_group_name,
         )
     except client.exceptions.DeploymentGroupDoesNotExistException:
-
         return client.create_deployment_group(
             applicationName=app_name,
             deploymentGroupName=deployment_group_name,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-localflavor==3.1
 django-extensions==3.2.3
 djangorestframework==3.14.0
 django-redis==5.2.0
-hiredis==2.1.1
+hiredis==2.2.3
 redis==4.6.0
 Pillow==9.5.0
 icalendar==5.0.7

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ requests==2.31.0
 django-filter==23.2
 django-model-utils==4.3.1
 Markdown==3.4.1
-django-localflavor==3.1
+django-localflavor==4.0
 django-extensions==3.2.3
 djangorestframework==3.14.0
 django-redis==5.3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,6 @@ djangorestframework==3.14.0
 django-redis==5.3.0
 hiredis==2.2.3
 redis==4.6.0
-Pillow==9.5.0
 icalendar==5.0.7
 dealer==2.1.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ Pillow==9.5.0
 icalendar==5.0.7
 dealer==2.1.0
 
-https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.1.7.tar.gz
+https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.2.0.tar.gz
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
 https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.6.tar.gz
 git+https://github.com/DemocracyClub/dc_logging.git@0.0.9

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ git+https://github.com/DemocracyClub/dc_logging.git@0.0.9
 djangorestframework-jsonp==1.0.2
 feedparser==6.0.10
 
-sentry-sdk==1.27.0
+sentry-sdk==1.27.1
 uk-election-timetables==2.4.0
 django-dotenv==1.4.2
 python-akismet==0.4.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ psycopg2-binary==2.9.6
 requests==2.31.0
 django-filter==23.2
 django-model-utils==4.3.1
-Markdown==3.4.1
+Markdown==3.4.3
 django-localflavor==4.0
 django-extensions==3.2.3
 djangorestframework==3.14.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ botocore==1.30.0
 boto3==1.27.0
 psycopg2-binary==2.9.6
 requests==2.31.0
-django-filter==22.1
+django-filter==23.2
 django-model-utils==4.3.1
 Markdown==3.4.1
 django-localflavor==3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ dealer==2.1.0
 
 https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.2.0.tar.gz
 https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.1.6.tar.gz
+https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.3.0.tar.gz
 git+https://github.com/DemocracyClub/dc_logging.git@0.0.9
 
 djangorestframework-jsonp==1.0.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,4 @@
-Django==4.1.10
-
+Django==4.2.3
 botocore==1.30.0
 boto3==1.27.0
 psycopg2-binary==2.9.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ Markdown==3.4.1
 django-localflavor==3.1
 django-extensions==3.2.3
 djangorestframework==3.14.0
-django-redis==5.2.0
+django-redis==5.3.0
 hiredis==2.2.3
 redis==4.6.0
 Pillow==9.5.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 Django==4.2.3
-botocore==1.30.0
-boto3==1.27.0
+botocore>=1.31.4
+boto3==1.28.5
 psycopg2-binary==2.9.6
 requests==2.31.0
 django-filter==23.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-black==22.12.0
+black==23.7.0
 
 pytest
 pytest-django

--- a/wcivf/apps/core/db_routers.py
+++ b/wcivf/apps/core/db_routers.py
@@ -1,5 +1,4 @@
 class LoggerRouter(object):
-
     apps_that_use_logger = ["core", "feedback", "notifications"]
 
     def db_for_read(self, model, **hints):

--- a/wcivf/apps/core/management/commands/init_data.py
+++ b/wcivf/apps/core/management/commands/init_data.py
@@ -23,7 +23,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-
         if options["full"]:
             commands = [
                 ("import_parties",),

--- a/wcivf/apps/core/migrations/0001_initial.py
+++ b/wcivf/apps/core/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/wcivf/apps/core/migrations/0002_auto_20170526_1448.py
+++ b/wcivf/apps/core/migrations/0002_auto_20170526_1448.py
@@ -15,7 +15,6 @@ def add_site(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("core", "0001_initial"), ("sites", "0001_initial")]
 
     operations = [migrations.RunPython(add_site)]

--- a/wcivf/apps/core/migrations/0003_auto_20210225_1103.py
+++ b/wcivf/apps/core/migrations/0003_auto_20210225_1103.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0002_auto_20170526_1448"),
     ]

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -15,7 +15,6 @@ from .forms import PostcodeLookupForm
 
 class TranslatedTemplateView(TemplateView):
     def get_template_names(self):
-
         templates = super().get_template_names()
         base_template_name, ext = self.template_name.rsplit(".", 1)
         current_language = translation.get_language()
@@ -132,7 +131,6 @@ class StatusCheckView(View):
         return False
 
     def get(self, request, *args, **kwargs):
-
         status = 503
 
         data = {"ready_to_serve": False}

--- a/wcivf/apps/elections/helpers.py
+++ b/wcivf/apps/elections/helpers.py
@@ -13,7 +13,6 @@ import requests
 
 
 class EEHelper:
-
     ee_cache = {}
 
     @property

--- a/wcivf/apps/elections/migrations/0001_initial.py
+++ b/wcivf/apps/elections/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/wcivf/apps/elections/migrations/0002_auto_20160323_1533.py
+++ b/wcivf/apps/elections/migrations/0002_auto_20160323_1533.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0003_post.py
+++ b/wcivf/apps/elections/migrations/0003_post.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0002_auto_20160323_1533")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0004_auto_20160326_1038.py
+++ b/wcivf/apps/elections/migrations/0004_auto_20160326_1038.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0003_post")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0005_election_election_type.py
+++ b/wcivf/apps/elections/migrations/0005_election_election_type.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0004_auto_20160326_1038")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0006_votingsystem_uses_lists.py
+++ b/wcivf/apps/elections/migrations/0006_votingsystem_uses_lists.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0005_election_election_type")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0007_auto_20160405_0857.py
+++ b/wcivf/apps/elections/migrations/0007_auto_20160405_0857.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0006_votingsystem_uses_lists")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0008_auto_20160405_1412.py
+++ b/wcivf/apps/elections/migrations/0008_auto_20160405_1412.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0007_auto_20160405_0857")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0009_election_for_post_role.py
+++ b/wcivf/apps/elections/migrations/0009_election_for_post_role.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0008_auto_20160405_1412")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0010_auto_20160502_1542.py
+++ b/wcivf/apps/elections/migrations/0010_auto_20160502_1542.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0009_election_for_post_role")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0011_auto_20170303_1823.py
+++ b/wcivf/apps/elections/migrations/0011_auto_20170303_1823.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0010_auto_20160502_1542")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0012_auto_20170304_1351.py
+++ b/wcivf/apps/elections/migrations/0012_auto_20170304_1351.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0011_auto_20170303_1823")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0013_auto_20170304_1354.py
+++ b/wcivf/apps/elections/migrations/0013_auto_20170304_1354.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0012_auto_20170304_1351")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0014_remove_post_elections.py
+++ b/wcivf/apps/elections/migrations/0014_remove_post_elections.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0013_auto_20170304_1354")]
 
     operations = [migrations.RemoveField(model_name="post", name="elections")]

--- a/wcivf/apps/elections/migrations/0015_auto_20170304_1354.py
+++ b/wcivf/apps/elections/migrations/0015_auto_20170304_1354.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0014_remove_post_elections")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0016_postelection_contested.py
+++ b/wcivf/apps/elections/migrations/0016_postelection_contested.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0015_auto_20170304_1354")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0017_parl-2017-06-08-weight.py
+++ b/wcivf/apps/elections/migrations/0017_parl-2017-06-08-weight.py
@@ -11,7 +11,6 @@ def change_weight(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0016_postelection_contested")]
 
     operations = [migrations.RunPython(change_weight)]

--- a/wcivf/apps/elections/migrations/0018_postelection_locked.py
+++ b/wcivf/apps/elections/migrations/0018_postelection_locked.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0017_parl-2017-06-08-weight")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0019_election_metadata.py
+++ b/wcivf/apps/elections/migrations/0019_election_metadata.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0018_postelection_locked")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0020_postelection_ballot_paper_id.py
+++ b/wcivf/apps/elections/migrations/0020_postelection_ballot_paper_id.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0019_election_metadata")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0021_postelection_winner_count.py
+++ b/wcivf/apps/elections/migrations/0021_postelection_winner_count.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0020_postelection_ballot_paper_id")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0022_auto_20181031_1603.py
+++ b/wcivf/apps/elections/migrations/0022_auto_20181031_1603.py
@@ -8,7 +8,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0021_postelection_winner_count")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0023_election_any_non_by_elections.py
+++ b/wcivf/apps/elections/migrations/0023_election_any_non_by_elections.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0022_auto_20181031_1603")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0024_default_for_has_by_elections.py
+++ b/wcivf/apps/elections/migrations/0024_default_for_has_by_elections.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0023_election_any_non_by_elections")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0025_auto_20190412_1528.py
+++ b/wcivf/apps/elections/migrations/0025_auto_20190412_1528.py
@@ -54,7 +54,6 @@ def delete_voting_systems(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0024_default_for_has_by_elections")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0026_postelection_voting_system.py
+++ b/wcivf/apps/elections/migrations/0026_postelection_voting_system.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0025_auto_20190412_1528")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0027_unique_on_ballot_id.py
+++ b/wcivf/apps/elections/migrations/0027_unique_on_ballot_id.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0026_postelection_voting_system")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0028_add_territory_to_posts.py
+++ b/wcivf/apps/elections/migrations/0028_add_territory_to_posts.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0027_unique_on_ballot_id")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0029_wikipedia_on_ballot.py
+++ b/wcivf/apps/elections/migrations/0029_wikipedia_on_ballot.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0028_add_territory_to_posts")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0030_post_organization_type.py
+++ b/wcivf/apps/elections/migrations/0030_post_organization_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0029_wikipedia_on_ballot")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0031_post_division_type.py
+++ b/wcivf/apps/elections/migrations/0031_post_division_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0030_post_organization_type"),
     ]

--- a/wcivf/apps/elections/migrations/0032_auto_20210210_1155.py
+++ b/wcivf/apps/elections/migrations/0032_auto_20210210_1155.py
@@ -9,7 +9,6 @@ def forwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0031_post_division_type"),
     ]

--- a/wcivf/apps/elections/migrations/0033_auto_20210210_1422.py
+++ b/wcivf/apps/elections/migrations/0033_auto_20210210_1422.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0032_auto_20210210_1155"),
     ]

--- a/wcivf/apps/elections/migrations/0034_update_ordering.py
+++ b/wcivf/apps/elections/migrations/0034_update_ordering.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0033_auto_20210210_1422"),
     ]

--- a/wcivf/apps/elections/migrations/0035_auto_20210928_1303.py
+++ b/wcivf/apps/elections/migrations/0035_auto_20210928_1303.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0034_update_ordering"),
     ]

--- a/wcivf/apps/elections/migrations/0036_add_timestamps.py
+++ b/wcivf/apps/elections/migrations/0036_add_timestamps.py
@@ -6,7 +6,6 @@ import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0035_auto_20210928_1303"),
     ]

--- a/wcivf/apps/elections/migrations/0037_dummypostelection.py
+++ b/wcivf/apps/elections/migrations/0037_dummypostelection.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0036_add_timestamps"),
     ]

--- a/wcivf/apps/elections/migrations/0038_default_winner_count.py
+++ b/wcivf/apps/elections/migrations/0038_default_winner_count.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0037_dummypostelection"),
     ]

--- a/wcivf/apps/elections/migrations/0039_remove_historic_metadata.py
+++ b/wcivf/apps/elections/migrations/0039_remove_historic_metadata.py
@@ -11,7 +11,6 @@ def remove_historical_metadata(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0038_default_winner_count")]
 
     operations = [

--- a/wcivf/apps/elections/migrations/0040_postelection_requires_voter_id.py
+++ b/wcivf/apps/elections/migrations/0040_postelection_requires_voter_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0039_remove_historic_metadata"),
     ]

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -136,7 +136,6 @@ class Election(models.Model):
 
     @property
     def nice_election_name(self):
-
         name = self.name
         if not self.any_non_by_elections:
             name = name.replace("elections", "")

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -583,7 +583,6 @@ class TestPostElectionsToPeopleMixin(TestCase):
 
 
 class TestPostelectionsToPeopleMixin(TestCase):
-
     # should be updated as more queries are added
     PERSON_POST_QUERY = 1
     PLEDGE_QUERY = 1

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -306,7 +306,6 @@ class TestYNRBallotImporter:
                 assert importer.import_url == expected
 
     def test_add_replaced_ballot(self, importer, mocker, subtests):
-
         ballot = mocker.Mock()
         test_cases = [
             {

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -381,7 +381,6 @@ class TestPostElectionModel:
 
     @pytest.mark.freeze_time("2021-04-09")
     def test_past_expected_sopn_day(self, post_election, mocker, subtests):
-
         dates = [
             (timezone.datetime(2021, 4, 14).date(), False),
             (timezone.datetime(2021, 1, 1).date(), True),

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -215,7 +215,6 @@ class PostcodeView(
 class PostcodeiCalView(
     NewSlugsRedirectMixin, PostcodeToPostsMixin, View, PollingStationInfoMixin
 ):
-
     pk_url_kwarg = "postcode"
 
     def get(self, request, *args, **kwargs):

--- a/wcivf/apps/feedback/migrations/0001_initial.py
+++ b/wcivf/apps/feedback/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/wcivf/apps/feedback/migrations/0002_feedback_token.py
+++ b/wcivf/apps/feedback/migrations/0002_feedback_token.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("feedback", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/feedback/migrations/0003_auto_20210225_1103.py
+++ b/wcivf/apps/feedback/migrations/0003_auto_20210225_1103.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("feedback", "0002_feedback_token"),
     ]

--- a/wcivf/apps/feedback/migrations/0004_feedback_sources.py
+++ b/wcivf/apps/feedback/migrations/0004_feedback_sources.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("feedback", "0003_auto_20210225_1103"),
     ]

--- a/wcivf/apps/feedback/migrations/0005_feedback_vote.py
+++ b/wcivf/apps/feedback/migrations/0005_feedback_vote.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("feedback", "0004_feedback_sources"),
     ]

--- a/wcivf/apps/feedback/migrations/0006_feedback_flagged_as_spam.py
+++ b/wcivf/apps/feedback/migrations/0006_feedback_flagged_as_spam.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("feedback", "0005_feedback_vote"),
     ]

--- a/wcivf/apps/feedback/views.py
+++ b/wcivf/apps/feedback/views.py
@@ -36,7 +36,6 @@ class FeedbackFormView(UpdateView):
             return Feedback(token=token)
 
     def get_success_url(self):
-
         messages.success(
             self.request,
             render_to_string(

--- a/wcivf/apps/hustings/management/commands/import_hustings.py
+++ b/wcivf/apps/hustings/management/commands/import_hustings.py
@@ -56,7 +56,6 @@ def set_time_string_on_datetime(dt, time_string):
 
 
 class Command(BaseCommand):
-
     URLS = [
         # NI
         "https://docs.google.com/spreadsheets/d/e/2PACX-1vTnQcyfJHIDBhtJuuxQShQ0rjWKfv-zNW_fa0OyxQf3md4BHEwmwHmprRe-IOJYfIY8ZkKweY039F74/pub?gid=1940364340&single=true&output=csv",

--- a/wcivf/apps/hustings/migrations/0001_initial.py
+++ b/wcivf/apps/hustings/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("elections", "0016_postelection_contested")]

--- a/wcivf/apps/hustings/migrations/0002_auto_20170601_2155.py
+++ b/wcivf/apps/hustings/migrations/0002_auto_20170601_2155.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("hustings", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/hustings/migrations/0003_husting_video_url.py
+++ b/wcivf/apps/hustings/migrations/0003_husting_video_url.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("hustings", "0002_auto_20170601_2155")]
 
     operations = [

--- a/wcivf/apps/hustings/migrations/0004_auto_20170602_1031.py
+++ b/wcivf/apps/hustings/migrations/0004_auto_20170602_1031.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("hustings", "0003_husting_video_url")]
 
     operations = [

--- a/wcivf/apps/hustings/migrations/0005_auto_20210326_1111.py
+++ b/wcivf/apps/hustings/migrations/0005_auto_20210326_1111.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0004_auto_20170602_1031"),
     ]

--- a/wcivf/apps/hustings/migrations/0006_increase_url_max_length.py
+++ b/wcivf/apps/hustings/migrations/0006_increase_url_max_length.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0005_auto_20210326_1111"),
     ]

--- a/wcivf/apps/hustings/migrations/0007_auto_20210419_1539.py
+++ b/wcivf/apps/hustings/migrations/0007_auto_20210419_1539.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0006_increase_url_max_length"),
     ]

--- a/wcivf/apps/hustings/migrations/0008_url_max_length.py
+++ b/wcivf/apps/hustings/migrations/0008_url_max_length.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0007_auto_20210419_1539"),
     ]

--- a/wcivf/apps/hustings/migrations/0009_remove_postcode_amend_location.py
+++ b/wcivf/apps/hustings/migrations/0009_remove_postcode_amend_location.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0008_url_max_length"),
     ]

--- a/wcivf/apps/hustings/migrations/0010_husting_created_husting_modified.py
+++ b/wcivf/apps/hustings/migrations/0010_husting_created_husting_modified.py
@@ -6,7 +6,6 @@ import model_utils.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("hustings", "0009_remove_postcode_amend_location"),
     ]

--- a/wcivf/apps/hustings/tests/test_hustings.py
+++ b/wcivf/apps/hustings/tests/test_hustings.py
@@ -38,7 +38,6 @@ class TestHustings(TestCase):
     @freeze_time("2017-3-22")
     @vcr.use_cassette("fixtures/vcr_cassettes/test_mayor_elections.yaml")
     def test_hustings_display_on_postcode_page(self):
-
         response = self.client.get("/elections/e32nx", follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.hust.title)

--- a/wcivf/apps/leaflets/management/commands/import_leaflets.py
+++ b/wcivf/apps/leaflets/management/commands/import_leaflets.py
@@ -79,7 +79,6 @@ class Command(BaseCommand):
 
     def add_leaflets(self, results):
         for leaflet in results:
-
             if not "people" in leaflet:
                 continue
             for person_data in leaflet["people"]:

--- a/wcivf/apps/leaflets/migrations/0001_initial.py
+++ b/wcivf/apps/leaflets/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("people", "0019_associatedcompany")]

--- a/wcivf/apps/leaflets/migrations/0002_auto_20210603_0922.py
+++ b/wcivf/apps/leaflets/migrations/0002_auto_20210603_0922.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("leaflets", "0001_initial"),
     ]

--- a/wcivf/apps/news_mentions/migrations/0001_initial.py
+++ b/wcivf/apps/news_mentions/migrations/0001_initial.py
@@ -6,7 +6,6 @@ import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("elections", "0028_add_territory_to_posts")]

--- a/wcivf/apps/news_mentions/migrations/0002_ballotnewsarticle_publisher.py
+++ b/wcivf/apps/news_mentions/migrations/0002_ballotnewsarticle_publisher.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("news_mentions", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/news_mentions/migrations/0003_auto_20210225_1103.py
+++ b/wcivf/apps/news_mentions/migrations/0003_auto_20210225_1103.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("news_mentions", "0002_ballotnewsarticle_publisher"),
     ]

--- a/wcivf/apps/parishes/management/commands/import_parish_council_elections.py
+++ b/wcivf/apps/parishes/management/commands/import_parish_council_elections.py
@@ -4,7 +4,6 @@ from parishes.importers import ParishCouncilElectionImporter
 
 
 class Command(BaseCommand):
-
     URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTbfedaTDoTT3UcJOcOJHojISaSb06yzjFNvTiIUxHd7oWsN0wqFNqHXoklcTeK2G7aoUUH9NHvWy0q/pub?gid=756401424&single=true&output=csv"
 
     def handle(self, **options):

--- a/wcivf/apps/parishes/migrations/0001_initial.py
+++ b/wcivf/apps/parishes/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/wcivf/apps/parishes/migrations/0002_alter_parishcouncilelection_is_contested.py
+++ b/wcivf/apps/parishes/migrations/0002_alter_parishcouncilelection_is_contested.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parishes", "0001_initial"),
     ]

--- a/wcivf/apps/parties/importers.py
+++ b/wcivf/apps/parties/importers.py
@@ -11,7 +11,6 @@ LocalElection = namedtuple("LocalElection", ["date", "csv_files"])
 
 
 class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
-
     # TODO check if this need updating
     JOINT_PARTIES = [["party:53", "joint-party:53-119"]]
 
@@ -228,7 +227,6 @@ class LocalPartyImporter(ReadFromUrlMixin, ReadFromFileMixin):
         language = row.get("Manifesto Language", "English").strip()
         easy_read_url = row.get("Manifesto Easy Read PDF", "").strip()
         if any([manifesto_web, manifesto_pdf]):
-
             defaults = {
                 "web_url": manifesto_web,
                 "pdf_url": manifesto_pdf,

--- a/wcivf/apps/parties/management/commands/import_euro_parl_parties.py
+++ b/wcivf/apps/parties/management/commands/import_euro_parl_parties.py
@@ -95,7 +95,6 @@ class Command(BaseCommand):
             )
 
     def add_manifesto(self, row, party):
-
         manifesto_web = row["EP2019 manifesto/info webpage"].strip()
         manifesto_pdf = row["EP2019 manifesto PDF"].strip()
         if any([manifesto_web, manifesto_pdf]):

--- a/wcivf/apps/parties/management/commands/import_parties.py
+++ b/wcivf/apps/parties/management/commands/import_parties.py
@@ -8,7 +8,6 @@ from parties.models import Party
 
 class Command(BaseCommand):
     def handle(self, **options):
-
         next_page = settings.YNR_BASE + "/api/next/parties/?page_size=200"
         while next_page:
             req = requests.get(next_page)

--- a/wcivf/apps/parties/migrations/0001_initial.py
+++ b/wcivf/apps/parties/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/wcivf/apps/parties/migrations/0002_auto_20160412_1739.py
+++ b/wcivf/apps/parties/migrations/0002_auto_20160412_1739.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/parties/migrations/0003_auto_20160422_1148.py
+++ b/wcivf/apps/parties/migrations/0003_auto_20160422_1148.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0002_auto_20160412_1739")]
 
     operations = [

--- a/wcivf/apps/parties/migrations/0004_auto_20170530_1520.py
+++ b/wcivf/apps/parties/migrations/0004_auto_20170530_1520.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0016_postelection_contested"),
         ("parties", "0003_auto_20160422_1148"),

--- a/wcivf/apps/parties/migrations/0005_auto_20170530_1736.py
+++ b/wcivf/apps/parties/migrations/0005_auto_20170530_1736.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0004_auto_20170530_1520")]
 
     operations = [

--- a/wcivf/apps/parties/migrations/0006_auto_20180417_1711.py
+++ b/wcivf/apps/parties/migrations/0006_auto_20180417_1711.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0020_postelection_ballot_paper_id"),
         ("parties", "0005_auto_20170530_1736"),

--- a/wcivf/apps/parties/migrations/0007_auto_20180417_1733.py
+++ b/wcivf/apps/parties/migrations/0007_auto_20180417_1733.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0020_postelection_ballot_paper_id"),
         ("parties", "0006_auto_20180417_1711"),

--- a/wcivf/apps/parties/migrations/0008_auto_20180422_1248.py
+++ b/wcivf/apps/parties/migrations/0008_auto_20180422_1248.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0007_auto_20180417_1733")]
 
     operations = [

--- a/wcivf/apps/parties/migrations/0009_manifesto_easy_read_url.py
+++ b/wcivf/apps/parties/migrations/0009_manifesto_easy_read_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0008_auto_20180422_1248")]
 
     operations = [

--- a/wcivf/apps/parties/migrations/0010_localparty_is_local.py
+++ b/wcivf/apps/parties/migrations/0010_localparty_is_local.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0009_manifesto_easy_read_url"),
     ]

--- a/wcivf/apps/parties/migrations/0011_replace_emblem_with_emblem_url.py
+++ b/wcivf/apps/parties/migrations/0011_replace_emblem_with_emblem_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0010_localparty_is_local"),
     ]

--- a/wcivf/apps/parties/migrations/0012_add_youtube_and_contact_url.py
+++ b/wcivf/apps/parties/migrations/0012_add_youtube_and_contact_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0011_replace_emblem_with_emblem_url"),
     ]

--- a/wcivf/apps/parties/migrations/0013_add_file_url.py
+++ b/wcivf/apps/parties/migrations/0013_add_file_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0012_add_youtube_and_contact_url"),
     ]

--- a/wcivf/apps/parties/migrations/0014_localparty_created_localparty_modified.py
+++ b/wcivf/apps/parties/migrations/0014_localparty_created_localparty_modified.py
@@ -6,7 +6,6 @@ import model_utils.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0013_add_file_url"),
     ]

--- a/wcivf/apps/parties/migrations/0015_party_date_deregistered_party_date_registered_and_more.py
+++ b/wcivf/apps/parties/migrations/0015_party_date_deregistered_party_date_registered_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0014_localparty_created_localparty_modified"),
     ]

--- a/wcivf/apps/parties/migrations/0016_partydescription.py
+++ b/wcivf/apps/parties/migrations/0016_partydescription.py
@@ -7,7 +7,6 @@ import model_utils.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         (
             "parties",

--- a/wcivf/apps/parties/migrations/0017_partyemblem.py
+++ b/wcivf/apps/parties/migrations/0017_partyemblem.py
@@ -7,7 +7,6 @@ import model_utils.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0016_partydescription"),
     ]

--- a/wcivf/apps/parties/migrations/0018_alter_partydescription_options.py
+++ b/wcivf/apps/parties/migrations/0018_alter_partydescription_options.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0017_partyemblem"),
     ]

--- a/wcivf/apps/parties/migrations/0019_alter_partydescription_options_and_more.py
+++ b/wcivf/apps/parties/migrations/0019_alter_partydescription_options_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0018_alter_partydescription_options"),
     ]

--- a/wcivf/apps/parties/migrations/0020_party_alternative_name.py
+++ b/wcivf/apps/parties/migrations/0020_party_alternative_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0019_alter_partydescription_options_and_more"),
     ]

--- a/wcivf/apps/parties/tests/factories.py
+++ b/wcivf/apps/parties/tests/factories.py
@@ -14,7 +14,6 @@ class PartyFactory(factory.django.DjangoModelFactory):
 
 
 class LocalPartyFactory(factory.django.DjangoModelFactory):
-
     parent = factory.SubFactory(PartyFactory)
     post_election = factory.SubFactory(PostElectionFactory)
 

--- a/wcivf/apps/people/management/commands/import_wikipedia_bios.py
+++ b/wcivf/apps/people/management/commands/import_wikipedia_bios.py
@@ -17,7 +17,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, **options):
-
         people = Person.objects.exclude(wikipedia_url=None)
         if options["current"]:
             current_candidacies = PersonPost.objects.current()

--- a/wcivf/apps/people/managers.py
+++ b/wcivf/apps/people/managers.py
@@ -94,7 +94,6 @@ class PersonPostManager(models.Manager):
 
 class PersonManager(models.Manager):
     def update_or_create_from_ynr(self, person):
-
         last_updated = parse_datetime(person["last_updated"])
 
         sort_name = person.get("sort_name")

--- a/wcivf/apps/people/migrations/0001_initial.py
+++ b/wcivf/apps/people/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("elections", "0007_auto_20160405_0857")]

--- a/wcivf/apps/people/migrations/0002_auto_20160412_1739.py
+++ b/wcivf/apps/people/migrations/0002_auto_20160412_1739.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0002_auto_20160412_1739"),
         ("people", "0001_initial"),

--- a/wcivf/apps/people/migrations/0003_auto_20160414_0704.py
+++ b/wcivf/apps/people/migrations/0003_auto_20160414_0704.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0002_auto_20160412_1739")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0004_auto_20160414_0927.py
+++ b/wcivf/apps/people/migrations/0004_auto_20160414_0927.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0003_auto_20160414_0704")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0005_person_wikipedia_bio.py
+++ b/wcivf/apps/people/migrations/0005_person_wikipedia_bio.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0004_auto_20160414_0927")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0006_personpost_party.py
+++ b/wcivf/apps/people/migrations/0006_personpost_party.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0002_auto_20160412_1739"),
         ("people", "0005_person_wikipedia_bio"),

--- a/wcivf/apps/people/migrations/0007_personpost_election.py
+++ b/wcivf/apps/people/migrations/0007_personpost_election.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0009_election_for_post_role"),
         ("people", "0006_personpost_party"),

--- a/wcivf/apps/people/migrations/0008_remove_person_party.py
+++ b/wcivf/apps/people/migrations/0008_remove_person_party.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0007_personpost_election")]
 
     operations = [migrations.RemoveField(model_name="person", name="party")]

--- a/wcivf/apps/people/migrations/0009_auto_20170303_1823.py
+++ b/wcivf/apps/people/migrations/0009_auto_20170303_1823.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0008_remove_person_party")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0010_auto_20170306_1206.py
+++ b/wcivf/apps/people/migrations/0010_auto_20170306_1206.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0015_auto_20170304_1354"),
         ("people", "0009_auto_20170303_1823"),

--- a/wcivf/apps/people/migrations/0011_person_statement_to_voters.py
+++ b/wcivf/apps/people/migrations/0011_person_statement_to_voters.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0010_auto_20170306_1206")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0012_auto_20170515_1641.py
+++ b/wcivf/apps/people/migrations/0012_auto_20170515_1641.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0011_person_statement_to_voters")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0013_auto_20170515_2047.py
+++ b/wcivf/apps/people/migrations/0013_auto_20170515_2047.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0012_auto_20170515_1641")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0014_auto_20170518_1009.py
+++ b/wcivf/apps/people/migrations/0014_auto_20170518_1009.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0013_auto_20170515_2047")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0015_auto_20170518_1015.py
+++ b/wcivf/apps/people/migrations/0015_auto_20170518_1015.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0014_auto_20170518_1009")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0016_auto_20170518_1028.py
+++ b/wcivf/apps/people/migrations/0016_auto_20170518_1028.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0015_auto_20170518_1015")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0017_auto_20170518_1158.py
+++ b/wcivf/apps/people/migrations/0017_auto_20170518_1158.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0016_auto_20170518_1028")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0018_auto_20170518_1255.py
+++ b/wcivf/apps/people/migrations/0018_auto_20170518_1255.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0017_auto_20170518_1158")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0019_associatedcompany.py
+++ b/wcivf/apps/people/migrations/0019_associatedcompany.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0018_auto_20170518_1255")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0020_person_favourite_biscuit.py
+++ b/wcivf/apps/people/migrations/0020_person_favourite_biscuit.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0019_associatedcompany")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0021_person_twfy_id.py
+++ b/wcivf/apps/people/migrations/0021_person_twfy_id.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0020_person_favourite_biscuit")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0022_auto_20170605_1425.py
+++ b/wcivf/apps/people/migrations/0022_auto_20170605_1425.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0021_person_twfy_id")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0023_auto_20170605_1559.py
+++ b/wcivf/apps/people/migrations/0023_auto_20170605_1559.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0022_auto_20170605_1425")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0024_personpost_elected.py
+++ b/wcivf/apps/people/migrations/0024_personpost_elected.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0023_auto_20170605_1559")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0025_personpost_post_election.py
+++ b/wcivf/apps/people/migrations/0025_personpost_post_election.py
@@ -23,7 +23,6 @@ def add_post_election(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0020_postelection_ballot_paper_id"),
         ("people", "0024_personpost_elected"),

--- a/wcivf/apps/people/migrations/0026_auto_20180417_1944.py
+++ b/wcivf/apps/people/migrations/0026_auto_20180417_1944.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0025_personpost_post_election")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0027_person_party_ppc_page_url.py
+++ b/wcivf/apps/people/migrations/0027_person_party_ppc_page_url.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0026_auto_20180417_1944")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0028_person_pk_to_int.py
+++ b/wcivf/apps/people/migrations/0028_person_pk_to_int.py
@@ -31,7 +31,6 @@ def drop_varchar_pattern_ops_index(apps, schemaEditor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0027_person_party_ppc_page_url"),
         ("peoplecvs", "0002_auto_20170522_1324"),

--- a/wcivf/apps/people/migrations/0029_person_last_updated.py
+++ b/wcivf/apps/people/migrations/0029_person_last_updated.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0028_person_pk_to_int")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0030_insta-youtube.py
+++ b/wcivf/apps/people/migrations/0030_insta-youtube.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0029_person_last_updated")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0031_person_sort_name.py
+++ b/wcivf/apps/people/migrations/0031_person_sort_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0030_insta-youtube")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0032_person_death_date.py
+++ b/wcivf/apps/people/migrations/0032_person_death_date.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0031_person_sort_name")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0033_facebookadvert.py
+++ b/wcivf/apps/people/migrations/0033_facebookadvert.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0032_person_death_date")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0034_auto_20191213_0942.py
+++ b/wcivf/apps/people/migrations/0034_auto_20191213_0942.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0033_facebookadvert")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0035_personpost_votes_cast.py
+++ b/wcivf/apps/people/migrations/0035_personpost_votes_cast.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0034_auto_20191213_0942")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0036_auto_20191213_1028.py
+++ b/wcivf/apps/people/migrations/0036_auto_20191213_1028.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0035_personpost_votes_cast")]
 
     operations = [

--- a/wcivf/apps/people/migrations/0037_auto_20210604_1245.py
+++ b/wcivf/apps/people/migrations/0037_auto_20210604_1245.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0036_auto_20191213_1028"),
     ]

--- a/wcivf/apps/people/migrations/0038_add_party_name_to_personposts.py
+++ b/wcivf/apps/people/migrations/0038_add_party_name_to_personposts.py
@@ -9,7 +9,6 @@ CHANGE_DATE = timezone.datetime(2021, 1, 6).date()
 
 
 def add_party_name(apps, schema_editor):
-
     PersonPost = apps.get_model("people", "PersonPost")
 
     brexit_candidacies = PersonPost.objects.filter(
@@ -33,7 +32,6 @@ def remove_party_names(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0037_auto_20210604_1245"),
     ]

--- a/wcivf/apps/people/migrations/0039_auto_20210928_1303.py
+++ b/wcivf/apps/people/migrations/0039_auto_20210928_1303.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0038_add_party_name_to_personposts"),
     ]

--- a/wcivf/apps/people/migrations/0040_person_blog_url.py
+++ b/wcivf/apps/people/migrations/0040_person_blog_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0039_auto_20210928_1303"),
     ]

--- a/wcivf/apps/people/migrations/0041_dummycandidacy_dummyperson.py
+++ b/wcivf/apps/people/migrations/0041_dummycandidacy_dummyperson.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0040_person_blog_url"),
     ]

--- a/wcivf/apps/people/migrations/0042_personpost_previous_party_affiliations.py
+++ b/wcivf/apps/people/migrations/0042_personpost_previous_party_affiliations.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0012_add_youtube_and_contact_url"),
         ("people", "0041_dummycandidacy_dummyperson"),

--- a/wcivf/apps/people/migrations/0043_personpost_rank.py
+++ b/wcivf/apps/people/migrations/0043_personpost_rank.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0042_personpost_previous_party_affiliations"),
     ]

--- a/wcivf/apps/people/migrations/0044_person_mastodon_username.py
+++ b/wcivf/apps/people/migrations/0044_person_mastodon_username.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0043_personpost_rank"),
     ]

--- a/wcivf/apps/people/tests/factories.py
+++ b/wcivf/apps/people/tests/factories.py
@@ -30,7 +30,6 @@ class PersonPostFactory(factory.django.DjangoModelFactory):
 
 
 class PersonPostWithPartyFactory(PersonPostFactory):
-
     party = factory.SubFactory(PartyFactory)
 
     @factory.lazy_attribute

--- a/wcivf/apps/people/urls.py
+++ b/wcivf/apps/people/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, path
+from django.urls import path
 
 from .views import PersonView, EmailPersonView, DummyPersonView
 
@@ -8,8 +8,8 @@ urlpatterns = [
         DummyPersonView.as_view(),
         name="dummy-profile",
     ),
-    re_path(
-        r"^(?P<pk>[^/]+)/email/(?P<ignored_slug>.*)$",
+    path(
+        "<int:pk>/email/<slug:ignored_slug>",
         EmailPersonView.as_view(),
         name="email_person_view",
     ),

--- a/wcivf/apps/peoplecvs/migrations/0001_initial.py
+++ b/wcivf/apps/peoplecvs/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("people", "0018_auto_20170518_1255")]

--- a/wcivf/apps/peoplecvs/migrations/0002_auto_20170522_1324.py
+++ b/wcivf/apps/peoplecvs/migrations/0002_auto_20170522_1324.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("peoplecvs", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/peoplecvs/migrations/0003_delete_cvs.py
+++ b/wcivf/apps/peoplecvs/migrations/0003_delete_cvs.py
@@ -5,13 +5,11 @@ from django.db import migrations
 
 
 def delete_cvs(app, schema_editor):
-
     CV = apps.get_model("peoplecvs", "CV")
     CV.objects.all().delete()
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("peoplecvs", "0002_auto_20170522_1324"),
     ]

--- a/wcivf/apps/pledges/migrations/0001_initial.py
+++ b/wcivf/apps/pledges/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/wcivf/apps/pledges/migrations/0002_auto_20180502_0946.py
+++ b/wcivf/apps/pledges/migrations/0002_auto_20180502_0946.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("pledges", "0001_initial")]
 
     operations = [

--- a/wcivf/apps/profiles/migrations/0001_initial.py
+++ b/wcivf/apps/profiles/migrations/0001_initial.py
@@ -7,7 +7,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("people", "0007_personpost_election")]

--- a/wcivf/apps/referendums/management/commands/import_referendums.py
+++ b/wcivf/apps/referendums/management/commands/import_referendums.py
@@ -4,7 +4,6 @@ from referendums.importers import ReferendumImporter
 
 
 class Command(BaseCommand):
-
     URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQHIsqVdfcZnCNgrwgtcS_ihMQbFn2S5T1ncUGKUDz2B3ONC9cUjOcdFWRtBmUxDN-f3PNEfW7bucmp/pub?gid=0&single=true&output=csv"
 
     def handle(self, **options):

--- a/wcivf/apps/referendums/migrations/0001_initial.py
+++ b/wcivf/apps/referendums/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/wcivf/apps/referendums/migrations/0002_referendum_ballot.py
+++ b/wcivf/apps/referendums/migrations/0002_referendum_ballot.py
@@ -5,7 +5,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0034_update_ordering"),
         ("referendums", "0001_initial"),

--- a/wcivf/apps/referendums/models.py
+++ b/wcivf/apps/referendums/models.py
@@ -4,7 +4,6 @@ from django.utils import timezone
 
 
 class Referendum(models.Model):
-
     # TODO remove this as part of a wider refactor of referendums if
     # these changes are kept
     ballots = models.ManyToManyField(


### PR DESCRIPTION
Ref https://trello.com/c/ZRtruYOs/3413-django-42-upgrades

Dependent on https://github.com/DemocracyClub/dc_django_utils/pull/55 and https://github.com/DemocracyClub/dc_signup_form/pull/27

https://docs.djangoproject.com/en/4.2/releases/4.2.3/

This work:

- upgrades WCIVF to `Django==4.2.3`
- removes Pillow as it's no longer in use; we are using thumbnails for person photos imported directly from YNR
- reformats some urls to follow url disp
- upgrades `black` which requires a mass space reformatting