### PR TITLE
Set url content

### DIFF
--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -7,6 +7,7 @@
 {% block page_description %}{% include "elections/includes/_postcode_meta_description.html" %}{% endblock page_description %}
 {% block og_title_content  %}{% include "elections/includes/_postcode_meta_title.html" %}{% endblock og_title_content  %}
 {% block og_description_content %}{% include "elections/includes/_postcode_meta_description.html" %}{% endblock og_description_content %}
+{% block og_url_content %}{{ CANONICAL_URL }}{% endblock og_url_content %}
 {% block twitter_title_content %}{% include "elections/includes/_postcode_meta_title.html" %}{% endblock twitter_title_content %}
 {% block twitter_description_content %}{% include "elections/includes/_postcode_meta_title.html" %}{% endblock twitter_description_content %}
 

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -9,7 +9,6 @@
 {% block og_title_content %}{% include "people/includes/_person_meta_title.html" %}{% endblock og_title_content %}
 {% block og_description_content %}{% include "people/includes/_person_meta_description.html" %}{% endblock og_description_content %}
 {% block og_image_content %}{% if object.photo_url %}{{ object.photo_url }}{% else %}{{ CANONICAL_URL }}{% static 'images/blank-avatar.png' %}{% endif %}{% endblock og_image_content %}
-{% block og_url_content %}{{ CANONICAL_URL }}{{ request.path }}{% endblock og_url_content %}
 {% block twitter_title_content %}{% include "people/includes/_person_meta_title.html" %}{% endblock twitter_title_content %}
 {% block twitter_image %}{% if object.photo_url %}{{ object.photo_url }}{% else %}{{ CANONICAL_URL }}{% static 'images/blank-avatar.png' %}{% endif %}{% endblock twitter_image %}
 {% block twitter_description_content %}{% include "people/includes/_person_meta_description.html" %}{% endblock twitter_description_content %}

--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load i18n %}
 
+{% block og_url_content %}{{ request.build_absolute_uri }}{% endblock og_url_content %}
 
 {% block extra_site_css %}
     {% if USE_COMPRESSED_CSS %}


### PR DESCRIPTION
Peter reported an issue with WCIVF links [posted to Mastodon](https://mastodon.me.uk/@DemocracyClub/111125385497019926) not routing to the correct page. In this case it's the `election_view` not being configured properly, but I decided to update both that and `ballot_view` so we don't have to come back again to fix that too.

Full disclosure, I don't know if this is going to work. That said, I can't make it any more broken than it already is and local testing options are limited 🤷  

I verified this by running the project, going to `http://localhost:8000/elections/parl.2023-10-19/uk-parliament-elections/`, viewing the page source, and verifying that the `<head>` contains `<meta property="og:url" content="http://localhost:8000/elections/parl.2023-10-19/uk-parliament-elections/">` (with the correct URL). Hopefully that's enough! 

Any page (except postcode pages) should now have the complete url because I updated it in the base template. Postcode pages are overridden with their former default (`CANONICAL_URL`) to maintain the same behaviour as before.

```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
```
