### PR TITLE
Add the API key variable to Lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,14 +280,14 @@ workflows:
           - build_and_test
           - sam_build
           context: [ deployment-development-wcivf, slack-secrets ]
-          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
+          filters: { branches: { only: [ main, master, staging, development ] } }
       - post_deploy_tests:
           name: post_deploy_tests_development
           dc-environment: development
           requires:
             - sam_deploy_development
           context: [ deployment-development-wcivf, slack-secrets ]
-          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
+          filters: { branches: { only: [ main, master, staging, development ] } }
       - code_deploy:
           name: code_deploy_development
           dc-environment: development
@@ -297,7 +297,7 @@ workflows:
           requires:
           - post_deploy_tests_development
           context: [ deployment-development-wcivf, slack-secrets ]
-          filters: { branches: { only: [ main, master, staging, hotfix/make-token-more-unique ] } }
+          filters: { branches: { only: [ main, master, staging, development ] } }
       - sam_deploy:
           name: sam_deploy_staging
           dc-environment: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
                    AppDcEnvironment='$DC_ENVIRONMENT' \
                    AppLoggerDbPassword='$LOGGER_DB_PASSWORD' \
                    AppLoggerDbHost='$LOGGER_DB_HOST' \
+                   AppYnrApiKey='$YNR_API_KEY' \
                    VpcIdParameter=<<parameters.vpc-id>> \
                    SubnetIdsParameter=<<parameters.subnet-ids>> \
                    SSLCertificateArn=<<parameters.ssl-certificate-arn>> \

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -71,6 +71,10 @@ Parameters:
     Description: "Webhook url used to send feeback entries to Slack"
     Type: String
 
+  AppYnrApiKey:
+    Description: "API key used to import data from YNR"
+    Type: String 
+
 Resources:
   WCIVFControllerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -94,6 +98,7 @@ Resources:
           SLACK_FEEDBACK_WEBHOOK_URL: !Ref AppSlackFeedbackWebhookUrl
           LOGGER_DB_PASSWORD: !Ref AppLoggerDbPassword
           LOGGER_DB_HOST: !Ref AppLoggerDbHost
+          YNR_API_KEY: !Ref AppYnrApiKey
       Tags:
         dc-environment: !Ref AppDcEnvironment
         dc-product: wcivf

--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -210,6 +210,7 @@ class YNRBallotImporter:
         force_current_metadata=False,
         recently_updated=False,
         base_url=None,
+        api_key=None,
         default_params=None,
     ):
         self.stdout = stdout
@@ -224,6 +225,7 @@ class YNRBallotImporter:
         self.force_current_metadata = force_current_metadata
         self.recently_updated = recently_updated
         self.base_url = base_url or settings.YNR_BASE
+        self.api_key = api_key or settings.YNR_API_KEY
         self.default_params = default_params or {"page_size": 200}
 
     @time_function_length
@@ -263,6 +265,10 @@ class YNRBallotImporter:
         empty dict
         """
         params = params or {}
+
+        if self.api_key:
+            params["auth_token"] = self.api_key
+
         if self.current_only:
             params["current"] = True
 

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -246,11 +246,13 @@ class TestYNRBallotImporter:
         result = importer.build_params(params=None)
         assert result == {"last_updated": ts.isoformat(), "page_size": 200}
 
+        importer.api_key = "test_api_key"
         result = importer.build_params(params={"foo": "bar"})
         assert result == {
             "last_updated": ts.isoformat(),
             "page_size": 200,
             "foo": "bar",
+            "auth_token": "test_api_key",
         }
 
     def test_should_run_post_ballot_import_tasks(

--- a/wcivf/apps/parties/management/commands/import_parties.py
+++ b/wcivf/apps/parties/management/commands/import_parties.py
@@ -6,7 +6,10 @@ from parties.models import Party
 
 class Command(BaseCommand):
     def handle(self, **options):
-        next_page = settings.YNR_BASE + "/api/next/parties/?page_size=200"
+        next_page = f"{settings.YNR_BASE}/api/next/parties/?page_size=200"
+        if settings.YNR_API_KEY:
+            next_page = f"{next_page}&auth_token={settings.YNR_API_KEY}"
+
         while next_page:
             req = requests.get(next_page)
             results = req.json()

--- a/wcivf/apps/people/import_helpers.py
+++ b/wcivf/apps/people/import_helpers.py
@@ -11,6 +11,9 @@ class YNRPersonImporter:
         self.base_url = base_url or settings.YNR_BASE
         self.params = {"page_size": 200}
         self.stdout = stdout or sys.stdout
+        self.api_key = settings.YNR_API_KEY
+        if self.api_key:
+            self.params["auth_token"] = self.api_key
         if params:
             self.params.update(params)
 

--- a/wcivf/apps/people/tests/test_import_helpers.py
+++ b/wcivf/apps/people/tests/test_import_helpers.py
@@ -14,9 +14,9 @@ class TestYNRPersonImporter:
         assert importer.base_url == "http://example.com"
 
     def test_import_url(self):
-        params = {"foo": "bar"}
+        params = {"foo": "bar", "auth_token": "1234"}
         importer = YNRPersonImporter(params=params)
-        expected = f"{settings.YNR_BASE}/api/next/people/?page_size=200&foo=bar"
+        expected = f"{settings.YNR_BASE}/api/next/people/?page_size=200&foo=bar&auth_token=1234"
         assert importer.import_url == expected
 
     def test_paginator(self):

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -216,6 +216,7 @@ CACHES = {
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_CACHE_ALIAS = "default"
 
+YNR_API_KEY = os.environ.get("YNR_API_KEY", None)
 YNR_BASE = "https://candidates.democracyclub.org.uk"
 YNR_UTM_QUERY_STRING = "utm_source=who&utm_campaign=ynr_cta"
 EE_BASE = "https://elections.democracyclub.org.uk"

--- a/wcivf/settings/ci.py
+++ b/wcivf/settings/ci.py
@@ -18,5 +18,5 @@ DATABASES = {
 }
 
 SECRET_KEY = "just_for_ci"
-
+YNR_API_KEY = None
 EE_BASE = "https://elections.democracyclub.org.uk"


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1205760666515689/f

Following the [enforcement of API keys on YNR](url), imports are sometimes broken or incomplete. This change:

- adds the YNR API variable to the Lambda for the importers to access
- adds the YNR API variable to every API call