### PR TITLE
Use exact lookup for election type on filter

### DIFF
--- a/wcivf/apps/elections/filters.py
+++ b/wcivf/apps/elections/filters.py
@@ -69,7 +69,7 @@ class ElectionTypeFilter(django_filters.FilterSet):
     def election_type_filter(self, queryset, name, value):
         if value == "senedd":
             return queryset.filter(election_type__in=["senedd", "naw"])
-        return queryset.filter(election_type__contains=value)
+        return queryset.filter(election_type=value)
 
     election_type = django_filters.ChoiceFilter(
         widget=DSLinkWidget,

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -125,6 +125,34 @@ class ElectionViewTests(TestCase):
         self.assertContains(response, local_election.election_date)
         self.assertNotContains(response, parl_election.nice_election_name)
 
+    def test_election_filters_exact_election_type(self):
+        """
+        Regresson test: previously we would get false positive results when
+        filtering on 'parl', as 'europarl' also contains 'parl'. The lookup expression
+        should be exact not "contains"
+        """
+
+        ElectionWithPostFactory(
+            slug="europarl.uk-eastern.2014-05-22",
+            election_date="2014-05-22",
+            name="European Union Parliament (UK) elections: Eastern",
+            election_type="europarl",
+        )
+        ElectionWithPostFactory(
+            slug="parl.stroud.2019-12-12",
+            election_date="2019-12-12",
+            name="Stroud 2019",
+            election_type="parl",
+        )
+        url = reverse("elections_view")
+        url = f"{url}?election_type=parl"
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 200)
+        print(response.content)
+        self.assertNotContains(
+            response, "European Union Parliament (UK) elections: Eastern"
+        )
+
 
 class ElectionPostViewTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Previously we were filtering using "contains". This caused a false positive for "europarl" when filtering on "parl".

This change makes the filter use an exact lookup for election type
