### PR TITLE
Hotfix/show explanations & booklets

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -217,7 +217,7 @@ class Election(models.Model):
             "mayor.newham.2022-05-05": "booklets/2022-05-05/mayoral/mayor.newham.2022-05-05.pdf",
             "mayor.sheffield-city-ca.2022-05-05": "booklets/2022-05-05/mayoral/mayor.sheffield-city-ca.2022-05-05.pdf",
             "mayor.tower-hamlets.2022-05-05": "booklets/2022-05-05/mayoral/mayor.tower-hamlets.2022-05-05.pdf",
-            "mayor.hackney.2023-11-09": "booklets/2023-11-09/mayoral/mayor.hackney.2023-11-09.pdf",
+            "mayor.hackney.by.2023-11-09": "booklets/2023-11-09/mayoral/mayor.hackney.2023-11-09.pdf",
         }
 
         return election_to_booklet.get(self.slug)

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -165,6 +165,15 @@
                     </div>
                 </section>
             {% endif %}
+            {% if postelection.election.election_booklet %}
+                <h4>
+                    <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
+                </h4>
+            {% endif %}
+
+            {% if postelection.election.description %}
+                {% blocktrans with description=postelection.election.description|markdown %} {{ description }} {% endblocktrans %}
+            {% endif %}
             {% if postelection.people and postelection.should_show_candidates %}
                 {% if postelection.display_as_party_list %}
                     {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
@@ -189,15 +198,6 @@
                     {% endif %}
                 </p>
 
-                {% if postelection.election.election_booklet %}
-                    <h4>
-                        <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a></h4>
-                {% endif %}
-
-                {% if postelection.election.description %}
-                    {% blocktrans with description=postelection.election.description|markdown %} {{ description }} {% endblocktrans %}
-                {% endif %}
-
                 {%  if not postelection.cancelled %}
                     {% if postelection.election.voter_age %}
                         <ul class="ds-details">
@@ -220,9 +220,6 @@
                     {% endif %}
                 {% endif %}
             {% endif %}
-
-
-
 
             {% if postelection.ballotnewsarticle_set.exists %}
                 {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}


### PR DESCRIPTION
This change fixes the slug for the Hackney mayoral election and moves the booklet and explanation logic to show in every case. 

<img width="912" alt="Screenshot 2023-11-09 at 10 35 06 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/6fcb0d70-11cc-48ab-9f67-335553431752">
