### PR TITLE
Update no election text logic

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -4,6 +4,8 @@
     <div class="ds-card-body">
         {% if postelections.count == 0 %}
             <h2>{% trans "We don't know of any upcoming elections in your area." %}</h2>
+            <p>{% trans "Local and devolved elections in the UK typically happen on the first Thursday in May. By-elections and parliamentary general elections can happen at any time. Not all areas have elections each year." %}</p>
+            <p>{% blocktrans %}Learn more about elections in the UK <a href="https://www.electoralcommission.org.uk/i-am-a/voter/types-elections">on the Electoral Commission website</a>.{% endblocktrans %}</p>
         {% else %}
             {% regroup postelections by election.election_date as header_elections_by_date %}
             {% if address_picker %}
@@ -80,13 +82,7 @@
             {% if referendums %}
                 {% include 'referendums/includes/_list.html' with referendums=referendums %}
             {% endif %}
-
-            {% if not ballot.election.contested and not ballot.election.ynr_sopn_link %}
-                <p>{% trans "There may be parish, town or community council elections in some areas." %}</p>
-                <p>{% trans "Local and devolved elections in the UK typically happen on the first Thursday in May. By-elections and parliamentary general elections can happen at any time. Not all areas have elections each year." %}</p>
-                <p>{% blocktrans %}Learn more about elections in the UK <a href="https://www.electoralcommission.org.uk/i-am-a/voter/types-elections">on the Electoral Commission website</a>.{% endblocktrans %}</p>
-            {% endif %}
-
+            <p>{% trans "There may be parish, town or community council elections in some areas." %}</p>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
Closes #1694 

The logic for this was totally broken, referencing variables that seemingly weren't in the page payload. As this message should only be displayed when there are no elections to show, I've simply moved the html up to the same conditional block that is responsible for the "No elections in your area" text.

This means there's a slight change in text order on the "No elections" style page, but imo this looks fine.

To test:
- Run `manage.py import_ballots --current` if you're not totally up to date 
- Use B773AE in the postcode search
- You should see the Elections in Your Area card without the "Local and devolved elections..." message

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
```
