### PR TITLE
Hotfix/define modules

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,9 +15,9 @@ redis==4.6.0
 icalendar==5.0.7
 dealer==2.1.0
 
-https://github.com/DemocracyClub/dc_signup_form/archive/refs/tags/2.3.0.tar.gz
-https://github.com/DemocracyClub/design-system/archive/refs/tags/0.2.4.tar.gz
-https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.3.0.tar.gz
+git+https://github.com/DemocracyClub/dc_signup_form.git@3.0.0
+git+https://github.com/DemocracyClub/design-system.git@0.2.4
+git+https://github.com/DemocracyClub/dc_django_utils.git@2.3.0
 git+https://github.com/DemocracyClub/dc_logging.git@0.0.9
 
 djangorestframework-jsonp==1.0.2

--- a/wcivf/apps/mailing_list/urls.py
+++ b/wcivf/apps/mailing_list/urls.py
@@ -1,7 +1,7 @@
 from dc_signup_form.forms import MailingListSignupForm
 from dc_signup_form.views import SignupFormView
 from django.conf import settings
-from django.urls import include, re_path
+from django.urls import re_path
 from django.views.decorators.csrf import csrf_exempt
 
 app_name = "mailing_list"
@@ -19,5 +19,4 @@ urlpatterns = [
         ),
         name="mailing_list_signup_view",
     ),
-    re_path(r"^api_signup/v1/", include("dc_signup_form.signup_server.urls")),
 ]

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -65,7 +65,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "django_filters",
     "dc_signup_form",
-    "dc_signup_form.signup_server",
     "dc_utils",
     "mailing_list",
     "pipeline",


### PR DESCRIPTION
This change attempts to fix [recently failed deploys](https://app.circleci.com/pipelines/github/DemocracyClub/WhoCanIVoteFor/3694/workflows/78178d0f-c1a4-4f5c-920c-8cb03100380e/jobs/10265) where `dc_utils` was not found. 

