### PR TITLE
Party should not be linked

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -20,9 +20,9 @@
         {% endif %}
         {% if person_post.deselected %}
             <p>
-                {% trans "This candidate has been deselected by their party, but will remain on the ballot paper."%}
-                <a href="{{ person_post.deselected_source }}" target="_blank">{% trans "Learn more" %}<a>.
-                </p>
+                {% trans "This candidate has been deselected by their party, but will remain on the ballot paper." %}
+                <a href="{{ person_post.deselected_source }}" target="_blank">{% trans "Learn more" %}.</a>
+            </p>
         {% endif %}
 
         {% if not person_post.list_position or not postelection.display_as_party_list %}


### PR DESCRIPTION
Quick fix to close a `<a>` tag. 

Before: http://localhost:8000/elections/local.hackney.cazenove.by.2024-01-18/

After: 
<img width="865" alt="Screenshot 2024-01-18 at 2 19 29 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/08544885-20a7-4ce4-96f2-fac2ddd51b68">
