### PR TITLE
Party list page filtering

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-14 11:40+0100\n"
+"POT-Creation-Date: 2023-07-21 15:46+0100\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -29,21 +29,21 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
-#: wcivf/apps/elections/models.py:659
+#: wcivf/apps/elections/models.py:658
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
-#: wcivf/apps/elections/models.py:661
+#: wcivf/apps/elections/models.py:660
 #, fuzzy
 #| msgid "The Additional Member System"
 msgid "Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
 
-#: wcivf/apps/elections/models.py:663
+#: wcivf/apps/elections/models.py:662
 msgid "Supplementary Vote"
 msgstr "Pleidlais Atodol"
 
-#: wcivf/apps/elections/models.py:665
+#: wcivf/apps/elections/models.py:664
 msgid "Single Transferable Vote"
 msgstr "Pleidlais Sengl Drosglwyddadwy"
 
@@ -219,7 +219,7 @@ msgid "Read more"
 msgstr "Darllenwch ragor"
 
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:3
-#: wcivf/apps/parties/templates/parties/party_list.html:10
+#: wcivf/apps/parties/templates/parties/parties_view.html:9
 msgid "You are here"
 msgstr "Rydych chi yma"
 
@@ -889,7 +889,7 @@ msgid "%(party_name)s's Facebook profile"
 msgstr "Tudalen Facebook %(party_name)s"
 
 #: wcivf/apps/elections/templates/elections/party_list_view.html:39
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:43
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:64
 msgid "Home page"
 msgstr "Hafan"
 
@@ -899,7 +899,7 @@ msgid "%(party_name)s's home page"
 msgstr "Hafan %(party_name)s"
 
 #: wcivf/apps/elections/templates/elections/party_list_view.html:48
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:109
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:130
 #: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:40
 msgid "Email"
 msgstr "E-bost"
@@ -915,7 +915,6 @@ msgid "Find out more about the %(party_name)s in their %(manifesto)s."
 msgstr "Dysgwch fwy am %(party_name)s yn eu %(manifesto)s."
 
 #: wcivf/apps/elections/templates/elections/party_list_view.html:74
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:124
 msgid "Latest tweets"
 msgstr "Trydariadau diweddar"
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Enter this URL and save"
 msgstr "Rhowch yr URL hwn a'i arbed"
 
-#: wcivf/apps/feedback/models.py:6 wcivf/apps/feedback/models.py:7
+#: wcivf/apps/feedback/models.py:8 wcivf/apps/feedback/models.py:9
 msgid "Yes"
 msgstr "Ie"
 
-#: wcivf/apps/feedback/models.py:6 wcivf/apps/feedback/models.py:7
+#: wcivf/apps/feedback/models.py:8 wcivf/apps/feedback/models.py:9
 msgid "No"
 msgstr "Na"
 
@@ -1168,6 +1167,43 @@ msgid ""
 "\"%(ballot_name)s\", or with no description at all."
 msgstr ""
 
+#: wcivf/apps/parties/templates/parties/parties_view.html:4
+#: wcivf/apps/parties/templates/parties/parties_view.html:5
+msgid "UK Political Parties"
+msgstr "Pleidiau Gwleidyddol y DU"
+
+#: wcivf/apps/parties/templates/parties/parties_view.html:6
+msgid "List of candidates for UK Political Parties"
+msgstr "Rhestr o ymgeiswyr Pleidiau Gwleidyddol y DU"
+
+#: wcivf/apps/parties/templates/parties/parties_view.html:14
+msgid "Current: Parties"
+msgstr "Ar hyn o bryd: Pleidiau"
+
+#: wcivf/apps/parties/templates/parties/parties_view.html:22
+#, fuzzy
+#| msgid "UK Political Parties"
+msgid "UK political parties"
+msgstr "Pleidiau Gwleidyddol y DU"
+
+#: wcivf/apps/parties/templates/parties/parties_view.html:23
+msgid ""
+"<p>The following is a list of all political parties represented by "
+"candidates in Democracy Club's UK election database (est. 2015). This list "
+"includes registered and deregistered parties.</p> <p>There are two party "
+"registers in the UK: a combined Great Britain register for England, Wales "
+"and Scotland, and a separate register for Northern Ireland. Parties in Great "
+"Britain can only field candidates in the nations they have specified in "
+"their entry.</p> <p>A registered party may field candidates in elections.</"
+"p> <p>A deregistered party may no longer field candidates in elections. A "
+"party can become deregistered through choice, or becuase it failed to renew "
+"its annual registration status. In some cases, parties have been "
+"deregistered and then subsequently reregistered; in these cases, the party "
+"will have an entry for each registration.</p> <p>Party names and emblems are "
+"taken from the <a href=\"http://www.electoralcommission.org.uk/\">Electoral "
+"Commission's register of political parties.</a></p>"
+msgstr ""
+
 #: wcivf/apps/parties/templates/parties/party_detail.html:36
 #, fuzzy, python-format
 #| msgid "Current: %(party_name)s"
@@ -1287,36 +1323,6 @@ msgid ""
 "cannot be used:"
 msgstr ""
 
-#: wcivf/apps/parties/templates/parties/party_list.html:4
-#: wcivf/apps/parties/templates/parties/party_list.html:5
-msgid "UK Political Parties"
-msgstr "Pleidiau Gwleidyddol y DU"
-
-#: wcivf/apps/parties/templates/parties/party_list.html:6
-msgid "List of candidates for UK Political Parties"
-msgstr "Rhestr o ymgeiswyr Pleidiau Gwleidyddol y DU"
-
-#: wcivf/apps/parties/templates/parties/party_list.html:15
-msgid "Current: Parties"
-msgstr "Ar hyn o bryd: Pleidiau"
-
-#: wcivf/apps/parties/templates/parties/party_list.html:20
-msgid ""
-"<h2>UK political parties</h2> <p>The following is a list of all political "
-"parties represented by candidates in Democracy Club's UK election database "
-"(est. 2015). The list includes active, deregistered, and defunct parties.</"
-"p> <p>Party names and emblems are taken from the <a href=\"http://www."
-"electoralcommission.org.uk/\">Electoral Commission's register of political "
-"parties.</a></p>"
-msgstr ""
-"<h2>Pleidiau Gwleidyddol y DU</h2> <p>Rhestr yw'r isod o'r holl bleidiau "
-"gwleidyddol sy'n cael eu cynrychioli gan ymgeiswyr yng ngronfa ddata "
-"etholiadau'r DU Democracy Club (sefyd. 2015). Mae'r rhestr yn cynnwys "
-"pleidiau gweithredol, rhai sydd wedi datgofrestru, a rhai sydd wedi dod i "
-"ben.</p> <p>Cymerwyd enwau a symbolau'r pleidiau o <a href=\"http://www."
-"electoralcommission.org.uk/\">gofrestr y Comisiwn Etholiadol o bleidiau "
-"gwleidyddol.</a></p>"
-
 #: wcivf/apps/parties/templates/parties/single_manifesto.html:5
 #, python-format
 msgid "%(manifesto_country)s manifesto"
@@ -1401,45 +1407,6 @@ msgstr "%(num_votes)s pleidlais"
 msgid "Not elected (vote count not available)"
 msgstr "Nid yw'r cyfrif pleidleisiau ar gael"
 
-#: wcivf/apps/people/templates/people/_person_email_form.html:27
-#, python-format
-msgid ""
-"This page generates a customised email for %(name)s to ask them to provide "
-"missing data for the Democracy Club dataset."
-msgstr ""
-"Mae'r dudalen hon yn cynhyrchu e-bost wedi'i deilwra ar gyfer %(name)s i "
-"ofyn iddynt ddarparu data coll ar gyfer cronfa ddata'r Democracy Club."
-
-#: wcivf/apps/people/templates/people/_person_email_form.html:35
-#, python-format
-msgid ""
-"Add your name, check the box if you live in %(post_label)s, and then press "
-"'open email in email program'."
-msgstr ""
-"Ychwanegwch eich enw, ticiwch y bocs os ydych chi'n byw yn %(post_label)s, "
-"ac yna gwasgwch 'agor yr e-bost mewn rhaglen e-bost'."
-
-#: wcivf/apps/people/templates/people/_person_email_form.html:50
-#, fuzzy, python-format
-#| msgid ""
-#| "Here's the email text we've generated for you to send to <span "
-#| "class=\"candidatename\">%(person_name)s"
-msgid ""
-"Here's the email text we've generated for you to send to <span "
-"class=\"candidatename\">%(person_name)s</span>."
-msgstr ""
-"Dyma destun yr e-bost a gynhyrchwyd gennym er mwyn i chi ei anfon at<span "
-"class=\"candidatename\">%(person_name)s"
-
-#: wcivf/apps/people/templates/people/email_person.html:31
-#, python-format
-msgid ""
-"We don't know %(person_name)s's email address. <a "
-"href=\"%(edit_profile_url)s\">Can you add it?</a>"
-msgstr ""
-"Nid oes gennym gyfeiriad e-bost %(person_name)s. <a "
-"href=\"%(edit_profile_url)s\">A allwch chi ei ychwanegu?</a>"
-
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:6
 #, python-format
 msgid "About %(name)s"
@@ -1468,76 +1435,92 @@ msgstr "Facebook personol %(person_name)s"
 msgid "%(person_name)s's Facebook page"
 msgstr "Tudalen Facebook %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:32
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:31
+#: wcivf/templates/base.html:111
+msgid "Twitter"
+msgstr "Trydar"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:33
+#, fuzzy, python-format
+#| msgid "%(person_name)s's LinkedIn profile"
+msgid "%(person_name)s's Twitter profile"
+msgstr "Tudalen LinkedIn %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:41
+msgid "Mastodon"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:43
+#, fuzzy, python-format
+#| msgid "%(person_name)s's LinkedIn profile"
+msgid "%(person_name)s's Mastodon profile"
+msgstr "Tudalen LinkedIn %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:53
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:34
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:55
 #, python-format
 msgid "%(person_name)s's LinkedIn profile"
 msgstr "Tudalen LinkedIn %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:45
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:66
 #, python-format
 msgid "%(person_name)s's home page"
 msgstr "Hafan %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:54
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:75
 #: wcivf/templates/base.html:110
 msgid "Blog"
 msgstr "Blog"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:56
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:57
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:77
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:78
 #, python-format
 msgid "%(person_name)s's blog"
 msgstr "Blog %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:65
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:86
 msgid "Instagram"
 msgstr "Instagram"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:67
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:88
 #, python-format
 msgid "%(person_name)s's Instagram"
 msgstr "Instagram %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:76
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:97
 msgid "YouTube"
 msgstr "YouTube"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:78
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:99
 #, python-format
 msgid "%(person_name)s's YouTube"
 msgstr "YouTube %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:98
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:119
 msgid "The party's candidate page for this person"
 msgstr "Tudalen ymgeisydd y blaid ar gyfer y person hwn"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:100
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:121
 #, python-format
 msgid "Party page for %(person_name)s"
 msgstr "Tudalen y blaid ar gyfer %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:111
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:132
 #, python-format
 msgid "%(person_name)s's email"
 msgstr "E-bost %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:116
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:137
 #, python-format
 msgid "<dt>We don't know %(person_name)s's email address.</dt>"
 msgstr "<dt>Nid oes gennym gyfeiriad e-bost %(person_name)s.</dt>"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:118
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:139
 msgid "Can you add it?"
 msgstr "A allwch chi ei ychwanegu?"
-
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:127
-#, python-format
-msgid "Tweets by @%(twitter_name)s"
-msgstr "Trydariadau gan @%(twitter_name)s"
 
 #: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:7
 msgid "That's all we know! Will you help us find more about this candidate?"
@@ -1553,39 +1536,22 @@ msgstr ""
 "Bu ein gwirfoddolwyr yn gweithio'n galed yn ychwanegu gwybodaeth ar gymaint "
 "â phosibl o ymgeiswyr, ond mae angen help arnynt."
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:11
-msgid "Thousands of voters will rely on this site."
-msgstr "Mae miloedd o bleidleiswyr yn dibynnu ar y wefan hon."
-
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:13
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:10
 msgid "If you can add information that should be on this page"
 msgstr "Os gallwch chi, ychwanegwch wybodaeth a ddylai fod ar y dudalen hon"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:16
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:13
 #, python-format
 msgid "- such as %(person)s's %(cta)s -"
 msgstr "- fel%(cta)s %(person)s -"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:19
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:16
 msgid "please use our crowdsourcing website to add it."
 msgstr "defnyddiwch ein gwefan torfoli i'w ychwanegu."
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:22
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:19
 msgid "Add or edit details &raquo;"
 msgstr "Ychwanegwch neu golygwch fanylion &raquo;"
-
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:26
-#, python-format
-msgid ""
-"You can also email %(person)s directly to ask them to add information to "
-"this page."
-msgstr ""
-"Gallwch hefyd anfon e-bost yn uniongyrchol at %(person)s yn gofyn iddynt "
-"ychwanegu gwybodaeth at y dudalen hon."
-
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:28
-msgid "Ask the candidate for more information &raquo;"
-msgstr "Holwch yr ymgeisydd am fwy o wybodaeth &raquo;"
 
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:12
 msgid "an,a"
@@ -2051,39 +2017,6 @@ msgstr "Refferendwm%(council_name)s "
 msgid "%(short_cancelled_message)s"
 msgstr "%(short_cancelled_message)s"
 
-#: wcivf/apps/results/templates/results/results_list.html:3
-msgid "Election results"
-msgstr "Canlyniadau etholiad"
-
-#: wcivf/apps/results/templates/results/results_list.html:13
-#, fuzzy
-#| msgid "Election results"
-msgid "Latest election results"
-msgstr "Canlyniadau etholiad"
-
-#: wcivf/apps/results/templates/results/results_list.html:16
-msgid "See these results on a map, thanks to our friends at ODI Leeds"
-msgstr ""
-"Gallwch weld y canlyniadau hyn ar fap, diolch i'n ffrindiau yn ODI Leeds"
-
-#: wcivf/apps/results/templates/results/results_list.html:33
-#: wcivf/apps/results/templates/results/results_list.html:39
-msgid "Constituency"
-msgstr "Etholaeth"
-
-#: wcivf/apps/results/templates/results/results_list.html:34
-#: wcivf/apps/results/templates/results/results_list.html:40
-msgid "Result"
-msgstr "Canlyniad"
-
-#: wcivf/apps/results/templates/results/results_list.html:60
-msgid "Expected"
-msgstr "Disgwyl"
-
-#: wcivf/apps/results/templates/results/results_list.html:71
-msgid "No results yet"
-msgstr "Dim canlyniadau eto"
-
 #: wcivf/templates/base.html:58
 msgid "Language:"
 msgstr "Iaith:"
@@ -2118,10 +2051,6 @@ msgstr "Ynglŷn â'r Clwb Democratiaeth"
 #: wcivf/templates/base.html:109
 msgid "Contact Us"
 msgstr "Cysylltwch â Ni"
-
-#: wcivf/templates/base.html:111
-msgid "Twitter"
-msgstr "Trydar"
 
 #: wcivf/templates/base.html:112
 msgid "GitHub"
@@ -2220,6 +2149,99 @@ msgstr "Etholiadau i ddod"
 #: wcivf/templates/mailing_list.html:8
 msgid "Join our mailing list"
 msgstr "Ymunwch â'n rhestr bostio"
+
+#~ msgid ""
+#~ "<h2>UK political parties</h2> <p>The following is a list of all political "
+#~ "parties represented by candidates in Democracy Club's UK election "
+#~ "database (est. 2015). The list includes active, deregistered, and defunct "
+#~ "parties.</p> <p>Party names and emblems are taken from the <a "
+#~ "href=\"http://www.electoralcommission.org.uk/\">Electoral Commission's "
+#~ "register of political parties.</a></p>"
+#~ msgstr ""
+#~ "<h2>Pleidiau Gwleidyddol y DU</h2> <p>Rhestr yw'r isod o'r holl bleidiau "
+#~ "gwleidyddol sy'n cael eu cynrychioli gan ymgeiswyr yng ngronfa ddata "
+#~ "etholiadau'r DU Democracy Club (sefyd. 2015). Mae'r rhestr yn cynnwys "
+#~ "pleidiau gweithredol, rhai sydd wedi datgofrestru, a rhai sydd wedi dod i "
+#~ "ben.</p> <p>Cymerwyd enwau a symbolau'r pleidiau o <a href=\"http://www."
+#~ "electoralcommission.org.uk/\">gofrestr y Comisiwn Etholiadol o bleidiau "
+#~ "gwleidyddol.</a></p>"
+
+#, python-format
+#~ msgid ""
+#~ "This page generates a customised email for %(name)s to ask them to "
+#~ "provide missing data for the Democracy Club dataset."
+#~ msgstr ""
+#~ "Mae'r dudalen hon yn cynhyrchu e-bost wedi'i deilwra ar gyfer %(name)s i "
+#~ "ofyn iddynt ddarparu data coll ar gyfer cronfa ddata'r Democracy Club."
+
+#, python-format
+#~ msgid ""
+#~ "Add your name, check the box if you live in %(post_label)s, and then "
+#~ "press 'open email in email program'."
+#~ msgstr ""
+#~ "Ychwanegwch eich enw, ticiwch y bocs os ydych chi'n byw yn "
+#~ "%(post_label)s, ac yna gwasgwch 'agor yr e-bost mewn rhaglen e-bost'."
+
+#, fuzzy, python-format
+#~| msgid ""
+#~| "Here's the email text we've generated for you to send to <span "
+#~| "class=\"candidatename\">%(person_name)s"
+#~ msgid ""
+#~ "Here's the email text we've generated for you to send to <span "
+#~ "class=\"candidatename\">%(person_name)s</span>."
+#~ msgstr ""
+#~ "Dyma destun yr e-bost a gynhyrchwyd gennym er mwyn i chi ei anfon at<span "
+#~ "class=\"candidatename\">%(person_name)s"
+
+#, python-format
+#~ msgid ""
+#~ "We don't know %(person_name)s's email address. <a "
+#~ "href=\"%(edit_profile_url)s\">Can you add it?</a>"
+#~ msgstr ""
+#~ "Nid oes gennym gyfeiriad e-bost %(person_name)s. <a "
+#~ "href=\"%(edit_profile_url)s\">A allwch chi ei ychwanegu?</a>"
+
+#, python-format
+#~ msgid "Tweets by @%(twitter_name)s"
+#~ msgstr "Trydariadau gan @%(twitter_name)s"
+
+#~ msgid "Thousands of voters will rely on this site."
+#~ msgstr "Mae miloedd o bleidleiswyr yn dibynnu ar y wefan hon."
+
+#, python-format
+#~ msgid ""
+#~ "You can also email %(person)s directly to ask them to add information to "
+#~ "this page."
+#~ msgstr ""
+#~ "Gallwch hefyd anfon e-bost yn uniongyrchol at %(person)s yn gofyn iddynt "
+#~ "ychwanegu gwybodaeth at y dudalen hon."
+
+#~ msgid "Ask the candidate for more information &raquo;"
+#~ msgstr "Holwch yr ymgeisydd am fwy o wybodaeth &raquo;"
+
+#~ msgid "Election results"
+#~ msgstr "Canlyniadau etholiad"
+
+#, fuzzy
+#~| msgid "Election results"
+#~ msgid "Latest election results"
+#~ msgstr "Canlyniadau etholiad"
+
+#~ msgid "See these results on a map, thanks to our friends at ODI Leeds"
+#~ msgstr ""
+#~ "Gallwch weld y canlyniadau hyn ar fap, diolch i'n ffrindiau yn ODI Leeds"
+
+#~ msgid "Constituency"
+#~ msgstr "Etholaeth"
+
+#~ msgid "Result"
+#~ msgstr "Canlyniad"
+
+#~ msgid "Expected"
+#~ msgstr "Disgwyl"
+
+#~ msgid "No results yet"
+#~ msgstr "Dim canlyniadau eto"
 
 #~ msgid "Subscribe to the iCal feed"
 #~ msgstr "Tanysgrifiwch i ffrwd iCal"

--- a/wcivf/apps/parties/filters.py
+++ b/wcivf/apps/parties/filters.py
@@ -1,0 +1,135 @@
+from urllib.parse import urlencode
+from django.db.models import BLANK_CHOICE_DASH
+from django.utils.encoding import force_str
+from django.utils.safestring import mark_safe
+from django_filters.widgets import LinkWidget
+
+import django_filters
+
+from parties.models import Party
+
+
+def party_register_choices():
+    return [
+        ("GB", "Great Britain"),
+        ("NI", "Northern Ireland"),
+    ]
+
+
+def party_status_choices():
+    return [("Registered", "Registered"), ("Deregistered", "Deregistered")]
+
+
+class DSLinkWidget(LinkWidget):
+    """
+    The LinkWidget doesn't allow iterating over choices in the template layer
+    to change the HTML wrapping the widget.
+
+    This breaks the way that Django *should* work, so we have to subclass
+    and alter the HTML in Python :/
+
+    https://github.com/carltongibson/django-filter/issues/880
+    """
+
+    def render(self, name, value, attrs=None, choices=(), renderer=None):
+        if not hasattr(self, "data"):
+            self.data = {}
+        if value is None:
+            value = ""
+        self.build_attrs(self.attrs, extra_attrs=attrs)
+        output = []
+        options = self.render_options(choices, [value], name)
+        if options:
+            output.append(options)
+        # output.append('</ul>')
+        return mark_safe("\n".join(output))
+
+    def render_option(self, name, selected_choices, option_value, option_label):
+        option_value = force_str(option_value)
+        if option_label == BLANK_CHOICE_DASH[0][1]:
+            option_label = "All"
+        data = self.data.copy()
+        data[name] = option_value
+        selected = data == self.data or option_value in selected_choices
+        try:
+            url = data.urlencode()
+        except AttributeError:
+            url = urlencode(data)
+        return self.option_string() % {
+            "attrs": selected and ' aria-current="true"' or "",
+            "query_string": url,
+            "label": force_str(option_label),
+        }
+
+
+class PartyRegisterFilter(django_filters.FilterSet):
+    def party_register_filter(self, queryset, name, value):
+        return queryset.filter(register=value)
+
+    def party_status_filter(self, queryset, name, value):
+        return queryset.filter(status=value)
+
+    def party_nations_filter(self, queryset, name, value):
+        return queryset.filter(nations__contains=[value])
+
+    register = django_filters.ChoiceFilter(
+        widget=DSLinkWidget,
+        method="party_register_filter",
+        choices=party_register_choices,
+        label="Party Register",
+    )
+
+    status = django_filters.ChoiceFilter(
+        widget=DSLinkWidget,
+        method="party_status_filter",
+        choices=party_status_choices,
+        label="Party Status",
+    )
+
+    nations = django_filters.ChoiceFilter(
+        widget=DSLinkWidget,
+        method="party_nations_filter",
+        choices=[("ENG", "England"), ("WAL", "Wales"), ("SCO", "Scotland")],
+        label="Nation",
+    )
+
+    class Meta:
+        model = Party
+        fields = ["register", "status", "nations"]
+
+    @property
+    def shortcuts(self):
+        """
+        Returns filter shorcuts
+        """
+        shortcut_list = [
+            {
+                "name": "gb_parties",
+                "label": "Registered in Great Britain",
+                "query": {"register": ["GB"], "status": ["Registered"]},
+            },
+            {
+                "name": "ni_parties",
+                "label": "Registered in Northern Ireland",
+                "query": {"register": ["NI"], "status": ["Registered"]},
+            },
+            {
+                "name": "gb_dereg_parties",
+                "label": "Deregistered in Great Britain",
+                "query": {"register": ["GB"], "status": ["Deregistered"]},
+            },
+            {
+                "name": "ni_dereg_parties",
+                "label": "Deregistered in Northern Ireland",
+                "query": {"register": ["NI"], "status": ["Deregistered"]},
+            },
+        ]
+
+        query = dict(self.request.GET)
+        shortcuts = {"list": shortcut_list}
+        for shortcut in shortcuts["list"]:
+            shortcut["querystring"] = urlencode(shortcut["query"], doseq=True)
+            if shortcut["query"] == query:
+                shortcut["active"] = True
+                shortcuts["active"] = shortcut
+        return shortcuts

--- a/wcivf/apps/parties/templates/parties/parties_view.html
+++ b/wcivf/apps/parties/templates/parties/parties_view.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block page_title %}{% trans "UK Political Parties" %}{% endblock page_title %}
+{% block og_title_content %}{% trans "UK Political Parties" %}{% endblock og_title_content %}
+{% block og_description_content %}{% trans "List of candidates for UK Political Parties" %}{% endblock og_description_content %}
+
+{% block content %}
+    <nav class="ds-breadcrumbs ds-stack" aria-label="{% trans 'You are here' %}: {{ request.path }}">
+        <ol>
+            <li>
+                <a href="{% url 'home_view' %}">Home</a>
+            </li>
+            <li>{% trans "Current: Parties" %}</li>
+        </ol>
+    </nav>
+
+
+    <div class="ds-stack-smaller">
+        <div class="ds-card">
+            <div class="ds-card-body">
+                <h1>{% trans "UK political parties" %}</h1>
+                {% blocktrans trimmed %}
+                    <p>The following is a list of all political parties represented by candidates in Democracy Club's UK election
+                        database (est. 2015). This list includes registered and deregistered parties.</p>
+                    <p>There are two party registers in the UK: a combined Great Britain register for England, Wales and Scotland, and a separate register for Northern Ireland. Parties in Great Britain can only field candidates in the nations they have specified in their entry.</p>
+                    <p>A registered party may field candidates in elections.</p>
+                    <p>A deregistered party may no longer field candidates in elections. A party can become deregistered through choice, or becuase it failed to renew its annual registration status. In some cases, parties have been deregistered and then subsequently reregistered; in these cases, the party will have an entry for each registration.</p>
+                    <p>Party names and emblems are taken from the <a href="http://www.electoralcommission.org.uk/">Electoral
+                        Commission's register of political parties.</a></p>
+                {% endblocktrans %}
+                <aside class="ds-filter" aria-labelledby="filter-label">
+                    <div class="ds-filter-cluster">
+                        <ul>
+                            <li id="filter-label" class="ds-filter-label" aria-hidden="true">Filter:</li>
+                            <li><a href="{{ photo_list_review_url }}" {% if request.get_full_path == photo_list_review_url %}aria-current="true" {% endif %}>All</a></li>
+                            {% for shortcut in shortcuts.list %}
+                                <li><a href="{{ photo_list_review_url }}?{{ shortcut.querystring }}" {% if shortcut.active %}aria-current="true" {% endif %}>{{ shortcut.label }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    <form>
+                        <details {% if filter.data %}open=""{% endif %}>
+                            <summary>Advanced filters</summary>
+                            <div class="ds-advanced-filters">
+                                <div class="ds-filter-cluster">
+                                    {% for field in filter.form.visible_fields %}
+                                        <ul aria-labelledby="adv-filter-label-{{ forloop.counter }}">
+                                            <li id="adv-filter-label-{{ forloop.counter }}" class="ds-filter-label" aria-hidden="true">{{ field.label }}:</li>
+                                            {{ field }}
+                                        </ul>
+                                    {% endfor %}
+
+                                </div>
+                            </div>
+                        </details>
+                    </form>
+                </aside>
+                {% include "parties/party_list.html" with parties=queryset %}
+            </div>
+        </div>
+    </div>
+
+{% endblock content %}

--- a/wcivf/apps/parties/templates/parties/party_list.html
+++ b/wcivf/apps/parties/templates/parties/party_list.html
@@ -1,35 +1,11 @@
-{% extends "base.html" %}
 {% load i18n %}
-}
-{% block page_title %}{% trans "UK Political Parties" %}{% endblock page_title %}
-{% block og_title_content %}{% trans "UK Political Parties" %}{% endblock og_title_content %}
-{% block og_description_content %}{% trans "List of candidates for UK Political Parties" %}{% endblock og_description_content %}
 
-
-{% block content %}
-    <nav class="ds-breadcrumbs ds-stack" aria-label="{% trans 'You are here' %}: {{ request.path }}">
-        <ol>
+<div id="election-urls" >
+    {% for party in parties %}
+        <ul>
             <li>
-                <a href="{% url 'home_view' %}">Home</a>
+                <a href="{{ party.get_absolute_url }}">{{ party.format_name }}</a>
             </li>
-            <li>{% trans "Current: Parties" %}</li>
-        </ol>
-    </nav>
-    <div class="ds-card ds-stack">
-        <div class="ds-card-body">
-            {% blocktrans trimmed %}
-                <h2>UK political parties</h2>
-                <p>The following is a list of all political parties represented by candidates in Democracy Club's UK election
-                    database (est. 2015). The list includes active, deregistered, and defunct parties.</p>
-
-                <p>Party names and emblems are taken from the <a href="http://www.electoralcommission.org.uk/">Electoral
-                    Commission's register of political parties.</a></p>
-            {% endblocktrans %}
-            <ul>
-                {% for party in object_list %}
-                    <li><a href="{{ party.get_absolute_url }}">{{ party.party_name }}</a></li>
-                {% endfor %}
-            </ul>
-        </div>
-    </div>
-{% endblock content %}
+        </ul>
+    {% endfor %}
+</div>

--- a/wcivf/apps/parties/views.py
+++ b/wcivf/apps/parties/views.py
@@ -1,10 +1,22 @@
-from django.views.generic import ListView, DetailView
+from django.views.generic import DetailView, TemplateView
 
 from .models import Party
+from .filters import PartyRegisterFilter
 
 
-class PartiesView(ListView):
-    queryset = Party.objects.exclude(personpost=None)
+class PartiesView(TemplateView):
+    template_name = "parties/parties_view.html"
+
+    def get_context_data(self, *args, **kwargs):
+        context = super(PartiesView, self).get_context_data(*args, **kwargs)
+        queryset = Party.objects.exclude(personpost=None).order_by("party_name")
+        f = PartyRegisterFilter(
+            data=self.request.GET, queryset=queryset, request=self.request
+        )
+        context["filter"] = f
+        context["shortcuts"] = f.shortcuts
+        context["queryset"] = f.qs
+        return context
 
 
 class PartyView(DetailView):


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1204880927741389/1205092272461905)

This work adds filters to the party list page @ /parties/  and updates the descriptive text at the top of the page. Text changes were spitballed between Peter and I but this can be modified if you have any suggestions on how to improve it 📈 

Initially the filters only include the most high level categories - nation, register and status. 

Most of the code which handles the filtering has been lifted from YNR's photo review filter code, as that implements both advanced filters and "shortcut" filters which were useful in this scenario. Shortcut filters allow us to have "quick filters" spanning multiple fields and values (e.g. a quick one-click filter for "Deregistered parties in Great Britain"). The advanced filters allow the user to curate their own filter and add functionality that allows the user to filter for nation - applicable to GB parties which must specify which nation(s) they operate in.

_NB: The nations filter is **inclusive**. That is to say, if you filter for "Wales" you will get parties that include Wales within their nation list, but may also contain other nations in their nation list. There is no way to filter for parties that stand exclusively in one or two nations._

<img width="941" alt="Screenshot 2023-07-21 at 15 35 45" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/9531063/0be36512-1a8d-4f19-8b49-c386db417cf1">

<img width="938" alt="Screenshot 2023-07-21 at 15 35 59" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/9531063/afc07cd3-bb2c-4bfe-90c7-b43579b2d17b">


# To Test
## Set-up
- You have probably done this already, but make sure you're up to date on migrations and you've run `manage.py import_parties`. You need the nations for this one!
## Quick filters
Work through the four quick filters. In some cases it's impossible to check exhaustively, but just a couple of parties checked should be sufficient :)  
- `Registered in Great Britain` and `Registered in Northern Ireland` shouldn't show any parties which have `(Deregistered)` after their names.
- All parties shown for `Deregistered in Great Britain` and `Deregistered in Northern Ireland` should show `(Deregistered)` after their names
- All parties shown for `Deregistered in Great Britain` and `Registered in Great Britain` should be on the `Great Britain` register
- All parties shown for `Deregistered in Northern Ireland` and `Registered in Northern Ireland` should be on the `Northern Ireland` register 
## Advanced filters
This is mostly just "having a play" and combining the filters. The quick filters rely on the advanced filters to function, so no additional steps will be given for party register and party status because there's no need to test twice.
### Nations
- Check that when you filter "Wales" you don't get parties only registered in one other nation, e.g. SNP
- Check that when you filter "Scotland" you don't get parties only registered in one other nation, e.g. PC
- Check that when you filter "England" you don't get parties only registered in one other nation, e.g. SNP, PC
- Check that when you filter nations = (one of ENG,WAL,SCO) and filter register = `Northern Ireland` no parties are shown


```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] If any new text is added, it's internationalized
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205092272461905