### PR TITLE
Reformat explainer into separate component

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -136,8 +136,14 @@
             {% endif %}
 
             {% if postelection.election.description %}
-                {% blocktrans with description=postelection.election.description|markdown %} {{ description }} {% endblocktrans %}
+                <div class="ds-card">
+                    <div class="ds-card-body">
+                        <h3>About this position</h3>
+                        <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
+                    </div>
+                </div>
             {% endif %}
+
             {% if postelection.election.in_past and postelection.has_results %}
                 <section class="ds-card ds-width-half-text">
                     <div class="ds-table">
@@ -208,7 +214,7 @@
                                     <p>
                                         {% blocktrans trimmed with voter_age=postelection.election.voter_age voter_age_date=postelection.election.election_date|date:"jS" election_date=postelection.election.election_date|date:"F Y" %}
                                             You need to be over {{ voter_age }} on the {{ voter_age_date }} of {{ election_date }} in order to vote in this election.
-                                        {% endblocktrans %}}
+                                        {% endblocktrans %}
                                     </p>
                                     {% if postelection.election.voter_citizenship %}
                                         <h5>{% trans "Citizenship" %}</h5>


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1748

@pmk01 to do: remove 'about this position' header from markdown now that it has been hardcoded here. 

![Screenshot 2023-12-13 at 1 03 51 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/0b4e14ad-acab-44d9-b8d0-baa3acb2a2a0)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206157829306087