### PR TITLE
Only show about section for current candidates

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -40,7 +40,9 @@
 
         {% include "people/includes/_person_manifesto_card.html" with party=object.featured_candidacy.party party_name=object.featured_candidacy.party.name %}
 
-        {% include "people/includes/_person_about_card.html" %}
+        {% if object.current_or_future_candidacies %}
+            {% include "people/includes/_person_about_card.html" %}
+        {% endif %}
 
         {% include "people/includes/_person_contact_card.html" %}
 

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -368,6 +368,16 @@ class PersonViewTests(TestCase):
         self.assertEqual(response.template_name, ["people/person_detail.html"])
         self.assertNotContains(response, "Wikipedia")
 
+    def test_not_current_about_section(self):
+        response = self.client.get(self.person_url, follow=True)
+        self.assertEqual(
+            response.template_name, ["people/not_current_person_detail.html"]
+        )
+        self.assertNotEqual(
+            response.template_name, ["people/person_about_card.html"]
+        )
+        self.assertNotContains(response, "About Candidate 24")
+
     def test_wikipedia(self):
         self.person.wikipedia_bio = "yo"
         self.person.wikipedia_url = "https//www.wikipedia.com/yo"


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1625

We limit wikipedia imports to current candidates to be nice to Wikipedia's API. To reduce inaccuracies, this change only shows the wikipedia excerpt for current candidates. The link to the wikipedia page still appears in the contact card for all candidates, where it exists. 

<img width="934" alt="Screenshot 2023-09-05 at 11 22 55 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/80b2d1b1-c5f6-4e88-aba3-43779173e6ab">

To test, `runserver` and navigate to any past candidate such as `person/4546/boris-johnson`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303545552858