### PR TITLE
Hotfix/pre-sopn ballot text

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -106,14 +106,22 @@
 
                                 {% else %}
                                     {# Case: Candidates and the post is NOT locked (add CTA) #}
-                                    {% blocktrans trimmed with num_ballots=postelection.party_ballot_count postelection=postelection.friendly_name ynr_link=postelection.ynr_link %}
-                                        The official candidate list has not yet been published.
-                                        However, we expect at least <strong>{{ num_ballots }}</strong>
-                                        in the {{ postelection }}.
+                                    {% blocktrans trimmed with expected_sopn_date=postelection.expected_sopn_date|date:"j F Y"  count counter=postelection.people.count %}
+                                        This candidate will not be confirmed until the council publishes
+                                        the official candidate list on {{ expected_sopn_date }}.
+                                    {% plural %}
+                                        These candidates will not be confirmed until the council publishes
+                                        the official candidate list on {{ expected_sopn_date }}.
+                                    {% endblocktrans %}
 
+
+                                    {% blocktrans trimmed with ynr_link=postelection.ynr_link %}
+                                        Once nomination papers are published, we will manually verify each candidate.
                                         You can help improve this page: <a href="{{ ynr_link }}">
                                             add information about candidates to our database</a>.
                                     {% endblocktrans %}
+
+
                                 {% endif %}
 
                             {% endif %}


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1147

This change updates the text when a ballot when the SOPN has not yet been published and the ballot is not locked but has affiliated candidates.

![Screenshot 2023-09-20 at 4 34 36 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/be1b9dc4-d39d-4358-8378-a791460deb30)

To test, run server with a recent ballot and people import. Then, visit `/elections/local.argyll-and-bute.south-kintyre.by.2023-11-02/south-kintyre/` to match with the screen shot below.

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303544790834