### PR TITLE
Bump uk-election-timetables from 2.4.0 to 2.4.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,6 +24,6 @@ djangorestframework-jsonp==1.0.2
 feedparser==6.0.10
 
 sentry-sdk==1.27.1
-uk-election-timetables==2.4.0
+uk-election-timetables==2.4.1
 django-dotenv==1.4.2
 python-akismet==0.4.3


### PR DESCRIPTION
As title. 
The new release of UK Election Timetables has corrected postal vote registration deadlines for NI. 
