### PR TITLE
Don't retry failed Lambda schedules

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -106,6 +106,8 @@ Resources:
             Name: import-people-recently-updated
             Description: Update all people updated in YNR recently
             Input: '{"command": "import_people", "args": ["--recently-updated"]}'
+            RetryPolicy:
+              MaximumRetryAttempts: 0
         DeleteDeletedPeople:
           Type: Schedule # More info about API Event Source: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
           Properties:
@@ -113,6 +115,8 @@ Resources:
             Name: delete-deleted-people
             Description: Deletes people deleted in YNR in the last hour
             Input: '{"command": "delete_deleted_people"}'
+            RetryPolicy:
+              MaximumRetryAttempts: 0
         ImportBallotsRecentlyUpdated:
           Type: Schedule # More info about API Event Source: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#schedule
           Properties:
@@ -120,6 +124,8 @@ Resources:
             Name: import-ballots-recently-updated
             Description: Update all ballots updated in YNR recently
             Input: '{"command": "import_ballots", "args": ["--recently-updated"]}'
+            RetryPolicy:
+              MaximumRetryAttempts: 0
         ImportParties:
           Type: Schedule
           Properties:
@@ -127,6 +133,8 @@ Resources:
             Name: import-parties
             Description: Import parties
             Input: '{"command": "import_parties"}'
+            RetryPolicy:
+              MaximumRetryAttempts: 0
         BatchFeedbackToSlack:
           Type: Schedule
           Properties:
@@ -155,6 +163,8 @@ Resources:
             Name: import-wikipedia-bios
             Description: Import wikipedia bio extracts
             Input: '{"command": "import_wikipedia_bios", "args": ["--current"]}'
+            RetryPolicy:
+              MaximumRetryAttempts: 0
 #        ILPGlobal:
 #          Type: Schedule
 #          Properties:


### PR DESCRIPTION
If a Lambda task fails for some reason, the default is to retry it at some later point.

This is mostly useful, but in our case it could cause stacking of retries. For example, when YNR was down, a load of import jobs backed up, making it more likely that YNR would be down for longer.

This change means that if a job fails it's never retried. This is ok, because all the jobs are scheduled and support time deltas, so will just pick up where the last import left off. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205746505138354