### PR TITLE
Not everything is a card

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-11 14:52+0000\n"
+"POT-Creation-Date: 2024-04-05 18:48+0100\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -29,21 +29,21 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
-#: wcivf/apps/elections/models.py:690
+#: wcivf/apps/elections/models.py:685
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
-#: wcivf/apps/elections/models.py:692
+#: wcivf/apps/elections/models.py:687
 #, fuzzy
 #| msgid "The Additional Member System"
 msgid "Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
 
-#: wcivf/apps/elections/models.py:694
+#: wcivf/apps/elections/models.py:689
 msgid "Supplementary Vote"
 msgstr "Pleidlais Atodol"
 
-#: wcivf/apps/elections/models.py:696
+#: wcivf/apps/elections/models.py:691
 msgid "Single Transferable Vote"
 msgstr "Pleidlais Sengl Drosglwyddadwy"
 
@@ -53,7 +53,7 @@ msgstr "Pleidlais Sengl Drosglwyddadwy"
 msgid "The %(election)s %(was_or_will_be)s held on %(date)s."
 msgstr "Cynhelir yr %(election)s %(was_or_will_be)s ar %(date)s."
 
-#: wcivf/apps/elections/templates/elections/election_view.html:23
+#: wcivf/apps/elections/templates/elections/election_view.html:22
 #, python-format
 msgid ""
 "The %(election)s <strong>is being held today</strong>. Polls are open from"
@@ -61,11 +61,11 @@ msgstr ""
 "Cynhelir yr %(election)s <strong>heddiw</strong>. Bydd y gorsafoedd "
 "pleidleisio ar agor o"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:24
+#: wcivf/apps/elections/templates/elections/election_view.html:23
 msgid "till"
 msgstr "tan"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:28
+#: wcivf/apps/elections/templates/elections/election_view.html:27
 #, fuzzy, python-format
 #| msgid "This election will be held <strong> %(election_date)s</strong>."
 msgid ""
@@ -74,7 +74,7 @@ msgid ""
 msgstr ""
 "Bydd yr etholiad hwn yn cael ei gynnal <strong>%(election_date)s</strong>"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:39
+#: wcivf/apps/elections/templates/elections/election_view.html:38
 #, python-format
 msgid ""
 "%(stood_or_standing)s for this election, in <strong>%(post_count)s</strong> "
@@ -83,21 +83,21 @@ msgstr ""
 "Ymgeisiodd%(stood_or_standing)s yn yr etholiad hwn, mewn "
 "<strong>%(post_count)s</strong> swydd."
 
-#: wcivf/apps/elections/templates/elections/election_view.html:45
+#: wcivf/apps/elections/templates/elections/election_view.html:44
 msgid "Add more at our candidate crowd-sourcing site"
 msgstr "Ychwanegwch ragor ar ein gwefan torfoli ymgeiswyr"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:50
+#: wcivf/apps/elections/templates/elections/election_view.html:49
 msgid "Add some candidates at our candidate crowd-sourcing site"
 msgstr "Ychwanegwch rai ymgeiswyr at ein gwefan torfoli ymgeiswyr"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:54
+#: wcivf/apps/elections/templates/elections/election_view.html:53
 #, fuzzy, python-format
 #| msgid " %(title)s"
 msgid "%(title)s"
 msgstr " %(title)s"
 
-#: wcivf/apps/elections/templates/elections/election_view.html:58
+#: wcivf/apps/elections/templates/elections/election_view.html:57
 #, python-format
 msgid ""
 "<a href=\"%(postelection_url)s\">%(post_label)s</a> %(cancelled_message)s"
@@ -115,12 +115,12 @@ msgstr "Etholiadau'r DU"
 msgid "All Elections in the UK"
 msgstr "Pob Etholiad yn y DU"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:18
-#: wcivf/templates/base.html:112
+#: wcivf/apps/elections/templates/elections/elections_view.html:16
+#: wcivf/templates/base.html:105
 msgid "All Elections"
 msgstr "Pob Etholiad"
 
-#: wcivf/apps/elections/templates/elections/elections_view.html:19
+#: wcivf/apps/elections/templates/elections/elections_view.html:17
 msgid ""
 "This is a list of upcoming elections, and all elections Democracy Club has "
 "covered since 2010. The local election database was founded in 2016."
@@ -132,6 +132,42 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_ams_breadcrumbs.html:7
 msgid "The Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
+
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:9
+#, python-format
+msgid "Add future elections in %(postcode)s to your calendar"
+msgstr "Ychwanegwch etholiadau'r dyfodol yn %(postcode)s at eich calendr"
+
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:13
+#, fuzzy
+#| msgid ""
+#| "Or manually subscribe by following these simple steps for your chosen "
+#| "calendar tool:"
+msgid ""
+"Manually subscribe by following these simple steps for your chosen calendar "
+"tool:"
+msgstr ""
+"Neu tanysgrifiwch â llaw drwy ddilyn y camau syml hyn ar gyfer eich offeryn "
+"calendr dewisol:"
+
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:16
+msgid ""
+"In your calendar app settings, choose the option for adding a new calendar."
+msgstr ""
+"Yng ngosodiadau eich ap calendr, dewiswch yr opsiwn ar gyfer ychwanegu "
+"calendr newydd."
+
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:19
+msgid ""
+"If presented with the option to choose a calendar type, choose web calendar."
+msgstr ""
+"Os cewch eich cyflwyno â'r opsiwn i ddewis math o galendr, dewiswch galendr "
+"y we."
+
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:23
+#: wcivf/apps/elections/templates/elections/includes/_calendar.html:25
+msgid "Enter this URL and save"
+msgstr "Rhowch yr URL hwn a'i arbed"
 
 #: wcivf/apps/elections/templates/elections/includes/_cancelled_election.html:8
 msgid "Uncontested Election"
@@ -306,22 +342,21 @@ msgstr "Rydych chi yma"
 #: wcivf/apps/parties/templates/parties/party_detail.html:17
 #: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:17
 #: wcivf/apps/people/templates/people/person_detail.html:31
-#: wcivf/templates/base.html:111
+#: wcivf/templates/base.html:104
 msgid "Home"
 msgstr "Cartref"
 
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:9
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:9
 msgid "Elections"
 msgstr "Etholiadau"
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:17
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:15
 #, fuzzy
 #| msgid "How you vote"
 msgid "How to vote"
 msgstr "Sut i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:20
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:18
 #, python-format
 msgid ""
 "This election uses <a href=\"%(voting_system_url)s\">%(voting_system_name)s</"
@@ -330,28 +365,28 @@ msgstr ""
 "Mae’r etholiad hwn yn defnyddio <a "
 "href=\"%(voting_system_url)s\">%(voting_system_name)s</a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:24
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:22
 #, python-format
 msgid "This election uses %(voting_system_name)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:33
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:85
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:31
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:75
 msgid "Mark an X in the box for your preferred candidate."
 msgstr "Nodwch X yn y blwch ar gyfer eich ymgeisydd dewisol."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:35
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:33
 msgid "Mark an X in the box for your preferred candidates."
 msgstr "Nodwch X yn y blwch ar gyfer eich ymgeiswyr dewisol."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:40
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:38
 #, python-format
 msgid "You can mark up to %(winner_count)s candidate."
 msgid_plural "You can mark up to %(winner_count)s candidates."
 msgstr[0] "Gallwch nodi hyd at %(winner_count)s ymgeisydd."
 msgstr[1] "Gallwch nodi hyd at %(winner_count)s o ymgeiswyr."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:51
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:49
 msgid ""
 "Rank the candidates by your preference: 1, 2, 3… You don't have to rank all "
 "the candidates, but you must at least mark your first choice."
@@ -359,30 +394,23 @@ msgstr ""
 "Graddiwch yr ymgeiswyr yn ôl eich dewis: 1, 2, 3… Does dim rhaid i chi "
 "raddio'r holl ymgeiswyr, ond rhaid i chi o leiaf nodi eich dewis cyntaf."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:60
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:58
 msgid ""
 "Mark an X in the first column for your first choice. Mark an X in the second "
 "column for your second choice. You do not have to mark a second choice."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:70
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:68
 msgid "Mark an X in the box for one party or independent candidate."
 msgstr ""
 "Bydd gennych un bleidlais, a gallwch bleidleisio dros un blaid neu ymgeisydd "
 "annibynnol."
 
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:78
-msgid ""
-"Mark an X in the box next to your preferred party or independent candidate"
-msgstr ""
-"Bydd gennych un bleidlais, a gallwch bleidleisio dros un blaid neu ymgeisydd "
-"annibynnol."
-
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:88
 msgid "Read the instructions at the top of your ballot paper carefully."
 msgstr "Darllenwch y cyfarwyddiadau ar frig eich papur pleidleisio yn ofalus."
 
-#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:89
+#: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:79
 msgid ""
 "For more information, visit <a href=\"https://www.electoralcommission.org.uk/"
 "i-am-a/voter/how-cast-your-vote\">The Electoral Commission's website</a> or "
@@ -393,19 +421,19 @@ msgstr ""
 "gofynnwch i swyddog yn eich gorsaf bleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15
-msgid "Elected:"
-msgstr "Etholwyd:"
-
-#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:24
 #, python-format
 msgid "Photo of %(pp.person.name)s"
 msgstr "Llun o %(pp.person.name)s"
 
-#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:37
+#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:22
+msgid "Elected:"
+msgstr "Etholwyd:"
+
+#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:36
 msgid "Party emblem"
 msgstr "Symbol y blaid"
 
-#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:45
+#: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:44
 #, python-format
 msgid "Show %(num_candidates)s candidates"
 msgstr "Dangos %(num_candidates)s ymgeiswyr"
@@ -414,54 +442,69 @@ msgstr "Dangos %(num_candidates)s ymgeiswyr"
 msgid "Elected"
 msgstr "Etholwyd"
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:25
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:23
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:42
+msgid ""
+"This candidate has been deselected by their party, but will remain on the "
+"ballot paper."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:24
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:43
+#, fuzzy
+#| msgid "Read more"
+msgid "Learn more"
+msgstr "Darllenwch ragor"
+
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:31
 #, fuzzy, python-format
 msgid "%(votes_cast)s votes"
 msgstr "%(votes_cast)s pleidlais (etholwyd)"
 
-#: wcivf/apps/elections/templates/elections/includes/_person_card.html:33
+#: wcivf/apps/elections/templates/elections/includes/_person_card.html:39
 #, python-format
 msgid "Photo of %(person_name)s"
 msgstr "Llun o %(person_name)s"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:10
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:9
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:82
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:16
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:15
 msgid ""
 "Your council is trialling a system that allows you to vote in person before "
 "polling day. You can vote in advance at this location, or vote at your "
 "polling station as normal on polling day."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:23
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:22
 msgid "Vote before polling day"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:25
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:24
 msgid "Your advance voting station is:"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:34
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:33
 msgid "Advance voting station opening times"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:36
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:12
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:35
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:9
 msgid "Date"
 msgstr "Dyddiad"
 
 #. Translators: Opening times, from and to
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:38
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:37
 msgid "Open"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:49
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:48
 msgid "Vote on polling day"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:51
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:50
 #, fuzzy, python-format
 #| msgid ""
 #| "Your polling station is <strong>%(polling_station_address)s</strong>.It "
@@ -473,28 +516,27 @@ msgstr ""
 "Eich gorsaf bleidleisio yw <strong>%(polling_station_address)s</strong>. "
 "Bydd ar agor o <strong>7am tan 10pm</strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:59
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:58
 msgid "It will be open from <strong>7am to 10pm</strong>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:65
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:64
 msgid "and"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:74
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:76
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:72
 #, fuzzy
 #| msgid "You don't need to take your poll card with you"
 msgid "You don't need to take your poll card with you."
 msgstr "Nid oes angen i chi ddod â'ch cerdyn pleidleisio gyda chi"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:82
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:77
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
 "election day up to 10pm"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:89
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:84
 #, fuzzy, python-format
 #| msgid ""
 #| "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
@@ -506,7 +548,7 @@ msgstr ""
 "<p>Gallwch ddod o hyd i'ch gorsaf bleidleisio drwy <a "
 "href=\"%(custom_finder)s\"> ddilyn y ddolen hon</a>.</p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:92
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
@@ -515,7 +557,7 @@ msgstr ""
 "<strong>Bydd gorsafoedd pleidleisio ar agor o %(open_time)s tan "
 "%(close_time)s heddiw.</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -526,14 +568,14 @@ msgstr ""
 "<a href=\"https://wheredoivote.co.uk/postcode/%(postcode)s/\">Gwiriwch yr "
 "orsaf bleidleisio gywir ar gyfer eich cyfeiriad&raquo;</a></p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:107
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 "Dylech dderbyn \"cerdyn pleidleisio\" drwy'r post yn dweud ble y dylech chi "
 "bleidleisio."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:105
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call the "
@@ -543,7 +585,7 @@ msgstr ""
 "ffonio'r Swyddfa Cofrestru Etholiadol <a href=\"tel:"
 "%(council_phone)s\">%(council_phone)s</a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
@@ -552,7 +594,7 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "%(council_name)s ar <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:120
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council"
@@ -560,25 +602,25 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "eich cyngor lleol"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:129
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:124
 msgid "You will need photographic identification."
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:135
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:130
 msgid "Read more about how to vote in Northern Ireland"
 msgstr "Darllenwch fwy am sut i bleidleisio yng Ngogledd Iwerddon"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:139
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:134
 msgid "Read more about how to vote"
 msgstr "Darllenwch fwy am sut i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:148
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:143
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions"
 msgstr "Cael cyfarwyddiadau cerdded o"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:152
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:147
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions from"
@@ -631,7 +673,7 @@ msgstr ""
 "bleidleisio"
 
 #: wcivf/apps/elections/templates/elections/includes/_postcode_search_form.html:11
-#: wcivf/templates/home.html:23
+#: wcivf/templates/home.html:22
 msgid "Find your candidates"
 msgstr "Dod o hyd i'ch ymgeiswyr"
 
@@ -648,11 +690,12 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:9
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:10
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:90
 msgid "Register to vote"
 msgstr "Cofrestru i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:13
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:15
 msgid ""
 "You need to be registered in order to vote. If you aren't registered to vote "
 "visit <a href=\"https://www.gov.uk/register-to-vote\"> https://www.gov.uk/"
@@ -662,7 +705,7 @@ msgstr ""
 "cofrestru i bleidleisio, ewch i <a href=\"https://www.gov.uk/register-to-"
 "vote\"> https://www.gov.uk/register-to-vote </a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:23
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:25
 #, python-format
 msgid ""
 "Register before midnight on %(registration_deadline)s to vote on "
@@ -671,21 +714,21 @@ msgstr ""
 "Cofrestrwch cyn hanner nos ar %(registration_deadline)s i bleidleisio ar "
 "%(election_date)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:30
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:36
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:32
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:38
 msgid "To register by post, contact your Valuation Joint Board."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:32
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:34
 #, python-format
 msgid "To register by post, contact %(council_name)s."
 msgstr "I gofrestru drwy'r post, cysylltwch â %(council_name)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:38
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:40
 msgid "To register by post, contact your local council."
 msgstr "I gofrestru drwy'r post, cysylltwch â'ch cyngor lleol."
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:50
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:52
 msgid ""
 "For questions about your poll card, polling place, or about returning your "
 "postal voting ballot, contact your council."
@@ -694,11 +737,11 @@ msgstr ""
 "bleidleisio, neu ynghylch dychwelyd eich pleidlais drwy'r post, cysylltwch "
 "â'ch cyngor."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:21
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:19
 msgid "Additional members"
 msgstr "Aelodau ychwanegol"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:32
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:30
 #, python-format
 msgid ""
 "This election <strong>is being held today</strong>. Polls are open from "
@@ -707,18 +750,28 @@ msgstr ""
 "Cynhelir yr etholiad hwn <strong>heddiw</strong>. Mae gorsafoedd pleidleisio "
 "ar agor o %(open_time)s tan %(close_time)s"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:38
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:36
 #, python-format
 msgid "This election was held <strong>%(election_date)s</strong>."
 msgstr "Cynhaliwyd yr etholiad hwn <strong>%(election_date)s</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:42
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:40
 #, python-format
 msgid "This election will be held <strong> %(election_date)s</strong>."
 msgstr ""
 "Bydd yr etholiad hwn yn cael ei gynnal <strong>%(election_date)s</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:55
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:53
+msgid "About this position"
+msgstr "Ynglŷn â'r rôl hon"
+
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:54
+#, fuzzy, python-format
+#| msgid " %(description)s "
+msgid " %(description)s"
+msgstr " %(description)s "
+
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:61
 #, python-format
 msgid ""
 "<strong>%(num_candidates)s candidate%(plural)s</strong> stood in the "
@@ -727,27 +780,30 @@ msgstr ""
 "Ymgeisiodd <strong>%(num_candidates)s ymgeisydd%(plural)s</strong> yn "
 "%(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:60
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:66
 msgid ""
 "We don't know of any candidates standing yet. You can help improve this page:"
 msgstr ""
 "Ni wyddwn am unrhyw ymgeiswyr sy'n sefyll eto. Gallwch helpu i wella'r "
 "dudalen hon:"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:61
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:68
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:67
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:78
 msgid "add information about candidates to our database"
 msgstr "ychwanegwch wybodaeth am ymgeiswyr i'n cronfa ddata"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:66
-msgid "We don't know of any candidates standing yet."
-msgstr "Ni wyddwn am unrhyw ymgeiswyr sy'n sefyll eto."
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:72
+#, python-format
+msgid ""
+"We don't know of any candidates standing yet. The official candidate list "
+"will be published by %(expected_sopn_date)s, when this page will be updated. "
+"You can help improve this page:"
+msgstr ""
+"Gallwch helpu i wella'r dudalen hon:Ni wyddwn am unrhyw ymgeiswyr sy'n "
+"sefyll eto. Bydd y rhestr swyddogol o ymgeiswyr yn cael ei chyhoeddi erbyn "
+"%(expected_sopn_date)s, pan fydd y dudalen hon yn cael ei diweddaru."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:67
-msgid "You can help improve this page:"
-msgstr "Gallwch helpu i wella'r dudalen hon:"
-
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:73
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:84
 msgid ""
 "You will have one vote, and can vote for a single party list or independent "
 "candidate."
@@ -755,17 +811,18 @@ msgstr ""
 "Bydd gennych un bleidlais, a gallwch bleidleisio dros un blaid neu ymgeisydd "
 "annibynnol."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:76
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:87
 #, python-format
 msgid ""
 "You will have <strong>%(winner_count)s vote%(plural)s</strong>, and can "
 "choose from <strong>%(num_candidates)s candidate%(plural_candidates)s</"
 "strong>."
 msgstr ""
-"Bydd gennych <strong>%(winner_count)s bleidlais%(plural)s</strong>, a gallwch ddewis o "
-"<strong>%(num_candidates)s ymgeisydd%(plural_candidates)s</strong>."
+"Bydd gennych <strong>%(winner_count)s bleidlais%(plural)s</strong>, a "
+"gallwch ddewis o <strong>%(num_candidates)s ymgeisydd%(plural_candidates)s</"
+"strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:82
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:93
 #, fuzzy, python-format
 #| msgid ""
 #| "You will have two votes, and can choose from <strong>%(num_ballots)s</"
@@ -777,7 +834,7 @@ msgstr ""
 "Bydd gennych ddwy bleidlais, a gallwch ddewis o <strong>%(num_ballots)s</"
 "strong> yn yr %(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:87
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
 #, fuzzy, python-format
 #| msgid ""
 #| "You will have two votes, and can choose from <strong>%(num_ballots)s</"
@@ -789,7 +846,7 @@ msgstr ""
 "Bydd gennych ddwy bleidlais, a gallwch ddewis o <strong>%(num_ballots)s</"
 "strong> yn yr %(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:94
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:105
 #, fuzzy, python-format
 #| msgid ""
 #| "There is one seat up for election, and you can choose from "
@@ -801,7 +858,7 @@ msgstr ""
 "Mae yna un sedd ar gael yn yr etholiad, a gallwch ddewis o %(num_ballots)s "
 "ymgeisydd."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:109
 #, fuzzy, python-format
 #| msgid ""
 #| "There are %(winner_count)s seats up for election, and you can choose from "
@@ -813,20 +870,17 @@ msgstr ""
 "Mae yna %(winner_count)s seddi sedd ar gael yn yr etholiad, a gallwch ddewis "
 "o %(num_ballots)s ymgeisydd."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:109
-#, python-format
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:120
+#, fuzzy, python-format
+#| msgid "%(num_candidates)s candidate%(pluralize_candidates)s"
 msgid ""
-"This candidate will not be confirmed until the council publishes the "
-"official candidate list on %(expected_sopn_date)s."
-msgid_plural ""
-"These candidates will not be confirmed until the council publishes the "
-"official candidate list on %(expected_sopn_date)s."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
+"We are currently aware of %(num_candidates)s candidate%(plural_candidates)s "
+"for this position."
+msgstr ""
+"We are currently aware of %(num_candidates)s "
+"ymgeisydd%(pluralize_candidates)s for this position."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:118
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:124
 #, fuzzy, python-format
 #| msgid ""
 #| "The official candidate list has not yet been published. However, we "
@@ -834,42 +888,37 @@ msgstr[3] ""
 #| "You can help improve this page: <a href=\"%(ynr_link)s\"> add information "
 #| "about candidates to our database</a>."
 msgid ""
-"Once nomination papers are published, we will manually verify each "
-"candidate. You can help improve this page: <a href=\"%(ynr_link)s\"> add "
-"information about candidates to our database</a>."
+"The official candidate list will be published by %(expected_sopn_date)s, "
+"when this page will be updated. Once nomination papers are published, we "
+"will manually verify each candidate. You can help improve this page: <a "
+"href=\"%(ynr_link)s\"> add information about candidates to our database</a>."
 msgstr ""
 "Nid yw'r rhestr swyddogol o ymgeiswyr wedi'i chyhoeddi eto. Fodd bynnag, "
 "disgwylwn <strong>%(num_ballots)s</strong> yn yr %(postelection)s. Gallwch "
 "helpu i wella'r dudalen hon: <a href=\"%(ynr_link)s\"> ychwanegwch wybodaeth "
 "am ymgeiswyr i'n cronfa ddata</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:134
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:140
 msgid "Read the official candidate booklet for this election."
 msgstr "Darllenwch y llyfryn ymgeiswyr swyddogol ar gyfer yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:142
-#, fuzzy, python-format
-#| msgid " %(description)s "
-msgid " %(description)s"
-msgstr " %(description)s "
-
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:153
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:150
 msgid "Electorate"
 msgstr "Nifer etholwyr"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:160
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:157
 msgid "Ballot Papers Issued"
 msgstr "Bapurau pleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:167
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:164
 msgid "Spoilt Ballots"
 msgstr "Nifer y bleidleisiau a ddifethwyd"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:174
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:171
 msgid "Turnout"
 msgstr "Cyfrif pleidleisiau"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:194
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:193
 #, python-format
 msgid ""
 "The <a href=\"%(sopn_url)s\">official candidate list</a> has been published."
@@ -877,23 +926,23 @@ msgstr ""
 "Mae'r <a href=\"%(sopn_url)s\">rhestr swyddogol o ymgeiswyr</a> wedi'i "
 "chyhoeddi."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:199
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:198
 msgid "The official candidate list should have been published on"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr fod wedi'i chyhoeddi ar "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:201
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:200
 msgid "The official candidate list should be published on"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr gael ei chyhoeddi ar"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:212
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:211
 msgid "Can you vote in this election?"
 msgstr "A allwch chi bleidleisio yn yr etholiad hwn?"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:213
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:212
 msgid "Age"
 msgstr "Oedran"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:215
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:214
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
@@ -902,27 +951,31 @@ msgstr ""
 "Mae angen i chi fod dros %(voter_age)s ar %(voter_age_date)s "
 "%(election_date)s i bleidleisio yn yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:220
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:219
 msgid "Citizenship"
 msgstr "Dinasyddiaeth"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:237
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:236
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:239
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:238
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:11
 msgid "Read more on Wikipedia"
 msgstr "Darllenwch fwy ar Wikipedia"
 
-#: wcivf/apps/elections/templates/elections/includes/_voter_id.html:10
+#: wcivf/apps/elections/templates/elections/includes/_voter_id.html:11
 msgid ""
 "You will need to take photo ID to vote at a polling station in this election"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_voter_id.html:13
-msgid "You must vote at your assigned polling station."
+#: wcivf/apps/elections/templates/elections/includes/_voter_id.html:15
+msgid ""
+"You do not need your poll card to vote. You must vote at your assigned "
+"polling station.\n"
+"                Read more about <a href=\"https://www.gov.uk/voting-in-the-"
+"uk/polling-stations\">voting in Great Britain</a>."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/eu_results.html:7
@@ -943,20 +996,20 @@ msgstr ""
 msgid "View results"
 msgstr "Gweld y canlyniadau"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:6
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:5
 #, fuzzy
 #| msgid "We don't know of any upcoming elections."
 msgid "We don't know of any upcoming elections in your area."
 msgstr "Ni wyddwn am unrhyw etholiadau sydd i ddod"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:7
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:6
 msgid ""
 "Local and devolved elections in the UK typically happen on the first "
 "Thursday in May. By-elections and parliamentary general elections can happen "
 "at any time. Not all areas have elections each year."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:8
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:7
 #, fuzzy
 #| msgid ""
 #| "For more information, visit <a href=\"https://www.electoralcommission.org."
@@ -971,15 +1024,15 @@ msgstr ""
 "am-a/voter/how-cast-your-vote\">Wefan y Comisiwn Etholiadol</a> neu "
 "gofynnwch i swyddog yn eich gorsaf bleidleisio."
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:14
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:13
 msgid "Elections in your area"
 msgstr "Etholiadau yn eich ardal"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:32
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:31
 msgid "Recently past elections"
 msgstr "Etholiadau diweddar yn y gorffennol"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:45
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:44
 #, python-format
 msgid ""
 "You will have %(num_ballots)s ballot paper%(ballots_pluralised)s to fill out."
@@ -987,81 +1040,92 @@ msgstr ""
 "Bydd gennych %(num_ballots)s papur pleidleisio%(ballots_pluralised)s i'w "
 "lenwi."
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:61
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:60
 #, python-format
 msgid "%(ballot.short_cancelled_message_html)s"
 msgstr "%(ballot.short_cancelled_message_html)s"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:71
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:70
 msgid "(uncontested)"
 msgstr "(dim cystadleuaeth)"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:72
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:71
 msgid "(may be contested)"
 msgstr "(efallai y bydd cystadleuaeth)"
 
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:85
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:79
+#, fuzzy
+#| msgid "Where to vote"
+msgid "Get ready to vote"
+msgstr "Ble i bleidleisio"
+
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:86
+msgid "Voter ID requirements"
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:101
 #, fuzzy
 #| msgid ""
 #| "There may also be parish, town or community council elections in some "
 #| "areas."
-msgid "There may be parish, town or community council elections in some areas."
+msgid ""
+"There may also be parish, town or community council elections in some areas."
 msgstr ""
 "Efallai y bydd etholiadau cyngor plwyf, tref neu gymunedol mewn rhai "
 "ardaloedd."
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:14
+#: wcivf/apps/elections/templates/elections/party_list_view.html:10
 msgid "emblem"
 msgstr "symbol"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:31
+#: wcivf/apps/elections/templates/elections/party_list_view.html:27
 #, python-format
 msgid "%(party_name)s's Facebook profile"
 msgstr "Tudalen Facebook %(party_name)s"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:39
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:64
+#: wcivf/apps/elections/templates/elections/party_list_view.html:35
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:66
 msgid "Home page"
 msgstr "Hafan"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:41
+#: wcivf/apps/elections/templates/elections/party_list_view.html:37
 #, python-format
 msgid "%(party_name)s's home page"
 msgstr "Hafan %(party_name)s"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:48
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:130
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:40
+#: wcivf/apps/elections/templates/elections/party_list_view.html:44
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:159
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:38
 msgid "Email"
 msgstr "E-bost"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:62
+#: wcivf/apps/elections/templates/elections/party_list_view.html:55
 #: wcivf/apps/people/templates/people/includes/_person_manifesto_card.html:7
 msgid "Party manifesto"
 msgstr "Maniffesto'r blaid"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:65
+#: wcivf/apps/elections/templates/elections/party_list_view.html:58
 #, python-format
 msgid "Find out more about the %(party_name)s in their %(manifesto)s."
 msgstr "Dysgwch fwy am %(party_name)s yn eu %(manifesto)s."
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:74
+#: wcivf/apps/elections/templates/elections/party_list_view.html:63
 msgid "Latest tweets"
 msgstr "Trydariadau diweddar"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:77
+#: wcivf/apps/elections/templates/elections/party_list_view.html:66
 msgid "Tweets by"
 msgstr "Trydariadau gan"
 
-#: wcivf/apps/elections/templates/elections/party_list_view.html:86
+#: wcivf/apps/elections/templates/elections/party_list_view.html:71
 msgid "Candidates"
 msgstr "Ymgeiswyr"
 
-#: wcivf/apps/elections/templates/elections/post_view.html:31
+#: wcivf/apps/elections/templates/elections/post_view.html:29
 msgid "Next election"
 msgstr "Yr etholiad nesaf"
 
-#: wcivf/apps/elections/templates/elections/post_view.html:33
+#: wcivf/apps/elections/templates/elections/post_view.html:31
 #, python-format
 msgid ""
 "The <a href=\"%(post_election_url)s\">next election for %(postelection)s</a> "
@@ -1070,49 +1134,13 @@ msgstr ""
 "Cynhelir yr <a href=\"%(post_election_url)s\">etholiad nesaf ar gyfer "
 "%(postelection)s</a>"
 
-#: wcivf/apps/elections/templates/elections/post_view.html:35
+#: wcivf/apps/elections/templates/elections/post_view.html:33
 msgid "being held today"
 msgstr "heddiw"
 
-#: wcivf/apps/elections/templates/elections/post_view.html:37
+#: wcivf/apps/elections/templates/elections/post_view.html:35
 msgid "due to take place on"
 msgstr "Mae disgwyl iddo gael ei gynnal ar"
-
-#: wcivf/apps/elections/templates/elections/postcode_view.html:61
-#, python-format
-msgid "Add future elections in %(postcode)s to your calendar"
-msgstr "Ychwanegwch etholiadau'r dyfodol yn %(postcode)s at eich calendr"
-
-#: wcivf/apps/elections/templates/elections/postcode_view.html:64
-#, fuzzy
-#| msgid ""
-#| "Or manually subscribe by following these simple steps for your chosen "
-#| "calendar tool:"
-msgid ""
-"Manually subscribe by following these simple steps for your chosen calendar "
-"tool:"
-msgstr ""
-"Neu tanysgrifiwch â llaw drwy ddilyn y camau syml hyn ar gyfer eich offeryn "
-"calendr dewisol:"
-
-#: wcivf/apps/elections/templates/elections/postcode_view.html:67
-msgid ""
-"In your calendar app settings, choose the option for adding a new calendar."
-msgstr ""
-"Yng ngosodiadau eich ap calendr, dewiswch yr opsiwn ar gyfer ychwanegu "
-"calendr newydd."
-
-#: wcivf/apps/elections/templates/elections/postcode_view.html:70
-msgid ""
-"If presented with the option to choose a calendar type, choose web calendar."
-msgstr ""
-"Os cewch eich cyflwyno â'r opsiwn i ddewis math o galendr, dewiswch galendr "
-"y we."
-
-#: wcivf/apps/elections/templates/elections/postcode_view.html:74
-#: wcivf/apps/elections/templates/elections/postcode_view.html:76
-msgid "Enter this URL and save"
-msgstr "Rhowch yr URL hwn a'i arbed"
 
 #: wcivf/apps/feedback/models.py:7 wcivf/apps/feedback/models.py:8
 msgid "Yes"
@@ -1131,16 +1159,10 @@ msgid "Has this information made you more likely to vote?"
 msgstr "A yw'r wybodaeth hon wedi eich gwneud chi'n fwy tebygol o bleidleisio?"
 
 #: wcivf/apps/feedback/templates/feedback/feedback_form.html:37
-msgid "What other websites/sources have you used to research the election?"
-msgstr ""
-"Pa wefannau/ffynonellau eraill rydych chi wedi'u defnyddio i ymchwilio i'r "
-"etholiad?"
-
-#: wcivf/apps/feedback/templates/feedback/feedback_form.html:42
 msgid "Can you tell us anything more?"
 msgstr "A allwch chi ddweud unrhyw beth arall i ni?"
 
-#: wcivf/apps/feedback/templates/feedback/feedback_form.html:45
+#: wcivf/apps/feedback/templates/feedback/feedback_form.html:40
 msgid "Send feedback"
 msgstr "Anfonwch adborth"
 
@@ -1149,20 +1171,28 @@ msgid "Thanks for your feedback!"
 msgstr "Diolch am eich adborth!"
 
 #: wcivf/apps/feedback/templates/feedback/feedback_thanks.html:10
+#, fuzzy
+#| msgid ""
+#| "<p>The information you see here is gathered publicly, by people like you."
+#| "</p> <p>Help us do more to make democracy work better for everyone!</p>"
 msgid ""
-"<p>The information you see here is gathered publicly, by people like you.</"
-"p> <p>Help us do more to make democracy work better for everyone!</p>"
+"<p>The information you see here is gathered publicly, by people like you.</p>"
 msgstr ""
 "<p>Cesglir y wybodaeth y gwelwch chi yma yn gyhoeddus, gan bobl fel chi.</p> "
 "<p>Helpwch ni i wneud mwy er mwyn gwneud i ddemocratiaeth weithio'n well i "
 "bawb</p>"
 
-#: wcivf/apps/feedback/templates/feedback/feedback_thanks.html:16
+#: wcivf/apps/feedback/templates/feedback/feedback_thanks.html:14
+#, fuzzy
+#| msgid ""
+#| "<p>We're sorry you didn't find what you were looking for. We'll read your "
+#| "feedback and pass it on to our volunteers.</p> <p>The information you see "
+#| "here is gathered publicly, by people like you.</p> <p>Help us do better "
+#| "in future!</p>"
 msgid ""
 "<p>We're sorry you didn't find what you were looking for. We'll read your "
 "feedback and pass it on to our volunteers.</p> <p>The information you see "
-"here is gathered publicly, by people like you.</p> <p>Help us do better in "
-"future!</p>"
+"here is gathered publicly, by people like you.</p>"
 msgstr ""
 "<p>Mae'n flin gennym na wnaethoch chi ddod o hyd i'r hyn roeddech chi'n "
 "chwilio amdano</p> <p>Cesglir y wybodaeth y gwelwch chi yma'n gyhoeddus, gan "
@@ -1311,13 +1341,13 @@ msgstr "Rhestr o ymgeiswyr Pleidiau Gwleidyddol y DU"
 msgid "Current: Parties"
 msgstr "Ar hyn o bryd: Pleidiau"
 
-#: wcivf/apps/parties/templates/parties/parties_view.html:22
+#: wcivf/apps/parties/templates/parties/parties_view.html:20
 #, fuzzy
 #| msgid "UK Political Parties"
 msgid "UK political parties"
 msgstr "Pleidiau Gwleidyddol y DU"
 
-#: wcivf/apps/parties/templates/parties/parties_view.html:23
+#: wcivf/apps/parties/templates/parties/parties_view.html:21
 msgid ""
 "<p>The following is a list of all political parties represented by "
 "candidates in Democracy Club's UK election database (est. 2015). This list "
@@ -1501,22 +1531,22 @@ msgid ""
 "\">their role in elections</a> on the parliament.uk website."
 msgstr ""
 
-#: wcivf/apps/people/models.py:76
+#: wcivf/apps/people/models.py:78
 msgid "Elected unopposed"
 msgstr "Wedi'i ethol yn ddiwrthwynebiad."
 
-#: wcivf/apps/people/models.py:77
+#: wcivf/apps/people/models.py:79
 #, fuzzy
 #| msgid "This election was cancelled."
 msgid "(election cancelled)"
 msgstr "Canslwyd yr etholiad hwn."
 
-#: wcivf/apps/people/models.py:88
+#: wcivf/apps/people/models.py:90
 #, python-format
 msgid "(Results due after %(date)s)"
 msgstr ""
 
-#: wcivf/apps/people/models.py:100
+#: wcivf/apps/people/models.py:102
 #, fuzzy, python-format
 #| msgid "%(num_votes)s votes"
 msgid "%(num_votes)s votes (elected)"
@@ -1532,7 +1562,7 @@ msgstr "Nid yw'r cyfrif pleidleisiau ar gael"
 msgid "%(num_votes)s votes (not elected)"
 msgstr "%(num_votes)s pleidlais"
 
-#: wcivf/apps/people/models.py:112
+#: wcivf/apps/people/models.py:110
 #, fuzzy
 #| msgid "Not Elected (vote count not available)"
 msgid "Not elected (vote count not available)"
@@ -1548,118 +1578,159 @@ msgstr "Ynglyn â %(name)s"
 msgid "<h4>Favourite Biscuit</h4> <p>%(biscuit)s</p>"
 msgstr "<h4>Hoff fisgedyn</h4> <p>%(biscuit)s</p>"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:5
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:4
 msgid "online"
 msgstr "Ar-lein"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:10
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:11
 msgid "Facebook"
 msgstr "Facebook"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:14
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:15
 #, python-format
 msgid "%(person_name)s's personal Facebook"
 msgstr "Facebook personol %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:21
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:22
 #, python-format
 msgid "%(person_name)s's Facebook page"
 msgstr "Tudalen Facebook %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:31
-#: wcivf/templates/base.html:121
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:33
+#: wcivf/templates/base.html:114
 msgid "Twitter"
 msgstr "Trydar"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:33
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:35
 #, fuzzy, python-format
 #| msgid "%(person_name)s's LinkedIn profile"
 msgid "%(person_name)s's Twitter profile"
 msgstr "Tudalen LinkedIn %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:41
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:44
 msgid "Mastodon"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:43
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:46
 #, fuzzy, python-format
 #| msgid "%(person_name)s's LinkedIn profile"
 msgid "%(person_name)s's Mastodon profile"
 msgstr "Tudalen LinkedIn %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:53
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:55
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:55
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:57
 #, python-format
 msgid "%(person_name)s's LinkedIn profile"
 msgstr "Tudalen LinkedIn %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:66
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:68
 #, python-format
 msgid "%(person_name)s's home page"
 msgstr "Hafan %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:75
-#: wcivf/templates/base.html:120
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:77
+#: wcivf/templates/base.html:113
 msgid "Blog"
 msgstr "Blog"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:77
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:78
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:79
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:80
 #, python-format
 msgid "%(person_name)s's blog"
 msgstr "Blog %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:86
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:88
 msgid "Instagram"
 msgstr "Instagram"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:88
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:90
 #, python-format
 msgid "%(person_name)s's Instagram"
 msgstr "Instagram %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:97
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:99
 msgid "YouTube"
 msgstr "YouTube"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:99
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:101
 #, python-format
 msgid "%(person_name)s's YouTube"
 msgstr "YouTube %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:119
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:110
 msgid "The party's candidate page for this person"
 msgstr "Tudalen ymgeisydd y blaid ar gyfer y person hwn"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:121
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:112
 #, python-format
 msgid "Party page for %(person_name)s"
 msgstr "Tudalen y blaid ar gyfer %(person_name)s"
 
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:121
+msgid "TikTok"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:123
+#, fuzzy, python-format
+#| msgid "%(person_name)s's blog"
+msgid "%(person_name)s's TikTok"
+msgstr "Blog %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:130
+msgid "Threads"
+msgstr ""
+
 #: wcivf/apps/people/templates/people/includes/_person_contact_card.html:132
+#, fuzzy, python-format
+#| msgid "%(person_name)s's email"
+msgid "%(person_name)s's Threads"
+msgstr "E-bost %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:139
+msgid "BlueSky"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:141
+#, fuzzy, python-format
+#| msgid "%(person_name)s's blog"
+msgid "%(person_name)sBlueSky'"
+msgstr "Blog %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:148
+msgid "Other contact info"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:150
+#, fuzzy, python-format
+#| msgid "%(person_name)s's personal Facebook"
+msgid "%(person_name)sother contact info"
+msgstr "Facebook personol %(person_name)s"
+
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:161
 #, python-format
 msgid "%(person_name)s's email"
 msgstr "E-bost %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:137
-#, python-format
-msgid "<dt>We don't know %(person_name)s's email address.</dt>"
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:169
+#, fuzzy, python-format
+#| msgid "<dt>We don't know %(person_name)s's email address.</dt>"
+msgid "<dt>We don't have %(person_name)s's contact info.</dt>"
 msgstr "<dt>Nid oes gennym gyfeiriad e-bost %(person_name)s.</dt>"
 
-#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:139
+#: wcivf/apps/people/templates/people/includes/_person_contact_card.html:170
 msgid "Can you add it?"
 msgstr "A allwch chi ei ychwanegu?"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:7
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:5
 msgid "That's all we know! Will you help us find more about this candidate?"
 msgstr ""
 "Dyna'r cyfan a wyddwn! A allwch chi ein helpu i ddarganfod mwy am yr "
 "ymgeisydd hwn?"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:8
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:6
 msgid ""
 "Our volunteers have been working hard to add information on as many "
 "candidates as possible, but they need help."
@@ -1667,20 +1738,20 @@ msgstr ""
 "Bu ein gwirfoddolwyr yn gweithio'n galed yn ychwanegu gwybodaeth ar gymaint "
 "â phosibl o ymgeiswyr, ond mae angen help arnynt."
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:10
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:8
 msgid "If you can add information that should be on this page"
 msgstr "Os gallwch chi, ychwanegwch wybodaeth a ddylai fod ar y dudalen hon"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:13
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:11
 #, python-format
 msgid "- such as %(person)s's %(cta)s -"
 msgstr "- fel%(cta)s %(person)s -"
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:16
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:14
 msgid "please use our crowdsourcing website to add it."
 msgstr "defnyddiwch ein gwefan torfoli i'w ychwanegu."
 
-#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:19
+#: wcivf/apps/people/templates/people/includes/_person_edit_details_card.html:17
 msgid "Add or edit details &raquo;"
 msgstr "Ychwanegwch neu golygwch fanylion &raquo;"
 
@@ -1689,8 +1760,11 @@ msgid "an,a"
 msgstr "an,a"
 
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:16
-#, python-format
-msgid "is %(a_or_an)s %(party_name)s candidate in the following elections:"
+#, fuzzy, python-format
+#| msgid "is %(a_or_an)s %(party_name)s candidate in the following elections:"
+msgid ""
+"is %(a_or_an)s <a href=\"%(party_link)s\">%(party_name)s</a> candidate in "
+"the following elections:"
 msgstr "yw %(a_or_an)s ymgeisydd y %(party_name)s yn yr etholiadau canlynol:"
 
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:24
@@ -1698,49 +1772,49 @@ msgstr "yw %(a_or_an)s ymgeisydd y %(party_name)s yn yr etholiadau canlynol:"
 msgid "%(election)s for"
 msgstr "%(election)s ar gyfer"
 
-#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:46
+#: wcivf/apps/people/templates/people/includes/_person_intro_card.html:56
 #, python-format
 msgid "profile photo of %(person)s"
 msgstr "Llun proffil %(person)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:8
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:6
 #, python-format
 msgid "%(person)s's local party is %(party_label)s."
 msgstr "Plaid leol %(person)s yw %(party_label)s."
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:10
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:8
 #, python-format
 msgid "%(person)s is a %(party)s candidate."
 msgstr "Mae %(person)s yn ymgeisydd ar ran y %(party)s."
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:32
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:30
 msgid "Party Homepage"
 msgstr "Hafan y Blaid"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:34
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:32
 #, python-format
 msgid "%(party)s's website"
 msgstr "Gwefan y %(party)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:42
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:40
 #, python-format
 msgid "%(party)s's email"
 msgstr "E-bost y %(party)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:48
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:46
 msgid "Contact page"
 msgstr "Tudalen gyswllt"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:50
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:48
 #, python-format
 msgid "%(party)s's contact page"
 msgstr "Tudalen gyswllt y %(party)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:56
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:54
 msgid "Youtube page"
 msgstr "Tudalen Youtube"
 
-#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:58
+#: wcivf/apps/people/templates/people/includes/_person_local_party_card.html:56
 #, python-format
 msgid "%(party)s's Youtube profile"
 msgstr "Tudalen Youtube y %(party)s"
@@ -1775,18 +1849,23 @@ msgid "%(intro)sGet the latest information on this candidate at %(SITE_TITLE)s"
 msgstr ""
 "%(intro)sCael y wybodaeth ddiweddaraf am yr ymgeisydd hwn ar %(SITE_TITLE)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:9
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:7
 #, python-format
 msgid "%(person_name)s's policies"
 msgstr "Polisïau %(person_name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:13
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:10
 msgid "Statement to voters"
 msgstr "Datganiad i bleidleiswyr"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:19
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:16
 msgid "Full statement"
 msgstr "Datganiad llawn"
+
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:25
+#, python-format
+msgid "This statement was last updated on %(date)s"
+msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/_person_policy_card.html:28
 #, fuzzy, python-format
@@ -1812,25 +1891,25 @@ msgstr ""
 msgid "Recent leaflets from %(person_name)s"
 msgstr "Taflenni diweddar gan %(object.name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:46
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:47
 #, fuzzy, python-format
 #| msgid "Thumbnail of leaflet from %(object.name)s"
 msgid "Thumbnail of leaflet from %(person_name)s"
 msgstr "Thumbnail o daflen gan %(object.name)s"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:50
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:51
 #, fuzzy, python-format
 #| msgid ""
 #| "Uploaded %(date)s<br /> <a href=\"https://electionleaflets.org/leaflets/"
 #| "%(leaflet.leaflet_id)s\" class=\"cta\">See leaflet</a>"
 msgid ""
-"Uploaded %(date)s<br /> <a href=\"https://electionleaflets.org/leaflets/"
+"Uploaded %(date)s<br/> <a href=\"https://electionleaflets.org/leaflets/"
 "%(leaflet_id)s\" class=\"cta\">See leaflet</a>"
 msgstr ""
 "Uwchlwythwyd %(date)s<br /> <a href=\"https://electionleaflets.org/leaflets/"
 "%(leaflet.leaflet_id)s\" class=\"cta\">Gweld y daflen</a>"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:60
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:61
 #, fuzzy, python-format
 #| msgid ""
 #| "<a class=\"ds-cta\" href=\"https://electionleaflets.org/person/"
@@ -1847,39 +1926,45 @@ msgstr ""
 "cta\" href=\"https://electionleaflets.org/leaflets/add/\">Uwchlwythwch "
 "daflen</a>"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:74
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:75
 msgid "Record in office"
 msgstr "Record yn y swydd"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:75
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:76
 msgid "See this candidate's "
 msgstr "Gweld record yr ymgeisydd hwn"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:77
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:78
 msgid "record on TheyWorkForYou"
 msgstr "ar TheyWorkForYou"
 
-#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:78
+#: wcivf/apps/people/templates/people/includes/_person_policy_card.html:79
 msgid "their speeches, voting history and more"
 msgstr "eu hareithiau, eu hanes pleidleisio a mwy"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:13
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:6
+#, fuzzy
+#| msgid "Elections"
+msgid "elections"
+msgstr "Etholiadau"
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:10
 msgid "Election"
 msgstr "Etholiad"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:14
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:11
 msgid "Party"
 msgstr "Plaid"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:15
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:12
 msgid "Results"
 msgstr "Canlyniadau"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:17
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:14
 msgid "Other party affiliations in the past 12 months"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:19
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:16
 msgid "Position"
 msgstr "Sefyllfa"
 
@@ -2156,64 +2241,64 @@ msgstr "%(short_cancelled_message)s"
 msgid "Language:"
 msgstr "Iaith:"
 
-#: wcivf/templates/base.html:113
+#: wcivf/templates/base.html:106
 #, fuzzy
 #| msgid "Parties"
 msgid "All Parties"
 msgstr "Pleidiau"
 
-#: wcivf/templates/base.html:114
+#: wcivf/templates/base.html:107
 msgid "Standing as a candidate?"
 msgstr "Sefyll fel ymgeisydd?"
 
-#: wcivf/templates/base.html:115
+#: wcivf/templates/base.html:108
 #, python-format
 msgid "About %(SITE_TITLE)s"
 msgstr "Ynglŷn %(SITE_TITLE)s"
 
-#: wcivf/templates/base.html:116
+#: wcivf/templates/base.html:109
 msgid "Privacy"
 msgstr "Preifatrwydd"
 
-#: wcivf/templates/base.html:117
+#: wcivf/templates/base.html:110
 msgid "Source code"
 msgstr "Cod ffynhonnell"
 
-#: wcivf/templates/base.html:118
+#: wcivf/templates/base.html:111
 msgid "About Democracy Club"
 msgstr "Ynglŷn â'r Clwb Democratiaeth"
 
-#: wcivf/templates/base.html:119
+#: wcivf/templates/base.html:112
 msgid "Contact Us"
 msgstr "Cysylltwch â Ni"
 
-#: wcivf/templates/base.html:122
+#: wcivf/templates/base.html:115
 msgid "GitHub"
 msgstr "GitHub"
 
-#: wcivf/templates/base.html:129
+#: wcivf/templates/base.html:124
 msgid "democracy"
 msgstr "democratiaeth"
 
-#: wcivf/templates/base.html:129
+#: wcivf/templates/base.html:124
 msgid "club"
 msgstr "clwb"
 
-#: wcivf/templates/base.html:135 wcivf/templates/home.html:5
+#: wcivf/templates/base.html:130 wcivf/templates/home.html:5
 #: wcivf/templates/home.html:6
 msgid "Who Can I Vote For?"
 msgstr "Pwy alla i bleidleisio ar gyfer?"
 
-#: wcivf/templates/base.html:139
+#: wcivf/templates/base.html:134
 #, python-format
 msgid "Copyright &copy; %(current_year)s"
 msgstr "Hawlfraint © %(current_year)s"
 
-#: wcivf/templates/base.html:140
+#: wcivf/templates/base.html:135
 msgid "Democracy Club Community Interest Company"
 msgstr "Cwmni Buddiannau Cymunedol y Clwb Democratiaeth"
 
-#: wcivf/templates/base.html:141
+#: wcivf/templates/base.html:136
 msgid ""
 "Company No: <a href=\"https://beta.companieshouse.gov.uk/"
 "company/09461226\">09461226</a>"
@@ -2221,17 +2306,17 @@ msgstr ""
 "Rhif y Cwmni: <a href=\"https://beta.companieshouse.gov.uk/"
 "company/09461226\">09461226</a>"
 
-#: wcivf/templates/base.html:143
+#: wcivf/templates/base.html:138
 msgid ""
 "Democracy Club is a UK-based Community Interest Company that builds the "
 "digital infrastructure needed for a 21st century democracy"
 msgstr ""
 
-#: wcivf/templates/home.html:12
+#: wcivf/templates/home.html:10
 msgid "Find out about candidates in your area"
 msgstr "Cael gwybod am ymgeiswyr yn eich ardal chi"
 
-#: wcivf/templates/home.html:19
+#: wcivf/templates/home.html:17
 #, python-format
 msgid ""
 "Sorry, we don't know the postcode %(postcode)s. Is there another one you can "
@@ -2240,43 +2325,60 @@ msgstr ""
 "Mae'n flin gennym, ond nid ydym yn gwybod y cod post %(postcode)s . A oes un "
 "arall y gallwch chi ei ddefnyddio?"
 
-#: wcivf/templates/home.html:38
+#: wcivf/templates/home.html:33
 #, fuzzy
 #| msgid "You will need photographic identification."
 msgid "Photographic identification"
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/templates/home.html:40
+#: wcivf/templates/home.html:35
 msgid ""
 "Photographic identification will be required to vote in English local "
 "elections, and parliamentary elections across the UK, on and after 4 May "
 "2023."
 msgstr ""
 
-#: wcivf/templates/home.html:41
+#: wcivf/templates/home.html:37
 msgid ""
 "Learn more about photographic identification for voters on the website of "
 "the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:41
+#: wcivf/templates/home.html:37
 msgid "Learn more on the website of the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:43
+#: wcivf/templates/home.html:40
 msgid ""
 "You can apply for a free 'Voter Authority Certificate' if you do not already "
 "possess a valid ID."
 msgstr ""
 
-#: wcivf/templates/home.html:44
+#: wcivf/templates/home.html:42
 msgid "Apply for free voter ID."
 msgstr ""
 
-#: wcivf/templates/home.html:45
+#: wcivf/templates/home.html:44
 msgid "You do not need photo ID to vote by post."
 msgstr ""
 
-#: wcivf/templates/home.html:52
+#: wcivf/templates/home.html:48
 msgid "Upcoming Elections"
 msgstr "Etholiadau i ddod"
+
+#~ msgid "We don't know of any candidates standing yet."
+#~ msgstr "Ni wyddwn am unrhyw ymgeiswyr sy'n sefyll eto."
+
+#~ msgid "You can help improve this page:"
+#~ msgstr "Gallwch helpu i wella'r dudalen hon:"
+
+#~ msgid ""
+#~ "Mark an X in the box next to your preferred party or independent candidate"
+#~ msgstr ""
+#~ "Bydd gennych un bleidlais, a gallwch bleidleisio dros un blaid neu "
+#~ "ymgeisydd annibynnol."
+
+#~ msgid "What other websites/sources have you used to research the election?"
+#~ msgstr ""
+#~ "Pa wefannau/ffynonellau eraill rydych chi wedi'u defnyddio i ymchwilio "
+#~ "i'r etholiad?"

--- a/wcivf/apps/elections/templates/elections/ams.html
+++ b/wcivf/apps/elections/templates/elections/ams.html
@@ -9,171 +9,169 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>The Additional Member System</h2>
-                    <p>The Additional Member System is a form of proportional representation.
-                        AMS is used for elections to the Scottish and Welsh Parliaments,
-                        as well as for those to the London Assembly.
-                    </p>
-                    <p>
-                        Voters get two ballot papers and may vote on both: one for their
-                        constituency representative, elected on the <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>
-                        method, and one for a regional representative. They don’t have to
-                        vote for the same party on both ballots.
+            <div class="ds-padded">
+                <h2>The Additional Member System</h2>
+                <p>The Additional Member System is a form of proportional representation.
+                    AMS is used for elections to the Scottish and Welsh Parliaments,
+                    as well as for those to the London Assembly.
+                </p>
+                <p>
+                    Voters get two ballot papers and may vote on both: one for their
+                    constituency representative, elected on the <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>
+                    method, and one for a regional representative. They don’t have to
+                    vote for the same party on both ballots.
 
-                        For example, a voter in Paisley in Scotland will receive a ballot
-                        that lists all of the candidates wanting to represent Paisley in
-                        the Scottish Parliament. They will also receive a ballot that
-                        lists the parties and/or independent candidates contesting the
-                        seven seats for West Scotland. The candidates on the regional
-                        ballot paper are ranked by the political party in the order they
-                        want them elected, and voters get no choice over this order
-                        (this is known as a 'closed list').
-                    </p>
+                    For example, a voter in Paisley in Scotland will receive a ballot
+                    that lists all of the candidates wanting to represent Paisley in
+                    the Scottish Parliament. They will also receive a ballot that
+                    lists the parties and/or independent candidates contesting the
+                    seven seats for West Scotland. The candidates on the regional
+                    ballot paper are ranked by the political party in the order they
+                    want them elected, and voters get no choice over this order
+                    (this is known as a 'closed list').
+                </p>
 
-                    <h3>Seat allocation</h3>
-                    <p>The overall number of constituency seats that a party wins will have
-                        an effect on how many regional representatives it is allocated.
-                        This is designed to bring a party's number of seats closer to the
-                        percentage of the overall vote it received in a region.
-                        Regional seats are allocated according to a formula known as the D’Hondt
-                        method. The number of votes needed to win a seat (the ‘quota’) is
-                        calculated using the following formula:
-                        <p class="ds-card ds-padded ds-dark">
-                            Vote quota = Total number of votes won by the party / Total number of seats already won by the
-                            party, +1.
-                        </p>
-                        <p>
-                            Seats are allocated after rounds of counting. In order to be
-                            allocated a regional seat, a party must have the highest vote number
-                            after the above formula has been applied.
-                        </p>
+                <h3>Seat allocation</h3>
+                <p>The overall number of constituency seats that a party wins will have
+                    an effect on how many regional representatives it is allocated.
+                    This is designed to bring a party's number of seats closer to the
+                    percentage of the overall vote it received in a region.
+                    Regional seats are allocated according to a formula known as the D’Hondt
+                    method. The number of votes needed to win a seat (the ‘quota’) is
+                    calculated using the following formula:
+                    <p class="ds-card ds-padded ds-dark">
+                        Vote quota = Total number of votes won by the party / Total number of seats already won by the
+                        party, +1.
                     </p>
-                    <h3>Example election</h3>
                     <p>
-                        In the 2016 West Scotland region, the result for the major parties was
-                        as follows (with vote quota totals for subsequent rounds shown in brackets):
+                        Seats are allocated after rounds of counting. In order to be
+                        allocated a regional seat, a party must have the highest vote number
+                        after the above formula has been applied.
                     </p>
-                    <div class="ds-table ds-padded">
-                        <table>
-                            <caption>
-                                <h2>
-                                    West Scotland region, 2016 Scottish Parliament elections
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Party</th>
-                                    <th>Constituency seats won (10 total)</th>
-                                    <th>Votes won</th>
-                                    <th>First round quota</th>
-                                    <th>Second round quota</th>
-                                    <th>Third round quota</th>
-                                    <th>Fourth round quota</th>
-                                    <th>Fifth round quota</th>
-                                    <th>Sixth round quota</th>
-                                    <th>Seventh round quota</th>
-                                    <th>Regional Seats Won</th>
-                                </tr>
-                                <tr>
-                                    <td>SNP</td>
-                                    <td>8</td>
-                                    <td>135,827</td>
-                                    <td>15,091</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>0</td>
-                                </tr>
-                                <tr>
-                                    <td>Labour</td>
-                                    <td>1</td>
-                                    <td>72,544</td>
-                                    <td>36,272 (elected)</td>
-                                    <td>24,181</td>
-                                    <td>18,136</td>
-                                    <td>No change (elected)</td>
-                                    <td>No change</td>
-                                    <td>No change (elected)</td>
-                                    <td>No change</td>
-                                    <td>3</td>
-                                </tr>
-                                <tr>
-                                    <td>Conservative</td>
-                                    <td>1</td>
-                                    <td>71,528</td>
-                                    <td>35,764</td>
-                                    <td>No change (elected)</td>
-                                    <td>23,842 (elected)</td>
-                                    <td>17,882</td>
-                                    <td>No change elected)</td>
-                                    <td>3,576</td>
-                                    <td>No change</td>
-                                    <td>3</td>
-                                </tr>
-                                <tr>
-                                    <td>Green</td>
-                                    <td>0</td>
-                                    <td>17,218</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change (elected)</td>
-                                    <td>1</td>
-                                </tr>
-                                <tr>
-                                    <td>Lib. Dem.</td>
-                                    <td>0</td>
-                                    <td>12,097</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>No change</td>
-                                    <td>0</td>
-                                </tr>
+                </p>
+                <h3>Example election</h3>
+                <p>
+                    In the 2016 West Scotland region, the result for the major parties was
+                    as follows (with vote quota totals for subsequent rounds shown in brackets):
+                </p>
+                <div class="ds-table ds-padded">
+                    <table>
+                        <caption>
+                            <h2>
+                                West Scotland region, 2016 Scottish Parliament elections
+                            </h2>
+                        </caption>
+                        <tbody>
+                            <tr>
+                                <th>Party</th>
+                                <th>Constituency seats won (10 total)</th>
+                                <th>Votes won</th>
+                                <th>First round quota</th>
+                                <th>Second round quota</th>
+                                <th>Third round quota</th>
+                                <th>Fourth round quota</th>
+                                <th>Fifth round quota</th>
+                                <th>Sixth round quota</th>
+                                <th>Seventh round quota</th>
+                                <th>Regional Seats Won</th>
+                            </tr>
+                            <tr>
+                                <td>SNP</td>
+                                <td>8</td>
+                                <td>135,827</td>
+                                <td>15,091</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>Labour</td>
+                                <td>1</td>
+                                <td>72,544</td>
+                                <td>36,272 (elected)</td>
+                                <td>24,181</td>
+                                <td>18,136</td>
+                                <td>No change (elected)</td>
+                                <td>No change</td>
+                                <td>No change (elected)</td>
+                                <td>No change</td>
+                                <td>3</td>
+                            </tr>
+                            <tr>
+                                <td>Conservative</td>
+                                <td>1</td>
+                                <td>71,528</td>
+                                <td>35,764</td>
+                                <td>No change (elected)</td>
+                                <td>23,842 (elected)</td>
+                                <td>17,882</td>
+                                <td>No change elected)</td>
+                                <td>3,576</td>
+                                <td>No change</td>
+                                <td>3</td>
+                            </tr>
+                            <tr>
+                                <td>Green</td>
+                                <td>0</td>
+                                <td>17,218</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change (elected)</td>
+                                <td>1</td>
+                            </tr>
+                            <tr>
+                                <td>Lib. Dem.</td>
+                                <td>0</td>
+                                <td>12,097</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>No change</td>
+                                <td>0</td>
+                            </tr>
 
-                            </tbody>
-                        </table>
-                    </div>
-                    <p>
-                        Although the SNP won the most votes,
-                        because they won eight out of the ten
-                        constituency seats their quota was 15,092,
-                        below almost all the other parties.
-                        As a result, they were not entitled to
-                        any regional seats.
-                    </p>
-                    <p>
-                        Labour and the Conservatives also each
-                        won a constituency seat, so their vote
-                        tally is divided by two in round one of
-                        the seat allocation, while everyone else’s
-                        is divided by one. Labour’s vote quota in
-                        round one was 36,272 (72,544/2) so the
-                        top-ranked person on their list was elected.
-                    </p>
-                    <p> This process was then repeated, with
-                        Labour’s vote total now 24,181 as it was
-                        divided by three. The Conservatives,
-                        therefore, took the second list seat.
-                        This process went on until the seventh
-                        seat was won by the Green party, who
-                        had 17,218 votes to the SNP’s quota of
-                        15,091.
-                    </p>
+                        </tbody>
+                    </table>
                 </div>
+                <p>
+                    Although the SNP won the most votes,
+                    because they won eight out of the ten
+                    constituency seats their quota was 15,092,
+                    below almost all the other parties.
+                    As a result, they were not entitled to
+                    any regional seats.
+                </p>
+                <p>
+                    Labour and the Conservatives also each
+                    won a constituency seat, so their vote
+                    tally is divided by two in round one of
+                    the seat allocation, while everyone else’s
+                    is divided by one. Labour’s vote quota in
+                    round one was 36,272 (72,544/2) so the
+                    top-ranked person on their list was elected.
+                </p>
+                <p> This process was then repeated, with
+                    Labour’s vote total now 24,181 as it was
+                    divided by three. The Conservatives,
+                    therefore, took the second list seat.
+                    This process went on until the seventh
+                    seat was won by the Green party, who
+                    had 17,218 votes to the SNP’s quota of
+                    15,091.
+                </p>
             </div>
+
         </div>
-    </div>
 
 {% endblock content %}

--- a/wcivf/apps/elections/templates/elections/ams_cy.html
+++ b/wcivf/apps/elections/templates/elections/ams_cy.html
@@ -2,134 +2,132 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Y System Aelodau Ychwanegol</h2>
-                    <p>Mae'r System Aelodau Ychwanegol (AMS) yn fath o gynrychiolaeth gyfrannol.
-                        Defnyddir y System Aelodau Ychwanegol yn etholiadau Senedd Cymru a Senedd yr Alban,                        yn ogystal ag etholiadau Cynulliad Llundain.
-                    </p>
-                    <p>
-                        Mae pleidleiswyr yn derbyn dau bapur pleidleisio a gallan nhw bleidleisio ar y ddau: un ar gyfer                        cynrychiolydd etholaeth, a etholir ar sail y <a href="{% url 'fptp_voting_system_view' %}">Cyntaf i'r felin</a>, ac un ar gyfer cynrychiolydd rhanbarthol. Does dim rhaid iddyn nhw bleidleisio dros yr un blaid gyda’r ddwy bleidlais.
+            <div class="ds-padded">
+                <h2>Y System Aelodau Ychwanegol</h2>
+                <p>Mae'r System Aelodau Ychwanegol (AMS) yn fath o gynrychiolaeth gyfrannol.
+                    Defnyddir y System Aelodau Ychwanegol yn etholiadau Senedd Cymru a Senedd yr Alban,                        yn ogystal ag etholiadau Cynulliad Llundain.
+                </p>
+                <p>
+                    Mae pleidleiswyr yn derbyn dau bapur pleidleisio a gallan nhw bleidleisio ar y ddau: un ar gyfer                        cynrychiolydd etholaeth, a etholir ar sail y <a href="{% url 'fptp_voting_system_view' %}">Cyntaf i'r felin</a>, ac un ar gyfer cynrychiolydd rhanbarthol. Does dim rhaid iddyn nhw bleidleisio dros yr un blaid gyda’r ddwy bleidlais.
 
-                        Er enghraifft, bydd pleidleisiwr yn Paisley yn yr Alban yn derbyn papur pleidleisio sy'n rhestru'r holl ymgeiswyr sydd am gynrychioli Paisley yn Senedd yr Alban. Byddan nhw hefyd yn cael papur pleidleisio sy'n                        rhestru'r pleidiau a/neu ymgeiswyr annibynnol sy'n sefyll                        am y saith sedd ar gyfer Gorllewin yr Alban. Mae'r ymgeiswyr ar y papur pleidleisio rhanbarthol                         yn cael eu rhestru yn y drefn y mae eu pleidiau gwleidyddol am iddyn nhw gael eu hethol, ac nid yw pleidleiswyr yn cael unrhyw ddewis dros y drefn hon                        (gelwir hyn yn 'restr gaeedig').
-                    </p>
+                    Er enghraifft, bydd pleidleisiwr yn Paisley yn yr Alban yn derbyn papur pleidleisio sy'n rhestru'r holl ymgeiswyr sydd am gynrychioli Paisley yn Senedd yr Alban. Byddan nhw hefyd yn cael papur pleidleisio sy'n                        rhestru'r pleidiau a/neu ymgeiswyr annibynnol sy'n sefyll                        am y saith sedd ar gyfer Gorllewin yr Alban. Mae'r ymgeiswyr ar y papur pleidleisio rhanbarthol                         yn cael eu rhestru yn y drefn y mae eu pleidiau gwleidyddol am iddyn nhw gael eu hethol, ac nid yw pleidleiswyr yn cael unrhyw ddewis dros y drefn hon                        (gelwir hyn yn 'restr gaeedig').
+                </p>
 
-                    <h3>Dyrannu seddau</h3>
-                    <p>Bydd nifer cyffredinol y seddi etholaethol y mae plaid yn eu hennill yn cael                        effaith ar faint o gynrychiolwyr rhanbarthol a ddyrennir i’r blaid honno.
-                        Bwriad hyn yw dod â nifer y seddi a enillir gan blaid yn nes at y                        ganran o’r bleidlais gyffredinol a dderbyniwyd ganddyn nhw yn y rhanbarth.
-                        Dyrennir seddi rhanbarthol yn ôl fformiwla a elwir yn ddull D'Hondt.                     Mae nifer y pleidleisiau sydd eu hangen i ennill sedd (y 'cwota') yn cael ei                        gyfrifo gan ddefnyddio'r fformiwla ganlynol:
-                        <p class="ds-card ds-padded ds-dark">
-                            Cwota'r bleidlais = Cyfanswm nifer y pleidleisiau a enillwyd gan y blaid / Cyfanswm nifer y seddi a enillwyd eisoes gan y                            blaid, +1.
-                        </p>
-                        <p>
-                            Dyrennir seddi ar ôl rowndiau cyfrif. Y pleidiau sydd â’r nifer uchaf o bleidleisiau                            ar ôl cymhwyso’r fformiwla uchod                             sy’n ennill y seddau rhanbarthol.
-                        </p>
+                <h3>Dyrannu seddau</h3>
+                <p>Bydd nifer cyffredinol y seddi etholaethol y mae plaid yn eu hennill yn cael                        effaith ar faint o gynrychiolwyr rhanbarthol a ddyrennir i’r blaid honno.
+                    Bwriad hyn yw dod â nifer y seddi a enillir gan blaid yn nes at y                        ganran o’r bleidlais gyffredinol a dderbyniwyd ganddyn nhw yn y rhanbarth.
+                    Dyrennir seddi rhanbarthol yn ôl fformiwla a elwir yn ddull D'Hondt.                     Mae nifer y pleidleisiau sydd eu hangen i ennill sedd (y 'cwota') yn cael ei                        gyfrifo gan ddefnyddio'r fformiwla ganlynol:
+                    <p class="ds-card ds-padded ds-dark">
+                        Cwota'r bleidlais = Cyfanswm nifer y pleidleisiau a enillwyd gan y blaid / Cyfanswm nifer y seddi a enillwyd eisoes gan y                            blaid, +1.
                     </p>
-                    <h3>Enghraifft o etholiad</h3>
                     <p>
-                        Yn rhanbarth Gorllewin yr Alban 2016, roedd canlyniadau’r prif bleidiau oedd                        fel a ganlyn (gyda chyfanswm y cwota pleidleisio ar gyfer rowndiau dilynol mewn cromfachau):
+                        Dyrennir seddi ar ôl rowndiau cyfrif. Y pleidiau sydd â’r nifer uchaf o bleidleisiau                            ar ôl cymhwyso’r fformiwla uchod                             sy’n ennill y seddau rhanbarthol.
                     </p>
-                    <div class="ds-table ds-padded">
-                        <table>
-                            <caption>
-                                <h2>
-                                    Rhanbarth Gorllewin yr Alban, etholiadau Senedd yr Alban 2016
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Plaid</th>
-                                    <th>Seddi etholaethol a enillwyd (cyfanswm o 10)</th>
-                                    <th>Pleidleisiau a enillwyd</th>
-                                    <th>Cwota rownd gyntaf</th>
-                                    <th>Cwota'r ail rownd</th>
-                                    <th>Cwota'r drydedd rownd</th>
-                                    <th>Cwota'r bedwaredd rownd</th>
-                                    <th>Cwota'r bumed rownd</th>
-                                    <th>Cwota'r chweched rownd</th>
-                                    <th>Cwota'r seithfed rownd</th>
-                                    <th>Seddi Rhanbarthol a Enillwyd</th>
-                                </tr>
-                                <tr>
-                                    <td>SNP</td>
-                                    <td>8</td>
-                                    <td>135,827</td>
-                                    <td>15,091</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>0</td>
-                                </tr>
-                                <tr>
-                                    <td>Llafur</td>
-                                    <td>1</td>
-                                    <td>72,544</td>
-                                    <td>36,272 (etholwyd)</td>
-                                    <td>24,181</td>
-                                    <td>18,136</td>
-                                    <td>Dim newid (etholwyd)</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid (etholwyd)</td>
-                                    <td>Dim newi</td>
-                                    <td>3</td>
-                                </tr>
-                                <tr>
-                                    <td>Ceidwadwyr</td>
-                                    <td>1</td>
-                                    <td>71,528</td>
-                                    <td>35,764</td>
-                                    <td>Dim newid (etholwyd)</td>
-                                    <td>23,842 (etholwyd)</td>
-                                    <td>17,882</td>
-                                    <td>Dim newid (etholwyd)</td>
-                                    <td>3,576</td>
-                                    <td>Dim newid</td>
-                                    <td>3</td>
-                                </tr>
-                                <tr>
-                                    <td>Y Blaid Werdd</td>
-                                    <td>0</td>
-                                    <td>17,218</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid (etholwyd)</td>
-                                    <td>1</td>
-                                </tr>
-                                <tr>
-                                    <td>Dem. Rhydd.</td>
-                                    <td>0</td>
-                                    <td>12,097</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>Dim newid</td>
-                                    <td>0</td>
-                                </tr>
+                </p>
+                <h3>Enghraifft o etholiad</h3>
+                <p>
+                    Yn rhanbarth Gorllewin yr Alban 2016, roedd canlyniadau’r prif bleidiau oedd                        fel a ganlyn (gyda chyfanswm y cwota pleidleisio ar gyfer rowndiau dilynol mewn cromfachau):
+                </p>
+                <div class="ds-table ds-padded">
+                    <table>
+                        <caption>
+                            <h2>
+                                Rhanbarth Gorllewin yr Alban, etholiadau Senedd yr Alban 2016
+                            </h2>
+                        </caption>
+                        <tbody>
+                            <tr>
+                                <th>Plaid</th>
+                                <th>Seddi etholaethol a enillwyd (cyfanswm o 10)</th>
+                                <th>Pleidleisiau a enillwyd</th>
+                                <th>Cwota rownd gyntaf</th>
+                                <th>Cwota'r ail rownd</th>
+                                <th>Cwota'r drydedd rownd</th>
+                                <th>Cwota'r bedwaredd rownd</th>
+                                <th>Cwota'r bumed rownd</th>
+                                <th>Cwota'r chweched rownd</th>
+                                <th>Cwota'r seithfed rownd</th>
+                                <th>Seddi Rhanbarthol a Enillwyd</th>
+                            </tr>
+                            <tr>
+                                <td>SNP</td>
+                                <td>8</td>
+                                <td>135,827</td>
+                                <td>15,091</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>Llafur</td>
+                                <td>1</td>
+                                <td>72,544</td>
+                                <td>36,272 (etholwyd)</td>
+                                <td>24,181</td>
+                                <td>18,136</td>
+                                <td>Dim newid (etholwyd)</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid (etholwyd)</td>
+                                <td>Dim newi</td>
+                                <td>3</td>
+                            </tr>
+                            <tr>
+                                <td>Ceidwadwyr</td>
+                                <td>1</td>
+                                <td>71,528</td>
+                                <td>35,764</td>
+                                <td>Dim newid (etholwyd)</td>
+                                <td>23,842 (etholwyd)</td>
+                                <td>17,882</td>
+                                <td>Dim newid (etholwyd)</td>
+                                <td>3,576</td>
+                                <td>Dim newid</td>
+                                <td>3</td>
+                            </tr>
+                            <tr>
+                                <td>Y Blaid Werdd</td>
+                                <td>0</td>
+                                <td>17,218</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid (etholwyd)</td>
+                                <td>1</td>
+                            </tr>
+                            <tr>
+                                <td>Dem. Rhydd.</td>
+                                <td>0</td>
+                                <td>12,097</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>Dim newid</td>
+                                <td>0</td>
+                            </tr>
 
-                            </tbody>
-                        </table>
-                    </div>
-                    <p>
-                        Er mai'r SNP enillodd y nifer fwyaf o bleidleisiau,                        gan eu bod wedi ennill wyth allan o'r deg                        sedd etholaethol, roedd eu cwota o 15,092, yn is na               bron pob un o'r pleidiau eraill.
-                        O ganlyniad, ni chawson nhw                        unrhyw seddi rhanbarthol.
-                    </p>
-                    <p>
-                        Enillodd y Blaid Lafur a'r Ceidwadwyr                        sedd etholaeth yr un hefyd, felly mae nifer eu pleidleisiau                        wedi cael ei rannu â dau yn rownd un y                        dyraniad seddi, tra bod cyfrif pawb arall yn                        wedi'i rannu ag un. Cwota pleidlais y blaid Lafur yn                        rownd un oedd 36,272 (72,544/2) felly cafodd                        yr ymgeisydd a oedd ar frig eu rhestr ei ethol.
-                    </p>
-                    <p> Yna ailadroddwyd y broses hon, a chyda                            cyfanswm pleidleisiau Llafur bellach yn 24,181 gan ei fod yn cael ei                            rannu â thri. O ganlyniad, y Ceidwadwyr,                            enillodd yr ail sedd ar y rhestr.
-                        Aeth y broses hon yn ei blaen nes enillwyd y seithfed                            sedd gan y Blaid Werdd, a                            oedd â 17,218 o bleidleisiau o gymharu â chwota'r SNP o                            15,091.
-                    </p>
+                        </tbody>
+                    </table>
                 </div>
+                <p>
+                    Er mai'r SNP enillodd y nifer fwyaf o bleidleisiau,                        gan eu bod wedi ennill wyth allan o'r deg                        sedd etholaethol, roedd eu cwota o 15,092, yn is na               bron pob un o'r pleidiau eraill.
+                    O ganlyniad, ni chawson nhw                        unrhyw seddi rhanbarthol.
+                </p>
+                <p>
+                    Enillodd y Blaid Lafur a'r Ceidwadwyr                        sedd etholaeth yr un hefyd, felly mae nifer eu pleidleisiau                        wedi cael ei rannu â dau yn rownd un y                        dyraniad seddi, tra bod cyfrif pawb arall yn                        wedi'i rannu ag un. Cwota pleidlais y blaid Lafur yn                        rownd un oedd 36,272 (72,544/2) felly cafodd                        yr ymgeisydd a oedd ar frig eu rhestr ei ethol.
+                </p>
+                <p> Yna ailadroddwyd y broses hon, a chyda                            cyfanswm pleidleisiau Llafur bellach yn 24,181 gan ei fod yn cael ei                            rannu â thri. O ganlyniad, y Ceidwadwyr,                            enillodd yr ail sedd ar y rhestr.
+                    Aeth y broses hon yn ei blaen nes enillwyd y seithfed                            sedd gan y Blaid Werdd, a                            oedd â 17,218 o bleidleisiau o gymharu â chwota'r SNP o                            15,091.
+                </p>
             </div>
         </div>
     </div>

--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -13,74 +13,73 @@
 
     {% include "elections/includes/_election_breadcrumbs.html" %}
 
-    <div class="ds-stack-smaller">
-        <div class="ds-card">
-            <div class="ds-card-body">
-                <h3>{{ object.nice_election_name }}</h3>
+    <div class="ds-card ds-stack-smaller">
+        <div class="ds-card-body">
+            <h3>{{ object.nice_election_name }}</h3>
 
-                <p>
-                    {% if object.is_election_day %}
-                        {% blocktrans trimmed with election=object.nice_election_name %}The {{ election }}
-                            <strong>is being held today</strong>. Polls are open from{% endblocktrans %} {{ object.polls_open|time:"ga" }} {% trans "till" %} {{ object.polls_close|time:"ga" }}
-                    {% else %}
-                        {% comment %} TO DO: Change text when the election is "tomorrow" {% endcomment %}
-                        {% blocktrans trimmed with was_will_be_in_past=object.in_past|yesno:"was,will be" election_date=object.election_date|naturalday:"\o\n l j F Y" %} This election {{ was_will_be_in_past }} held <strong>{{ election_date }}</strong>.{% endblocktrans %}
-                    {% endif %}
-                </p>
-                {% if object.election_type != "ref" %}
-                    {% if election.person_set.count %}
-                        <p>
-                            {% if object.locked %}
-                                There are <strong>{{election.person_set.count}}</strong> candidates
-                            {% else %}
-                                We know about <strong>{{election.person_set.count}} candidates</strong>
-                            {% endif %}
-                            {% blocktrans trimmed with stood_or_standing=object.in_past|yesno:"that stood,standing" post_count=object.post_set.count %}
-                                {{ stood_or_standing }} for this election, in <strong>{{ post_count }}</strong> posts.
-                            {% endblocktrans %}
-                        </p>
-
-                        {% if not object.in_past and not object.locked %}
-                            <p><a href="{{ object.ynr_link }}">{% trans "Add more at our candidate crowd-sourcing site" %}</a></p>
-                        {% endif %}
-
-                    {% else %}
-                        {% if not object.postelection_set.first.past_expected_sopn_day %}
-                            <p><a href="{{ object.ynr_link }}">{% trans "Add some candidates at our candidate crowd-sourcing site" %}</a></p>
-                        {% endif %}
-                    {% endif %}
-
-                    <h3>{% blocktrans trimmed with title=object.pluralized_division_name|title %} {{ title }}{% endblocktrans %}</h3>
-                    <ul>
-                        {% for postelection in object.postelection_set.all %}
-                            <li>
-                                {% blocktrans trimmed with postelection_url=postelection.get_absolute_url post_label=postelection.post.label cancelled_message=postelection.short_cancelled_message_html %}
-                                    <a href="{{ postelection_url }}">{{ post_label }}</a>
-                                    {{ cancelled_message }}
-                                {% endblocktrans %}
-                            </li>
-                        {% endfor %}
-                    </ul>
+            <p>
+                {% if object.is_election_day %}
+                    {% blocktrans trimmed with election=object.nice_election_name %}The {{ election }}
+                        <strong>is being held today</strong>. Polls are open from{% endblocktrans %} {{ object.polls_open|time:"ga" }} {% trans "till" %} {{ object.polls_close|time:"ga" }}
+                {% else %}
+                    {% comment %} TO DO: Change text when the election is "tomorrow" {% endcomment %}
+                    {% blocktrans trimmed with was_will_be_in_past=object.in_past|yesno:"was,will be" election_date=object.election_date|naturalday:"\o\n l j F Y" %} This election {{ was_will_be_in_past }} held <strong>{{ election_date }}</strong>.{% endblocktrans %}
                 {% endif %}
-                <script type="application/ld+json">
-                    {
-                        "@context": "http://schema.org",
-                        "@type": "Event",
-                        "name": "{{ object.name }}",
-                        "startDate": "{{ object.election_date }}",
-                        "url": "{{ CANONICAL_URL }}{% url 'election_view' object.slug object.name|slugify %}",
-                        "location": {
-                            "@type": "Place",
-                            "name": "UK",
-                        }
-                    }
-                </script>
-            </div>
-        </div>
-        {% include "elections/includes/_postcode_search_form.html" %}
+            </p>
+            {% if object.election_type != "ref" %}
+                {% if election.person_set.count %}
+                    <p>
+                        {% if object.locked %}
+                            There are <strong>{{election.person_set.count}}</strong> candidates
+                        {% else %}
+                            We know about <strong>{{election.person_set.count}} candidates</strong>
+                        {% endif %}
+                        {% blocktrans trimmed with stood_or_standing=object.in_past|yesno:"that stood,standing" post_count=object.post_set.count %}
+                            {{ stood_or_standing }} for this election, in <strong>{{ post_count }}</strong> posts.
+                        {% endblocktrans %}
+                    </p>
 
-        {% include "feedback/feedback_form.html" %}
+                    {% if not object.in_past and not object.locked %}
+                        <p><a href="{{ object.ynr_link }}">{% trans "Add more at our candidate crowd-sourcing site" %}</a></p>
+                    {% endif %}
+
+                {% else %}
+                    {% if not object.postelection_set.first.past_expected_sopn_day %}
+                        <p><a href="{{ object.ynr_link }}">{% trans "Add some candidates at our candidate crowd-sourcing site" %}</a></p>
+                    {% endif %}
+                {% endif %}
+
+                <h3>{% blocktrans trimmed with title=object.pluralized_division_name|title %} {{ title }}{% endblocktrans %}</h3>
+                <ul>
+                    {% for postelection in object.postelection_set.all %}
+                        <li>
+                            {% blocktrans trimmed with postelection_url=postelection.get_absolute_url post_label=postelection.post.label cancelled_message=postelection.short_cancelled_message_html %}
+                                <a href="{{ postelection_url }}">{{ post_label }}</a>
+                                {{ cancelled_message }}
+                            {% endblocktrans %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+            <script type="application/ld+json">
+                {
+                    "@context": "http://schema.org",
+                    "@type": "Event",
+                    "name": "{{ object.name }}",
+                    "startDate": "{{ object.election_date }}",
+                    "url": "{{ CANONICAL_URL }}{% url 'election_view' object.slug object.name|slugify %}",
+                    "location": {
+                        "@type": "Place",
+                        "name": "UK",
+                    }
+                }
+            </script>
+        </div>
     </div>
+    {% include "elections/includes/_postcode_search_form.html" %}
+
+    {% include "feedback/feedback_form.html" %}
+
 
 
 {% endblock content %}

--- a/wcivf/apps/elections/templates/elections/elections_view.html
+++ b/wcivf/apps/elections/templates/elections/elections_view.html
@@ -13,23 +13,19 @@
 
     {% include 'elections/includes/_elections_breadcrumbs.html' %}
     <div class="ds-stack-smaller">
-        <div class="ds-card">
-            <div class="ds-card-body">
-                <h1>{% trans "All Elections" %}</h1>
-                <p>{% trans "This is a list of upcoming elections, and all elections Democracy Club has covered since 2010. The local election database was founded in 2016." %}</p>
-                <aside class="ds-filter" aria-labelledby="filter-label">
-                    <div class="ds-filter-cluster" id="election-filters">
-                        <ul style="list-style: none;" aria-labelledby="filter-label">
-                            <li id="filter-label" class="ds-filter-label" aria-hidden="true">Filter:</li>
-                            {% for field in filter.form %}
-                                {{ field }}
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </aside>
-                {% include "elections/includes/_election_list.html" with elections=queryset %}
+        <h1>{% trans "All Elections" %}</h1>
+        <p>{% trans "This is a list of upcoming elections, and all elections Democracy Club has covered since 2010. The local election database was founded in 2016." %}</p>
+        <aside class="ds-filter" aria-labelledby="filter-label">
+            <div class="ds-filter-cluster" id="election-filters">
+                <ul style="list-style: none;" aria-labelledby="filter-label">
+                    <li id="filter-label" class="ds-filter-label" aria-hidden="true">Filter:</li>
+                    {% for field in filter.form %}
+                        {{ field }}
+                    {% endfor %}
+                </ul>
             </div>
-        </div>
+        </aside>
+        {% include "elections/includes/_election_list.html" with elections=queryset %}
 
         {% include "elections/includes/_postcode_search_form.html" %}
 

--- a/wcivf/apps/elections/templates/elections/fptp.html
+++ b/wcivf/apps/elections/templates/elections/fptp.html
@@ -9,84 +9,82 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>First-past-the-post (FPTP)</h2>
-                    <p>The First-past-the-post voting system
-                        is the simplest of all the voting
-                        systems used in UK elections. Simply put:
-                        each voter has a single vote, and the
-                        candidate with the most votes wins the seat.
-                        It is used in UK Parliament elections and for
-                        English and Welsh local government elections.
-                    </p>
 
-                    <h3>Block vote</h3>
-                    <p>The only variation of this voting system is
-                        known as the Block Vote. Some local government
-                        seats are multi-member, meaning, for example,
-                        that they may return three councillors to represent
-                        one ward. In this instance, the voter will get three
-                        votes. This is sometimes called a block vote.
-                        Voters do not have to vote for candidates from the
-                        same party, however.
-                    </p>
+            <h2>First-past-the-post (FPTP)</h2>
+            <p>The First-past-the-post voting system
+                is the simplest of all the voting
+                systems used in UK elections. Simply put:
+                each voter has a single vote, and the
+                candidate with the most votes wins the seat.
+                It is used in UK Parliament elections and for
+                English and Welsh local government elections.
+            </p>
 
-                    <h3>Example election</h3>
-                    <p>Taking an example ward from the 2019 local elections
-                        in Lincolnshire, you can see that the independent
-                        candidate was the most popular and so was elected,
-                        but only two of the three Conservatives were. If the
-                        Conservative vote had been split more evenly between
-                        their candidates, then they may have allowed the sole
-                        Labour candidate to get elected. Parties and voters,
-                        therefore, have to take an educated guess at how well
-                        they may do in this sort of election. Parties may wish
-                        to indicate who their lead candidates are to voters.
-                    </p>
-                    <div class="ds-table">
-                        <table>
-                            <caption>
-                                <h2>
-                                    2019 South Kesteven District Council election
-                                </h2>
-                                <h2>
-                                    Deeping St James Ward (three seats)
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Candidates</th>
-                                    <th>Votes</th>
-                                </tr>
-                                <tr>
-                                    <td>Independent</td>
-                                    <td>1,291 (Elected)</td>
-                                </tr>
-                                <tr>
-                                    <td>Conservative Party</td>
-                                    <td>349</td>
-                                </tr>
-                                <tr>
+            <h3>Block vote</h3>
+            <p>The only variation of this voting system is
+                known as the Block Vote. Some local government
+                seats are multi-member, meaning, for example,
+                that they may return three councillors to represent
+                one ward. In this instance, the voter will get three
+                votes. This is sometimes called a block vote.
+                Voters do not have to vote for candidates from the
+                same party, however.
+            </p>
 
-                                    <td>Labour Party</td>
-                                    <td>461</td>
+            <h3>Example election</h3>
+            <p>Taking an example ward from the 2019 local elections
+                in Lincolnshire, you can see that the independent
+                candidate was the most popular and so was elected,
+                but only two of the three Conservatives were. If the
+                Conservative vote had been split more evenly between
+                their candidates, then they may have allowed the sole
+                Labour candidate to get elected. Parties and voters,
+                therefore, have to take an educated guess at how well
+                they may do in this sort of election. Parties may wish
+                to indicate who their lead candidates are to voters.
+            </p>
+            <div class="ds-table">
+                <table>
+                    <caption>
+                        <h2>
+                            2019 South Kesteven District Council election
+                        </h2>
+                        <h2>
+                            Deeping St James Ward (three seats)
+                        </h2>
+                    </caption>
+                    <tbody>
+                        <tr>
+                            <th>Candidates</th>
+                            <th>Votes</th>
+                        </tr>
+                        <tr>
+                            <td>Independent</td>
+                            <td>1,291 (Elected)</td>
+                        </tr>
+                        <tr>
+                            <td>Conservative Party</td>
+                            <td>349</td>
+                        </tr>
+                        <tr>
 
-                                </tr>
-                                <tr>
-                                    <td>Conservative Party</td>
-                                    <td>945 (Elected)</td>
-                                </tr>
-                                <tr>
-                                    <td>Conservative Party</td>
-                                    <td>714 (Elected)</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                            <td>Labour Party</td>
+                            <td>461</td>
+
+                        </tr>
+                        <tr>
+                            <td>Conservative Party</td>
+                            <td>945 (Elected)</td>
+                        </tr>
+                        <tr>
+                            <td>Conservative Party</td>
+                            <td>714 (Elected)</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>
+
 
 {% endblock content %}

--- a/wcivf/apps/elections/templates/elections/fptp_cy.html
+++ b/wcivf/apps/elections/templates/elections/fptp_cy.html
@@ -2,62 +2,58 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Cyntaf i'r felin (FPTP)</h2>
-                    <p>System y cyntaf i'r felin                        yw'r symlaf o'r holl systemau pleidleisio                        a ddefnyddir yn etholiadau'r DU. Yn syml:                        mae pob pleidleisiwr yn cael un bleidlais, ac mae'r                        ymgeisydd sydd â'r nifer fwyaf o bleidleisiau yn ennill y sedd.
-                        Fe'i defnyddir yn etholiadau Senedd y DU ac ar gyfer                        etholiadau llywodraeth leol Cymru a Lloegr.
-                    </p>
+            <h2>Cyntaf i'r felin (FPTP)</h2>
+            <p>System y cyntaf i'r felin                        yw'r symlaf o'r holl systemau pleidleisio                        a ddefnyddir yn etholiadau'r DU. Yn syml:                        mae pob pleidleisiwr yn cael un bleidlais, ac mae'r                        ymgeisydd sydd â'r nifer fwyaf o bleidleisiau yn ennill y sedd.
+                Fe'i defnyddir yn etholiadau Senedd y DU ac ar gyfer                        etholiadau llywodraeth leol Cymru a Lloegr.
+            </p>
 
-                    <h3>Pleidlais bloc</h3>
-                    <p>Yr unig amrywiad o'r system bleidleisio hon yw’r hyn                        a elwir yn Bleidlais Bloc. Mae rhai o seddau llywodraeth leol                        yn rhai aml-aelod, sy'n golygu, er enghraifft,                        y gallan nhw ethol tri chynghorydd i gynrychioli                        un ward. Yn yr achos hwn, bydd y pleidleisiwr yn cael tair                        pleidlais. Gelwir hyn weithiau'n bleidlais bloc.
-                        Nid oes rhaid i bleidleiswyr bleidleisio dros ymgeiswyr o'r                        un blaid, fodd bynnag.
-                    </p>
+            <h3>Pleidlais bloc</h3>
+            <p>Yr unig amrywiad o'r system bleidleisio hon yw’r hyn                        a elwir yn Bleidlais Bloc. Mae rhai o seddau llywodraeth leol                        yn rhai aml-aelod, sy'n golygu, er enghraifft,                        y gallan nhw ethol tri chynghorydd i gynrychioli                        un ward. Yn yr achos hwn, bydd y pleidleisiwr yn cael tair                        pleidlais. Gelwir hyn weithiau'n bleidlais bloc.
+                Nid oes rhaid i bleidleiswyr bleidleisio dros ymgeiswyr o'r                        un blaid, fodd bynnag.
+            </p>
 
-                    <h3>Enghraifft o etholiad</h3>
-                    <p>Gan gymryd ward enghreifftiol o etholiadau lleol 2019                        yn Swydd Lincoln, gallwch weld mai’r ymgeisydd                        annibynnol oedd y mwyaf poblogaidd ac felly fe'i hetholwyd,                        ond dim ond dau o'r tri Ceidwadwr a etholwyd. Pe bai                        pleidleisiau’r Ceidwadwyr wedi'i rhannu'n fwy cyfartal rhwng                        eu hymgeiswyr, efallai y bydden nhw wedi caniatáu i’r unig                        ymgeisydd Llafur i gael ei ethol. Felly, rhaid i bleidiau a phleidleiswyr                        ddyfalu pa mor dda                        fydd eu canlyniad yn y math hwn o etholiad. Efallai y bydd pleidiau’n dymuno                        dweud wrth bleidleiswyr pwy yw eu prif ymgeiswyr.
-                    </p>
-                    <div class="ds-table">
-                        <table>
-                            <caption>
-                                <h2>
-                                    Etholiad Cyngor Ardal South Kesteven 2019
-                                </h2>
-                                <h2>
-                                    Ward Deeping St James (tair sedd)
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Ymgeiswyr</th>
-                                    <th>Pleidleisiau</th>
-                                </tr>
-                                <tr>
-                                    <td>Annibynnol</td>
-                                    <td>1,291 (Etholwyd)</td>
-                                </tr>
-                                <tr>
-                                    <td>Y Blaid Geidwadol</td>
-                                    <td>349</td>
-                                </tr>
-                                <tr>
+            <h3>Enghraifft o etholiad</h3>
+            <p>Gan gymryd ward enghreifftiol o etholiadau lleol 2019                        yn Swydd Lincoln, gallwch weld mai’r ymgeisydd                        annibynnol oedd y mwyaf poblogaidd ac felly fe'i hetholwyd,                        ond dim ond dau o'r tri Ceidwadwr a etholwyd. Pe bai                        pleidleisiau’r Ceidwadwyr wedi'i rhannu'n fwy cyfartal rhwng                        eu hymgeiswyr, efallai y bydden nhw wedi caniatáu i’r unig                        ymgeisydd Llafur i gael ei ethol. Felly, rhaid i bleidiau a phleidleiswyr                        ddyfalu pa mor dda                        fydd eu canlyniad yn y math hwn o etholiad. Efallai y bydd pleidiau’n dymuno                        dweud wrth bleidleiswyr pwy yw eu prif ymgeiswyr.
+            </p>
+            <div class="ds-table">
+                <table>
+                    <caption>
+                        <h2>
+                            Etholiad Cyngor Ardal South Kesteven 2019
+                        </h2>
+                        <h2>
+                            Ward Deeping St James (tair sedd)
+                        </h2>
+                    </caption>
+                    <tbody>
+                        <tr>
+                            <th>Ymgeiswyr</th>
+                            <th>Pleidleisiau</th>
+                        </tr>
+                        <tr>
+                            <td>Annibynnol</td>
+                            <td>1,291 (Etholwyd)</td>
+                        </tr>
+                        <tr>
+                            <td>Y Blaid Geidwadol</td>
+                            <td>349</td>
+                        </tr>
+                        <tr>
 
-                                    <td>Y Blaid Lafur</td>
-                                    <td>461</td>
+                            <td>Y Blaid Lafur</td>
+                            <td>461</td>
 
-                                </tr>
-                                <tr>
-                                    <td>Y Blaid Geidwadol</td>
-                                    <td>945 (Etholwyd)</td>
-                                </tr>
-                                <tr>
-                                    <td>Y Blaid Geidwadol</td>
-                                    <td>714 (Etholwyd)</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
+                        </tr>
+                        <tr>
+                            <td>Y Blaid Geidwadol</td>
+                            <td>945 (Etholwyd)</td>
+                        </tr>
+                        <tr>
+                            <td>Y Blaid Geidwadol</td>
+                            <td>714 (Etholwyd)</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/wcivf/apps/elections/templates/elections/includes/_calendar.html
+++ b/wcivf/apps/elections/templates/elections/includes/_calendar.html
@@ -1,0 +1,31 @@
+{% load humanize %}
+{% load i18n %}
+
+<li>
+    <details>
+        <summary>
+            <h4 id="calendar">
+                <span aria-hidden="true"></span>
+                {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
+            </h4>
+        </summary>
+        <p>
+            <p>{% trans "Manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>
+            <ol>
+                <li>
+                    {% trans "In your calendar app settings, choose the option for adding a new calendar." %}
+                </li>
+                <li>
+                    {% trans "If presented with the option to choose a calendar type, choose web calendar." %}
+                </li>
+                <li>
+                    {% if uprn %}
+                        {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'uprn_ical_view' postcode uprn %}</code>
+                    {% else %}
+                        {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}</code>
+                    {% endif %}
+                </li>
+            </ol>
+        </p>
+    </details>
+</li>

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -11,59 +11,65 @@ STV: Single Transferable Vote
 PR-CL: Closed List 
 {% endcomment %}
 
-<ul class="ds-details">
-    <li style="list-style: none;">
-        <details>
-            <summary>{% trans 'How to vote' %}</summary>
+<details>
+    <summary>{% trans 'How to vote' %}</summary>
+    <p>
+        {% if voting_system.get_absolute_url %}
+            {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.get_name %}
+                This election uses <a href="{{ voting_system_url }}">{{ voting_system_name }}</a>.
+            {% endblocktrans %}
+        {% else %}
+            {% blocktrans trimmed with voting_system_name=voting_system.get_name %}
+                This election uses {{ voting_system_name }}.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+
+    {% if voting_system.slug == "FPTP" %}
+        <p>
+            {% if postelection.winner_count == 1 %}
+                {% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}
+            {% else %}
+                {% blocktrans trimmed %}Mark an X in the box for your preferred candidates.{% endblocktrans %}
+            {% endif %}
+        </p>
+        {% if postelection.people|length > 1 %}
             <p>
-                {% if voting_system.get_absolute_url %}
-                    {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.get_name %}
-                        This election uses <a href="{{ voting_system_url }}">{{ voting_system_name }}</a>.
-                    {% endblocktrans %}
-                {% else %}
-                    {% blocktrans trimmed with voting_system_name=voting_system.get_name %}
-                        This election uses {{ voting_system_name }}.
-                    {% endblocktrans %}
-                {% endif %}
+                {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber count counter=postelection.winner_count %}
+                    You can mark up to {{ winner_count}} candidate.
+                {% plural %}
+                    You can mark up to {{ winner_count }} candidates.
+                {% endblocktrans %}
             </p>
+        {% endif %}
+    {% endif %}
 
-            {% if voting_system.slug == "FPTP" %}
-                <p>
-                    {% if postelection.winner_count == 1 %}
-                        {% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}
-                    {% else %}
-                        {% blocktrans trimmed %}Mark an X in the box for your preferred candidates.{% endblocktrans %}
-                    {% endif %}
-                </p>
-                {% if postelection.people|length > 1 %}
-                    <p>
-                        {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber count counter=postelection.winner_count %}
-                            You can mark up to {{ winner_count}} candidate.
-                        {% plural %}
-                            You can mark up to {{ winner_count }} candidates.
-                        {% endblocktrans %}
-                    </p>
-                {% endif %}
-            {% endif %}
+    {% if voting_system.slug == "STV" %}
+        <p>
+            {% blocktrans trimmed %}
+                Rank the candidates by your preference: 1, 2, 3…
+                You don't have to rank all the candidates, but you must at least mark your first choice.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
 
-            {% if voting_system.slug == "STV" %}
-                <p>
-                    {% blocktrans trimmed %}
-                        Rank the candidates by your preference: 1, 2, 3…
-                        You don't have to rank all the candidates, but you must at least mark your first choice.
-                    {% endblocktrans %}
-                </p>
-            {% endif %}
+    {% if voting_system.slug == "sv" %}
+        <p>
+            {% blocktrans trimmed %}
+                Mark an X in the first column for your first choice.
+                Mark an X in the second column for your second choice.
+                You do not have to mark a second choice.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
 
-            {% if voting_system.slug == "sv" %}
-                <p>
-                    {% blocktrans trimmed %}
-                        Mark an X in the first column for your first choice.
-                        Mark an X in the second column for your second choice.
-                        You do not have to mark a second choice.
-                    {% endblocktrans %}
-                </p>
-            {% endif %}
+    {% if voting_system.slug == "PR-CL" %}
+        <p>
+            {% blocktrans trimmed %}
+                Mark an X in the box for one party or independent candidate.
+            {% endblocktrans %}
+        </p>
+    {% endif %}
 
                      {% if voting_system.slug == "AMS" %}
                 <p>
@@ -81,20 +87,10 @@ PR-CL: Closed List
                 </p>
             {% endif %}
 
-            {% if is_regional %}
-                <p>
-                    {% blocktrans trimmed %}
-                        Mark an X in the box next to your preferred party or independent candidate
-                    {% endblocktrans %}
-                </p>
-            {% endif %}
+    {% if is_constituency %}
+        <p>{% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}</p>
+    {% endif %}
 
-            {% if is_constituency %}
-                <p>{% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}</p>
-            {% endif %}
-
-            <p>{% blocktrans trimmed %}Read the instructions at the top of your ballot paper carefully.{% endblocktrans %}</p>
-            <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
-        </details>
-    </li>
-</ul>
+    <p>{% blocktrans trimmed %}Read the instructions at the top of your ballot paper carefully.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
+</details>

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -63,29 +63,13 @@ PR-CL: Closed List
         </p>
     {% endif %}
 
-    {% if voting_system.slug == "PR-CL" %}
+    {% if voting_system.slug == "AMS" or voting_system.slug == "PR-CL"%}
         <p>
             {% blocktrans trimmed %}
                 Mark an X in the box for one party or independent candidate.
             {% endblocktrans %}
         </p>
     {% endif %}
-
-                     {% if voting_system.slug == "AMS" %}
-                <p>
-                    {% blocktrans trimmed %}
-                        Mark an X in the box for one party or independent candidate.
-                    {% endblocktrans %}
-                </p>
-            {% endif %}
-
-            {% if voting_system.slug == "PR-CL" %}
-                <p>
-                    {% blocktrans trimmed %}
-                        Mark an X in the box for one party or independent candidate.
-                    {% endblocktrans %}
-                </p>
-            {% endif %}
 
     {% if is_constituency %}
         <p>{% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}</p>

--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -31,7 +31,7 @@
         <div>
             <div class="ds-with-sidebar ds-card">
                 <div class="ds-card-body">
-                    <div style="flex-basis: 5rem">
+                    <div class="emblem-for-candidate-list" style="flex-basis: 5rem">
                         {% if person_post.list.0.party.emblem_url %}
                             <img src="{{ person_post.list.0.party.emblem_url }}" alt="{% trans "Party emblem" %}">
                         {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -8,8 +8,8 @@
     {% if person_post.list.0.party.is_independent %}
         {#  This is a special case where we don't want to group independants, but show a single card per person  #}
         {% for pp in person_post.list %}
-            <div class="ds-with-sidebar">
-                <div>
+            <div class="ds-with-sidebar ds-card">
+                <div class="ds-card-body">
                     <div class="ds-sidebar" style="flex-basis: 5rem">
                         {% if pp.person.photo_url %}
                             <img src="{{ pp.person.photo_url }}" alt="{% blocktrans trimmed %}Photo of {{ pp.person.name }}{% endblocktrans %}">
@@ -29,9 +29,9 @@
         {% endfor %}
     {% else %}
         <div>
-            <div class="ds-with-sidebar">
-                <div>
-                    <div class="ds-sidebar" style="flex-basis: 5rem">
+            <div class="ds-with-sidebar ds-card">
+                <div class="ds-card-body">
+                    <div style="flex-basis: 5rem">
                         {% if person_post.list.0.party.emblem_url %}
                             <img src="{{ person_post.list.0.party.emblem_url }}" alt="{% trans "Party emblem" %}">
                         {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -69,18 +69,14 @@
             </p>
             {% if not voter_id_required %}
                 <p>
-                    {% if not postcode|ni_postcode %}
-                        {% trans "You don't need to take your poll card with you." %}
-                    {% else %}
-                        {% trans "You don't need to take your poll card with you." %}
-                    {% endif %}
+                    {% trans "You don't need to take your poll card with you." %}
                 </p>
             {% endif %}
-            {% comment %} {% if not postcode|ni_postcode %}
-                    <p>
-                        {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
-                    </p>
-                {% endif %} {% endcomment %}
+            {% if not postcode|ni_postcode %}
+                <p>
+                    {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
+                </p>
+            {% endif %}
 
 
         {% else %}

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -2,14 +2,13 @@
 {% load humanize %}
 {% load i18n %}
 
-<div class="ds-card" id="polling_place">
-    <div class="ds-card-body">
-
-        <h2 id='where'>
-            <span aria-hidden="true">📍</span>
-            {% trans "Where to vote" %}
-        </h2>
-
+<li id="polling_place">
+    <details {% if polling_station.polling_station_known %}open{% endif %}>
+        <summary>
+            <h2 id='where'>
+                <span aria-hidden="true">{% trans "Where to vote" %}</span>
+            </h2>
+        </summary>
         {% if polling_station.polling_station_known %}
             {% if advance_voting_station and advance_voting_station.open_in_future %}
                 <p>
@@ -78,10 +77,10 @@
                 </p>
             {% endif %}
             {% comment %} {% if not postcode|ni_postcode %}
-                <p>
-                    {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
-                </p>
-            {% endif %} {% endcomment %}
+                    <p>
+                        {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
+                    </p>
+                {% endif %} {% endcomment %}
 
 
         {% else %}
@@ -155,53 +154,49 @@
         {% endif %}
 
 
-    </div>
+        {% if not polling_station.custom_finder and polling_station.polling_station_known and polling_station.station.geometry %}
+            <div id="area_map" class="ds-card-image"></div>
 
+            <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
+            <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
 
+            <script type="text/javascript">
+                // Maps
+                window.create_area_map = function(polling_station_point) {
+                    var polling_station_location = polling_station_point;
+                    window.polling_station_location = polling_station_location;
 
+                    var map = L.map('area_map', {
+                        zoomControl: true
+                    });
+                    map.dragging.disable();
+                    // map.touchZoom.disable();
+                    // map.doubleClickZoom.disable();
+                    map.scrollWheelZoom.disable();
 
-    {% if not polling_station.custom_finder and polling_station.polling_station_known and polling_station.station.geometry %}
-        <div id="area_map" class="ds-card-image"></div>
+                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.{ext}', {
+                        ext: 'png',
+                        attribution: 'Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
+                        subdomains: 'abc'
+                    }).addTo(map);
 
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
-        <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
+                    window.map = map;
 
-        <script type="text/javascript">
-            // Maps
-            window.create_area_map = function(polling_station_point) {
-                var polling_station_location = polling_station_point;
-                window.polling_station_location = polling_station_location;
+                    L.marker(polling_station_location, {
+                        'clickable': true,
+                    }).addTo(map);
 
-                var map = L.map('area_map', {
-                    zoomControl: true
-                });
-                map.dragging.disable();
-                // map.touchZoom.disable();
-                // map.doubleClickZoom.disable();
-                map.scrollWheelZoom.disable();
+                    map.setView(polling_station_location, 15);
+                };
 
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.{ext}', {
-                    ext: 'png',
-                    attribution: 'Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
-                    subdomains: 'abc'
-                }).addTo(map);
+                var polling_station_point = [
+                    {{ polling_station.station.geometry.coordinates.1 }},
+                    {{ polling_station.station.geometry.coordinates.0 }},
 
-                window.map = map;
+                ];
 
-                L.marker(polling_station_location, {
-                    'clickable': true,
-                }).addTo(map);
-
-                map.setView(polling_station_location, 15);
-            };
-
-            var polling_station_point = [
-                {{ polling_station.station.geometry.coordinates.1 }},
-                {{ polling_station.station.geometry.coordinates.0 }},
-
-            ];
-
-            create_area_map(polling_station_point);
-        </script>
-    {% endif %}
-</div>
+                create_area_map(polling_station_point);
+            </script>
+        {% endif %}
+    </details>
+</li>

--- a/wcivf/apps/elections/templates/elections/includes/_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_registration_details.html
@@ -2,12 +2,14 @@
 {% load postcode_tags %}
 {% load humanize %}
 
-<section class="ds-card">
-    <div class="ds-card-body">
-        <h2 id='where'>
-            <span aria-hidden="true">📝</span>
-            {% blocktrans trimmed %}Register to vote{% endblocktrans %}
-        </h2>
+<li>
+    <details>
+        <summary>
+            <h2 id='register'>
+                <span aria-hidden="true"></span>
+                {% blocktrans trimmed %}Register to vote{% endblocktrans %}
+            </h2>
+        </summary>
 
         <p>
             {% blocktrans trimmed %}
@@ -59,5 +61,5 @@
 
         {% endif %}
 
-    </div>
-</section>
+    </details>
+</li>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -241,8 +241,7 @@
         {% endif %}
         {% include "elections/includes/_ld_election.html" with election=postelection %}
     </div>
-</div>
-{% if postelection.husting_set.displayable %}
-    {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
-{% endif %}
+    {% if postelection.husting_set.displayable %}
+        {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
+    {% endif %}
 </div>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -3,56 +3,60 @@
 {% load static %}
 {% load i18n %}
 
-<div class="ds-stack-smaller">
-    <div class="ds-card" id="election_{{ postelection.election.slug }}">
-        <div class="ds-card-body">
+<div class="ds-stack">
+    <div id="election_{{ postelection.election.slug }}" class="ds-stack">
 
-            <h2>
-                <span aria-hidden="true">🗳️</span>
-                {{ postelection.election.name_without_brackets }}
-            </h2>
+        <h2>
+            <span aria-hidden="true">🗳️</span>
+            {{ postelection.election.name_without_brackets }}
+        </h2>
 
+        {% if postelection.cancelled %}
+            {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
+        {% else %}
 
-            {% if postelection.cancelled %}
-                {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
-            {% else %}
+            {% if not postelection.is_pcc and not postelection.is_mayoral %}
+                <h3>{% if postelection.is_london_assembly_additional %}{% trans "Additional members" %}{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
+            {% endif %}
 
-                {% if not postelection.is_pcc and not postelection.is_mayoral %}
-                    <h3>{% if postelection.is_london_assembly_additional %}{% trans "Additional members" %}{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
-                {% endif %}
+            {% if postelection.metadata.coronavirus_message %}
+                <div style="border:1px solid red;margin:1em 0;padding:1em">
+                    <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
+                </div>
+            {% endif %}
 
-                {% if postelection.metadata.coronavirus_message %}
-                    <div style="border:1px solid red;margin:1em 0;padding:1em">
-                        <strong>{{ postelection.metadata.coronavirus_message|safe }}</strong>
-                    </div>
-                {% endif %}
+            <p>
+                {% if postelection.election.is_election_day %}
+                    {% blocktrans trimmed with open_time=postelection.election.polls_open|time:"ga" close_time=postelection.election.polls_close|time:"ga" %}
+                        This election <strong>is being held today</strong>. Polls are open from {{ open_time }} till {{ close_time }}
+                    {% endblocktrans %}
 
-                <p>
-                    {% if postelection.election.is_election_day %}
-                        {% blocktrans trimmed with open_time=postelection.election.polls_open|time:"ga" close_time=postelection.election.polls_close|time:"ga" %}
-                            This election <strong>is being held today</strong>. Polls are open from {{ open_time }} till {{ close_time }}
-                        {% endblocktrans %}
-
-                    {% else %}
-                        {% if postelection.election.in_past %}
-                            {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
-                                This election was held <strong>{{ election_date }}</strong>.
-                            {% endblocktrans %}
-                        {% else %}
-                            {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
-                                This election will be held <strong> {{ election_date }}</strong>.
-                            {% endblocktrans %}
-                        {% endif %}
-                    {% endif %}
-                </p>
-
-                {% if object.election.slug == "europarl.2019-05-23"%}
-                    {% include "elections/includes/eu_results.html" with card=0 %}
-                {% endif %}
-
-                <p>
+                {% else %}
                     {% if postelection.election.in_past %}
-                        {% blocktrans trimmed with num_candidates=postelection.people|length plural=postelection.people|pluralize postelection=postelection.friendly_name %}<strong>{{ num_candidates }} candidate{{ plural }}</strong> stood in the {{ postelection }}.{% endblocktrans %}
+                        {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
+                            This election was held <strong>{{ election_date }}</strong>.
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
+                            This election will be held <strong> {{ election_date }}</strong>.
+                        {% endblocktrans %}
+                    {% endif %}
+                {% endif %}
+            </p>
+
+            {% if object.election.slug == "europarl.2019-05-23"%}
+                {% include "elections/includes/eu_results.html" with card=0 %}
+            {% endif %}
+
+            <p>
+                {% if postelection.election.in_past %}
+                    {% blocktrans trimmed with num_candidates=postelection.people|length plural=postelection.people|pluralize postelection=postelection.friendly_name %}<strong>{{ num_candidates }} candidate{{ plural }}</strong> stood in the {{ postelection }}.{% endblocktrans %}
+                {% else %}
+                    {# Display different messages depending on the number of candidates #}
+                    {# Case: No candidates for a contested election #}
+                    {% if not postelection.people and postelection.contested %}
+                        {% trans "We don't know of any candidates standing yet. You can help improve this page:" %} <a href="{{ postelection.ynr_link }}">
+                            {% trans "add information about candidates to our database" %}</a>.
                     {% else %}
                         {# Display different messages depending on the number of candidates #}
                         {# Case: No candidates for a contested election #}
@@ -119,8 +123,10 @@
 
                         {% endif %}
                     {% endif %}
-            {% endif %}
-        </p>
+                {% endif %}
+            </p>
+        {% endif %}
+
         {% if postelection.election.election_booklet %}
             <h4>
                 <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
@@ -172,6 +178,7 @@
                 </div>
             </section>
         {% endif %}
+
         {% if postelection.people and postelection.should_show_candidates %}
             {% if postelection.display_as_party_list %}
                 {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -47,6 +47,14 @@
             {% if object.election.slug == "europarl.2019-05-23"%}
                 {% include "elections/includes/eu_results.html" with card=0 %}
             {% endif %}
+            {% if postelection.election.description %}
+                <div class="ds-details">
+                    <details>
+                        <summary>{% trans "About this position" %}</summary>
+                        <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
+                    </details>
+                </div>
+            {% endif %}
 
             <p>
                 {% if postelection.election.in_past %}
@@ -131,15 +139,6 @@
             <h4>
                 <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
             </h4>
-        {% endif %}
-
-        {% if postelection.election.description %}
-            <div class="ds-card">
-                <div class="ds-card-body">
-                    <h3>About this position</h3>
-                    <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
-                </div>
-            </div>
         {% endif %}
 
         {% if postelection.election.in_past and postelection.has_results %}

--- a/wcivf/apps/elections/templates/elections/includes/_voter_id.html
+++ b/wcivf/apps/elections/templates/elections/includes/_voter_id.html
@@ -3,14 +3,16 @@
 {% load static %}
 {% load i18n %}
 
-<div class="ds-card">
-    <div class="ds-card-body">
-        <h2>
-            <span aria-hidden="true">🗳</span>️
-            {% trans "You will need to take photo ID to vote at a polling station in this election" %}
-        </h2>
+<li id="requirements">
+    <details>
+        <summary>
+            <h2>
+                <span aria-hidden="true"></span>️
+                {% trans "You will need to take photo ID to vote at a polling station in this election" %}
+            </h2>
+        </summary>
         <p>
             {% trans "You must vote at your assigned polling station." %}
         </p>
-    </div>
-</div>
+    </details>
+</li>

--- a/wcivf/apps/elections/templates/elections/includes/_voter_id.html
+++ b/wcivf/apps/elections/templates/elections/includes/_voter_id.html
@@ -12,7 +12,8 @@
             </h2>
         </summary>
         <p>
-            {% trans "You must vote at your assigned polling station." %}
+            {% blocktrans%}You do not need your poll card to vote. You must vote at your assigned polling station.
+                Read more about <a href="https://www.gov.uk/voting-in-the-uk/polling-stations">voting in Great Britain</a>.{% endblocktrans %}
         </p>
     </details>
 </li>

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -73,19 +73,25 @@
                         </a>
                     </li>
                 {% endif %}
-
-                {% if show_polling_card %}
-                    <li><a href="#where">Where to vote</a></li>
-                {% endif %}
-
-                {% if requires_voter_id %}
-                    <li><a href="#requirements">Voter ID requirements</a></li>
-                {% endif %}
-
-                {% if not postelections or not postelections.first.past_registration_deadline %}
-                    <li><a href="#register">Register to vote</a></li>
-                {% endif %}
             </ul>
+
+            {% if show_polling_card or requires_voter_id %}
+                <p>Get ready to vote:</p>
+                <ul>
+                    {% if show_polling_card %}
+                        <li><a href="#where">Where to vote</a></li>
+                    {% endif %}
+
+                    {% if requires_voter_id %}
+                        <li><a href="#requirements">Voter ID requirements</a></li>
+                    {% endif %}
+
+                    {% if not postelections or not postelections.first.past_registration_deadline %}
+                        <li><a href="#register">Register to vote</a></li>
+                    {% endif %}
+                </ul>
+            {% endif %}
+
         {% endfor %}
     {% endif %}
     {% if not address_picker %}

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -76,18 +76,18 @@
             </ul>
 
             {% if show_polling_card or requires_voter_id %}
-                <p>Get ready to vote:</p>
+                <p>{% trans "Get ready to vote" %}:</p>
                 <ul>
                     {% if show_polling_card %}
-                        <li><a href="#where">Where to vote</a></li>
+                        <li><a href="#where">{% trans "Where to vote" %}</a></li>
                     {% endif %}
 
                     {% if requires_voter_id %}
-                        <li><a href="#requirements">Voter ID requirements</a></li>
+                        <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
                     {% endif %}
 
                     {% if not postelections or not postelections.first.past_registration_deadline %}
-                        <li><a href="#register">Register to vote</a></li>
+                        <li><a href="#register">{% trans "Register to vote" %}</a></li>
                     {% endif %}
                 </ul>
             {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -1,88 +1,97 @@
 {% load humanize %}
 {% load i18n %}
-<div class="ds-card">
-    <div class="ds-card-body">
-        {% if postelections.count == 0 %}
-            <h2>{% trans "We don't know of any upcoming elections in your area." %}</h2>
-            <p>{% trans "Local and devolved elections in the UK typically happen on the first Thursday in May. By-elections and parliamentary general elections can happen at any time. Not all areas have elections each year." %}</p>
-            <p>{% blocktrans %}Learn more about elections in the UK <a href="https://www.electoralcommission.org.uk/i-am-a/voter/types-elections">on the Electoral Commission website</a>.{% endblocktrans %}</p>
+<div class="ds-stack-smaller">
+    {% if postelections.count == 0 %}
+        <h2>{% trans "We don't know of any upcoming elections in your area." %}</h2>
+        <p>{% trans "Local and devolved elections in the UK typically happen on the first Thursday in May. By-elections and parliamentary general elections can happen at any time. Not all areas have elections each year." %}</p>
+        <p>{% blocktrans %}Learn more about elections in the UK <a href="https://www.electoralcommission.org.uk/i-am-a/voter/types-elections">on the Electoral Commission website</a>.{% endblocktrans %}</p>
+    {% else %}
+        {% regroup postelections by election.election_date as header_elections_by_date %}
+        {% if address_picker %}
+            <h2>Select your address</h2>
         {% else %}
-            {% regroup postelections by election.election_date as header_elections_by_date %}
-            {% if address_picker %}
-                <h2>Select your address</h2>
-            {% else %}
-                <h2>{% trans "Elections in your area" %}</h2>
-            {% endif %}
-            {% if address_picker %}
-                <div class="ds-padded-large">
-                    <ul class="ds-stack-smaller">
-                        {% for address in addresses %}
-                            <li><a href="{% url "uprn_view" postcode=postcode uprn=address.slug %}">{{ address.address }}</a></li>
-                        {% endfor %}
-
-                    </ul>
-                </div>
-
-
-            {% endif %}
-            {% for election_group in header_elections_by_date %}
-
-                {% if election_group.list.0.past_date %}
-                    {% ifchanged election_group.list.0.past_date %}
-                        <h3>{% trans "Recently past elections" %}</h3>
-                    {% endifchanged %}
-                {% endif %}
-
-                {% if election_group.list.0.past_date %}
-                    <h4>
-                        {{ election_group.grouper|naturalday:"l j F Y"|title }}
-                    </h4>
-                {% else %}
-                    <h3>
-                        {{ election_group.grouper|naturalday:"l j F Y"|title }}
-                    </h3>
-                    <p>
-                        {% blocktrans trimmed with num_ballots=election_group.list|length|apnumber ballots_pluralised=election_group.list|pluralize %}
-                            You will have {{ num_ballots }} ballot paper{{ ballots_pluralised }} to fill out.
-                        {% endblocktrans %}
-                    </p>
-                {% endif %}
-
-                <ul>
-                    {% for ballot in election_group.list %}
-                        <li {% if ballot.past_date %}class="past_elections" {% endif %}>
-
-                            <a href="#election_{{ ballot.election.slug }}">
-                                {{ ballot.election.nice_election_name  }}
-                                {% if ballot.post.label != post.election and not ballot.is_mayoral and not ballot.is_pcc %}
-                                    : {{ ballot.post.label }}
-                                {% endif %}
-                            </a>
-                            {% blocktrans trimmed with short_cancelled_message=ballot.short_cancelled_message_html %}
-                                {{ ballot.short_cancelled_message_html }}
-                            {% endblocktrans %}
-                        </li>
+            <h2>{% trans "Elections in your area" %}</h2>
+        {% endif %}
+        {% if address_picker %}
+            <div class="ds-padded-large">
+                <ul class="ds-stack-smaller">
+                    {% for address in addresses %}
+                        <li><a href="{% url "uprn_view" postcode=postcode uprn=address.slug %}">{{ address.address }}</a></li>
                     {% endfor %}
 
-                    {% if parish_council_election and parish_council_election.election_date == election_group.grouper %}
-                        <li {% if parish_council_election.in_past %}class="past_elections" {% endif %}>
-                            <a href="#parishcouncil">
-                                {{ parish_council_election.council_name }}
-                                {% if parish_council_election.is_unconstested %} {% trans "(uncontested)" %}
-                                {% elif parish_council_election.unknown_if_contested %} {% trans "(may be contested)" %}
-                                {% endif %}
-                            </a>
-                        </li>
-                    {% endif %}
-
                 </ul>
-            {% endfor %}
+            </div>
+
+
         {% endif %}
-        {% if not address_picker %}
-            {% if referendums %}
-                {% include 'referendums/includes/_list.html' with referendums=referendums %}
+        {% for election_group in header_elections_by_date %}
+
+            {% if election_group.list.0.past_date %}
+                {% ifchanged election_group.list.0.past_date %}
+                    <h3>{% trans "Recently past elections" %}</h3>
+                {% endifchanged %}
             {% endif %}
-            <p>{% trans "There may be parish, town or community council elections in some areas." %}</p>
+
+            {% if election_group.list.0.past_date %}
+                <h4>
+                    {{ election_group.grouper|naturalday:"l j F Y"|title }}
+                </h4>
+            {% else %}
+                <h3>
+                    {{ election_group.grouper|naturalday:"l j F Y"|title }}
+                </h3>
+                <p>
+                    {% blocktrans trimmed with num_ballots=election_group.list|length|apnumber ballots_pluralised=election_group.list|pluralize %}
+                        You will have {{ num_ballots }} ballot paper{{ ballots_pluralised }} to fill out.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
+
+            <ul>
+                {% for ballot in election_group.list %}
+                    <li {% if ballot.past_date %}class="past_elections" {% endif %}>
+
+                        <a href="#election_{{ ballot.election.slug }}">
+                            {{ ballot.election.nice_election_name  }}
+                            {% if ballot.post.label != post.election and not ballot.is_mayoral and not ballot.is_pcc %}
+                                : {{ ballot.post.label }}
+                            {% endif %}
+                        </a>
+                        {% blocktrans trimmed with short_cancelled_message=ballot.short_cancelled_message_html %}
+                            {{ ballot.short_cancelled_message_html }}
+                        {% endblocktrans %}
+                    </li>
+                {% endfor %}
+
+                {% if parish_council_election and parish_council_election.election_date == election_group.grouper %}
+                    <li {% if parish_council_election.in_past %}class="past_elections" {% endif %}>
+                        <a href="#parishcouncil">
+                            {{ parish_council_election.council_name }}
+                            {% if parish_council_election.is_unconstested %} {% trans "(uncontested)" %}
+                            {% elif parish_council_election.unknown_if_contested %} {% trans "(may be contested)" %}
+                            {% endif %}
+                        </a>
+                    </li>
+                {% endif %}
+
+                {% if show_polling_card %}
+                    <li><a href="#where">Where to vote</a></li>
+                {% endif %}
+
+                {% if requires_voter_id %}
+                    <li><a href="#requirements">Voter ID requirements</a></li>
+                {% endif %}
+
+                {% if not postelections or not postelections.first.past_registration_deadline %}
+                    <li><a href="#register">Register to vote</a></li>
+                {% endif %}
+            </ul>
+        {% endfor %}
+    {% endif %}
+    {% if not address_picker %}
+        {% if referendums %}
+            {% include 'referendums/includes/_list.html' with referendums=referendums %}
         {% endif %}
-    </div>
+        <p>{% trans "There may be parish, town or community council elections in some areas." %}</p>
+    {% endif %}
 </div>

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -98,6 +98,6 @@
         {% if referendums %}
             {% include 'referendums/includes/_list.html' with referendums=referendums %}
         {% endif %}
-        <p>{% trans "There may be parish, town or community council elections in some areas." %}</p>
+        <p>{% trans "There may also be parish, town or community council elections in some areas." %}</p>
     {% endif %}
 </div>

--- a/wcivf/apps/elections/templates/elections/party_list_view.html
+++ b/wcivf/apps/elections/templates/elections/party_list_view.html
@@ -3,94 +3,78 @@
 
 {% block content %}
 
+    <div class="ds-with-sidebar">
+        <div>
+            <div class="ds-sidebar" style="flex-basis: 10rem">
+                {% if party.emblem_url %}
+                    <img src="{{ party.emblem_url }}" alt="{{ party_name }} {% trans 'emblem' %}">
+                {% endif %}
+            </div>
+            <div class="ds-not-sidebar">
 
-    <div class="ds-stack-smaller">
-        <div class="ds-card">
-            <div class="ds-padded-large">
-                <div class="ds-with-sidebar">
+                <h2>{{ party_name }}</h2>
+                <h4>
+                    {{ ballot.election.nice_election_name }}
+                    {% if not ballot.is_pcc and not ballot.is_mayoral %}: {{ ballot.friendly_name }}{% endif %}
+                </h4>
+
+                <dl class="ds-descriptions" style="border-style:none;">
                     <div>
-                        <div class="ds-sidebar" style="flex-basis: 10rem">
-                            {% if party.emblem_url %}
-                                <img src="{{ party.emblem_url }}" alt="{{ party_name }} {% trans 'emblem' %}">
-                            {% endif %}
-                        </div>
-                        <div class="ds-not-sidebar">
+                        {% if local_party.facebook_page %}
+                            <dt>Facebook</dt>
+                            <dd>
+                                {% if local_party.facebook_page %}
+                                    <a href="{{ local_party.facebook_page }}" title="{% blocktrans trimmed with party_name=local_party.name %}{{ party_name }}'s Facebook profile{% endblocktrans %}">
+                                        {{ local_party.facebook_page }}
+                                    </a>
+                                {% endif %}
+                            </dd>
+                        {% endif %}
 
-                            <h2>{{ party_name }}</h2>
-                            <h4>
-                                {{ ballot.election.nice_election_name }}
-                                {% if not ballot.is_pcc and not ballot.is_mayoral %}: {{ ballot.friendly_name }}{% endif %}
-                            </h4>
+                        {% if local_party.homepage %}
+                            <dt>{% trans "Home page" %}</dt>
+                            <dd>
+                                <a href="{{ local_party.homepage }}" title="{% blocktrans trimmed with party_name=local_party.name %}{{ party_name }}'s home page{% endblocktrans %}">
+                                    {{ local_party.homepage }}
+                                </a>
+                            </dd>
+                        {% endif %}
 
-                            <dl class="ds-descriptions" style="border-style:none;">
-                                <div>
-                                    {% if local_party.facebook_page %}
-                                        <dt>Facebook</dt>
-                                        <dd>
-                                            {% if local_party.facebook_page %}
-                                                <a href="{{ local_party.facebook_page }}" title="{% blocktrans trimmed with party_name=local_party.name %}{{ party_name }}'s Facebook profile{% endblocktrans %}">
-                                                    {{ local_party.facebook_page }}
-                                                </a>
-                                            {% endif %}
-                                        </dd>
-                                    {% endif %}
-
-                                    {% if local_party.homepage %}
-                                        <dt>{% trans "Home page" %}</dt>
-                                        <dd>
-                                            <a href="{{ local_party.homepage }}" title="{% blocktrans trimmed with party_name=local_party.name %}{{ party_name }}'s home page{% endblocktrans %}">
-                                                {{ local_party.homepage }}
-                                            </a>
-                                        </dd>
-                                    {% endif %}
-
-                                    {% if local_party.email %}
-                                        <dt>{% trans "Email" %}</dt>
-                                        <dd><a href="mailto:{{ local_party.email }}">{{ local_party.email }}</a></dd>
-                                    {% endif %}
-                                </div>
-                            </dl>
-                        </div>
+                        {% if local_party.email %}
+                            <dt>{% trans "Email" %}</dt>
+                            <dd><a href="mailto:{{ local_party.email }}">{{ local_party.email }}</a></dd>
+                        {% endif %}
                     </div>
-                </div>
-            </div>
-        </div>
-
-        {% if manifesto %}
-            <div class="ds-card">
-                <div class="ds-card-body">
-                    <h3>{% trans "Party manifesto" %}</h3>
-                    <p>
-
-                        {% blocktrans trimmed with party_name=party.party_name manifesto=manifesto|safe %}Find out more about the {{ party_name }} in their {{ manifesto }}.{% endblocktrans %}
-                    </p>
-                </div>
-            </div>
-        {% endif %}
-
-        {% if local_party.twitter %}
-            <div class="ds-card">
-                <div class="ds-card-body">
-                    <h3>{% trans "Latest tweets" %}</h3>
-                    <div class="twitter_container">
-                        <a data-width="100%" data-height="500" class="twitter-timeline" href="https://twitter.com/{{ object.twitter_username }}">
-                            {% trans "Tweets by" %} @{{ object.twitter_username }}</a>
-                        <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
-
-        <div class="ds-card">
-            <div class="ds-card-body">
-                <h3>{% trans "Candidates" %}</h3>
-                <ul class="ds-grid" style="--gridCellMin: 25ch">
-                    {% for person in person_posts %}
-                        {% include "elections/includes/_person_card.html" with person_post=person lists=True %}
-                    {% endfor %}
-                </ul>
+                </dl>
             </div>
         </div>
     </div>
+
+    {% if manifesto %}
+
+        <h3>{% trans "Party manifesto" %}</h3>
+        <p>
+
+            {% blocktrans trimmed with party_name=party.party_name manifesto=manifesto|safe %}Find out more about the {{ party_name }} in their {{ manifesto }}.{% endblocktrans %}
+        </p>
+
+    {% endif %}
+    {% if local_party.twitter %}
+        <h3>{% trans "Latest tweets" %}</h3>
+        <div class="twitter_container">
+            <a data-width="100%" data-height="500" class="twitter-timeline" href="https://twitter.com/{{ object.twitter_username }}">
+                {% trans "Tweets by" %} @{{ object.twitter_username }}</a>
+            <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+        </div>
+    {% endif %}
+
+    <h3>{% trans "Candidates" %}</h3>
+    <ul class="ds-grid" style="--gridCellMin: 25ch">
+        {% for person in person_posts %}
+            {% include "elections/includes/_person_card.html" with person_post=person lists=True %}
+        {% endfor %}
+    </ul>
+
+
 
 {% endblock %}

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -26,19 +26,15 @@
         {% endif %}
 
         {% if postelection.next_ballot %}
-            <div class="ds-card">
-                <div class="ds-card-body">
-                    <h3>{% trans "Next election" %}</h3>
-                    <p>
-                        {% blocktrans trimmed with post_election_url=postelection.next_ballot.get_absolute_url postelection=postelection.friendly_name %}The <a href="{{ post_election_url }}">next election for {{ postelection }}</a> is{% endblocktrans %}
-                        {% if postelection.next_ballot.election.is_election_day %}
-                            <strong>{% trans "being held today" %}</strong>.
-                        {% else %}
-                            {% trans "due to take place on" %} <strong>{{ postelection.next_ballot.election.election_date|date:"l j F Y"}}</strong>.
-                        {% endif %}
-                    </p>
-                </div>
-            </div>
+            <h3>{% trans "Next election" %}</h3>
+            <p>
+                {% blocktrans trimmed with post_election_url=postelection.next_ballot.get_absolute_url postelection=postelection.friendly_name %}The <a href="{{ post_election_url }}">next election for {{ postelection }}</a> is{% endblocktrans %}
+                {% if postelection.next_ballot.election.is_election_day %}
+                    <strong>{% trans "being held today" %}</strong>.
+                {% else %}
+                    {% trans "due to take place on" %} <strong>{{ postelection.next_ballot.election.election_date|date:"l j F Y"}}</strong>.
+                {% endif %}
+            </p>
         {% endif %}
 
         {% include "elections/includes/_postcode_search_form.html" %}

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -40,18 +40,21 @@
                 {% include "parishes/includes/_card.html" with parish_council_election=parish_council_election %}
             {% endif %}
 
-            {# Add this at the top of the page if it's known, or at the bottom if it's not #}
-            {% if show_polling_card %}
-                {% include "elections/includes/_polling_place.html" with elections_by_date=elections_by_date %}
-            {% endif %}
 
-            {% if requires_voter_id %}
-                {% include "elections/includes/_voter_id.html" %}
-            {% endif %}
+            <ul class="ds-details">
+                {# Add this at the top of the page if it's known, or at the bottom if it's not #}
+                {% if show_polling_card %}
+                    {% include "elections/includes/_polling_place.html" with elections_by_date=elections_by_date %}
+                {% endif %}
 
-            {% if not postelections or not postelections.first.past_registration_deadline %}
-                {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %}
-            {% endif %}
+                {% if requires_voter_id %}
+                    {% include "elections/includes/_voter_id.html" %}
+                {% endif %}
+
+                {% if not postelections or not postelections.first.past_registration_deadline %}
+                    {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %}
+                {% endif %}
+            </ul>
 
             {% if not messages %}
                 <div>

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -12,7 +12,7 @@
 {% block twitter_description_content %}{% include "elections/includes/_postcode_meta_title.html" %}{% endblock twitter_description_content %}
 
 {% block content %}
-    <div class="ds-stack-smaller">
+    <div class="ds-stack-larger">
         {% if postelections.count != 1 %}
             {#  Inline nav of elections #}
             {% include "elections/includes/inline_elections_nav_list.html" %}
@@ -54,31 +54,30 @@
             {% endif %}
 
             {% if not messages %}
-                <div class="ds-card">
-                    <div class="ds-card-body">
-                        <h4>
-                            <span aria-hidden="true">⏰</span>
-                            {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
-                        </h4>
-                        <p>
-                            <p>{% trans "Manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>
-                            <ol>
-                                <li>
-                                    {% trans "In your calendar app settings, choose the option for adding a new calendar." %}
-                                </li>
-                                <li>
-                                    {% trans "If presented with the option to choose a calendar type, choose web calendar." %}
-                                </li>
-                                <li>
-                                    {% if uprn %}
-                                        {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'uprn_ical_view' postcode uprn %}</code>
-                                    {% else %}
-                                        {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}</code>
-                                    {% endif %}
-                                </li>
-                            </ol>
-                        </p>
-                    </div>
+                <div>
+                    <h4>
+                        <span aria-hidden="true">⏰</span>
+                        {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
+                    </h4>
+                    <p>
+                        <p>{% trans "Manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>
+                        <ol>
+                            <li>
+                                {% trans "In your calendar app settings, choose the option for adding a new calendar." %}
+                            </li>
+                            <li>
+                                {% trans "If presented with the option to choose a calendar type, choose web calendar." %}
+                            </li>
+                            <li>
+                                {% if uprn %}
+                                    {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'uprn_ical_view' postcode uprn %}</code>
+                                {% else %}
+                                    {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}</code>
+                                {% endif %}
+                            </li>
+                        </ol>
+                    </p>
+
                 </div>
             {% endif %}
 

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -54,35 +54,11 @@
                 {% if not postelections or not postelections.first.past_registration_deadline %}
                     {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %}
                 {% endif %}
+
+                {% if not messages %}
+                    {% include "elections/includes/_calendar.html" %}
+                {% endif %}
             </ul>
-
-            {% if not messages %}
-                <div>
-                    <h4>
-                        <span aria-hidden="true">⏰</span>
-                        {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
-                    </h4>
-                    <p>
-                        <p>{% trans "Manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>
-                        <ol>
-                            <li>
-                                {% trans "In your calendar app settings, choose the option for adding a new calendar." %}
-                            </li>
-                            <li>
-                                {% trans "If presented with the option to choose a calendar type, choose web calendar." %}
-                            </li>
-                            <li>
-                                {% if uprn %}
-                                    {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'uprn_ical_view' postcode uprn %}</code>
-                                {% else %}
-                                    {% trans 'Enter this URL and save' %}: <code>webcal://whocanivotefor.co.uk{% url 'postcode_ical_view' postcode %}</code>
-                                {% endif %}
-                            </li>
-                        </ol>
-                    </p>
-
-                </div>
-            {% endif %}
 
             {% if postelections %}
                 {% include "feedback/feedback_form.html" %}

--- a/wcivf/apps/elections/templates/elections/stv.html
+++ b/wcivf/apps/elections/templates/elections/stv.html
@@ -8,41 +8,40 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Single Transferable Vote (STV)</h2>
 
-                    <p>In an STV election, voters rank candidates in order of
-                        preference using numbers rather than crosses. They may number
-                        as many candidates as they like on the ballot paper.
-                        STV constituencies or wards always contain more than one seat.
-                        It is designed to provide results that are more proportional than simple
-                        <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>.</p>
 
-                    <p>STV is used in Scottish and Northern Irish council elections, and for elections to the Northern Ireland Assembly. There is also a mechanism for Welsh councils to introduce it for Welsh council elections.</p>
+            <h2>Single Transferable Vote (STV)</h2>
 
-                    <h3>How STV works</h3>
+            <p>In an STV election, voters rank candidates in order of
+                preference using numbers rather than crosses. They may number
+                as many candidates as they like on the ballot paper.
+                STV constituencies or wards always contain more than one seat.
+                It is designed to provide results that are more proportional than simple
+                <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>.</p>
 
-                    <p>Candidates need a predetermined number of votes to get elected, known as the ‘quota’.
-                    </p>
+            <p>STV is used in Scottish and Northern Irish council elections, and for elections to the Northern Ireland Assembly. There is also a mechanism for Welsh councils to introduce it for Welsh council elections.</p>
 
-                    <p>To begin with, the number of votes needed to win a seat (the quota) is calculated using the following formula:
-                    </p>
+            <h3>How STV works</h3>
 
-                    <pre>(Valid Votes Cast) ➗ (seats available +1) + 1</pre>
+            <p>Candidates need a predetermined number of votes to get elected, known as the ‘quota’.
+            </p>
 
-                    <p>For example, in a three-member ward, each candidate will need a quarter of the votes plus one to win a seat.</p>
+            <p>To begin with, the number of votes needed to win a seat (the quota) is calculated using the following formula:
+            </p>
 
-                    <p>If no candidate has achieved that quota in first  preference (1s) votes, then the candidate with the fewest first preference votes is eliminated and their votes reallocated to other candidates, according to their voters’ second preferences (2s). This process continues until all the seats are filled.
-                    </p>
+            <pre>(Valid Votes Cast) ➗ (seats available +1) + 1</pre>
 
-                    <p>If a candidate does achieve the quota, any surplus votes gained by that candidate are reallocated according to the voters’ next preferences. Because this is done only using the proportion of votes that are surplus, fractions of a vote are usually created.
-                    </p>
+            <p>For example, in a three-member ward, each candidate will need a quarter of the votes plus one to win a seat.</p>
 
-                    <p>This process is repeated until all of the seats in a ward or constituency are filled. Counting votes cast in STV elections can take some time, although in many places the ballots are counted electronically to speed this up. Scotland uses e-counting methods in local elections.
-                    </p>
-                </div>
-            </div>
+            <p>If no candidate has achieved that quota in first  preference (1s) votes, then the candidate with the fewest first preference votes is eliminated and their votes reallocated to other candidates, according to their voters’ second preferences (2s). This process continues until all the seats are filled.
+            </p>
+
+            <p>If a candidate does achieve the quota, any surplus votes gained by that candidate are reallocated according to the voters’ next preferences. Because this is done only using the proportion of votes that are surplus, fractions of a vote are usually created.
+            </p>
+
+            <p>This process is repeated until all of the seats in a ward or constituency are filled. Counting votes cast in STV elections can take some time, although in many places the ballots are counted electronically to speed this up. Scotland uses e-counting methods in local elections.
+            </p>
+
         </div>
     </div>
 

--- a/wcivf/apps/elections/templates/elections/stv_cy.html
+++ b/wcivf/apps/elections/templates/elections/stv_cy.html
@@ -8,41 +8,40 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Pleidlais Sengl Drosglwyddadwy (PSD)</h2>
+            <div class="ds-padded">
+                <h2>Pleidlais Sengl Drosglwyddadwy (PSD)</h2>
 
-                    <p>Mewn etholiad PSD, mae pleidleiswyr yn graddio ymgeiswyr yn nhrefn
-                        eu dewis gan ddefnyddio rhifau yn hytrach na chroesau. Efallai y byddant yn rhifo
-                        cymaint o ymgeiswyr ag y mynnant ar y papur pleidleisio.
-                        Mae etholaethau neu wardiau PSD bob amser yn cynnwys mwy nag un sedd.
-                        Fe'u cynlluniwyd i ddarparu canlyniadau sy'n fwy cyfrannol na
-                        <a href="{% url 'fptp_voting_system_view' %}">System y Cyntaf i’r Felin</a>.</p>
+                <p>Mewn etholiad PSD, mae pleidleiswyr yn graddio ymgeiswyr yn nhrefn
+                    eu dewis gan ddefnyddio rhifau yn hytrach na chroesau. Efallai y byddant yn rhifo
+                    cymaint o ymgeiswyr ag y mynnant ar y papur pleidleisio.
+                    Mae etholaethau neu wardiau PSD bob amser yn cynnwys mwy nag un sedd.
+                    Fe'u cynlluniwyd i ddarparu canlyniadau sy'n fwy cyfrannol na
+                    <a href="{% url 'fptp_voting_system_view' %}">System y Cyntaf i’r Felin</a>.</p>
 
-                    <p>Defnyddir PSD yn etholiadau cyngor yr Alban a Gogledd Iwerddon, ac ar gyfer etholiadau i Gynulliad Gogledd Iwerddon. Mae mecanwaith hefyd i gynghorau Cymru ei gyflwyno ar gyfer etholiadau cynghorau Cymru.</p>
+                <p>Defnyddir PSD yn etholiadau cyngor yr Alban a Gogledd Iwerddon, ac ar gyfer etholiadau i Gynulliad Gogledd Iwerddon. Mae mecanwaith hefyd i gynghorau Cymru ei gyflwyno ar gyfer etholiadau cynghorau Cymru.</p>
 
 
-                    <h3>Sut mae PSD yn gweithio</h3>
+                <h3>Sut mae PSD yn gweithio</h3>
 
-                    <p>Mae angen nifer o bleidleisiau a bennwyd ymlaen llaw ar ymgeiswyr i gael eu hethol, a elwir yn 'gwota'.
-                    </p>
+                <p>Mae angen nifer o bleidleisiau a bennwyd ymlaen llaw ar ymgeiswyr i gael eu hethol, a elwir yn 'gwota'.
+                </p>
 
-                    <p>I ddechrau, cyfrifir nifer y pleidleisiau sydd eu hangen i ennill sedd (y cwota) gan ddefnyddio'r fformiwla ganlynol:
-                    </p>
+                <p>I ddechrau, cyfrifir nifer y pleidleisiau sydd eu hangen i ennill sedd (y cwota) gan ddefnyddio'r fformiwla ganlynol:
+                </p>
 
-                    <pre>(Pleidleisiau Dilys a Fwriwyd) ➗ (seddi ar gael +1) + 1</pre>
+                <pre>(Pleidleisiau Dilys a Fwriwyd) ➗ (seddi ar gael +1) + 1</pre>
 
-                    <p>Er enghraifft, mewn ward tri aelod, bydd angen chwarter y pleidleisiau ar bob ymgeisydd ynghyd ag un i ennill sedd.</p>
+                <p>Er enghraifft, mewn ward tri aelod, bydd angen chwarter y pleidleisiau ar bob ymgeisydd ynghyd ag un i ennill sedd.</p>
 
-                    <p>Os nad oes unrhyw ymgeisydd wedi cyflawni'r cwota hwnnw yn y pleidleisiau dewis cyntaf (1s), yna caiff yr ymgeisydd sydd â'r nifer lleiaf o bleidleisiau dewis cyntaf ei ddileu a chaiff ei bleidleisiau eu hailddyrannu i ymgeiswyr eraill, yn ôl ail ddewisiadau eu pleidleiswyr (2s). Mae'r broses hon yn parhau nes bod yr holl seddi wedi'u llenwi.</p>
+                <p>Os nad oes unrhyw ymgeisydd wedi cyflawni'r cwota hwnnw yn y pleidleisiau dewis cyntaf (1s), yna caiff yr ymgeisydd sydd â'r nifer lleiaf o bleidleisiau dewis cyntaf ei ddileu a chaiff ei bleidleisiau eu hailddyrannu i ymgeiswyr eraill, yn ôl ail ddewisiadau eu pleidleiswyr (2s). Mae'r broses hon yn parhau nes bod yr holl seddi wedi'u llenwi.</p>
 
-                    <p>Os yw ymgeisydd yn cyflawni'r cwota, caiff unrhyw bleidleisiau dros ben a enillwyd gan yr ymgeisydd hwnnw eu hailddyrannu yn unol â dewisiadau nesaf y pleidleiswyr. Oherwydd y gwneir hyn gan ddefnyddio dim ond cyfran y pleidleisiau sy’n warged, mae ffracsiynau o bleidlais yn cael eu creu fel arfer.</p>
+                <p>Os yw ymgeisydd yn cyflawni'r cwota, caiff unrhyw bleidleisiau dros ben a enillwyd gan yr ymgeisydd hwnnw eu hailddyrannu yn unol â dewisiadau nesaf y pleidleiswyr. Oherwydd y gwneir hyn gan ddefnyddio dim ond cyfran y pleidleisiau sy’n warged, mae ffracsiynau o bleidlais yn cael eu creu fel arfer.</p>
 
-                    <p>Caiff y broses hon ei hailadrodd nes bod yr holl seddi mewn ward neu etholaeth wedi'u llenwi. Gall cyfrif pleidleisiau a fwriwyd mewn etholiadau PSD gymryd peth amser, er bod y pleidleisiau'n cael eu cyfrif yn electronig mewn sawl lle i gyflymu hyn. Mae'r Alban yn defnyddio dulliau e-gyfrif mewn etholiadau lleol.</p>
+                <p>Caiff y broses hon ei hailadrodd nes bod yr holl seddi mewn ward neu etholaeth wedi'u llenwi. Gall cyfrif pleidleisiau a fwriwyd mewn etholiadau PSD gymryd peth amser, er bod y pleidleisiau'n cael eu cyfrif yn electronig mewn sawl lle i gyflymu hyn. Mae'r Alban yn defnyddio dulliau e-gyfrif mewn etholiadau lleol.</p>
 
-                </div>
             </div>
         </div>
+    </div>
     </div>
 
 {% endblock content %}

--- a/wcivf/apps/elections/templates/elections/sv.html
+++ b/wcivf/apps/elections/templates/elections/sv.html
@@ -9,91 +9,89 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Supplementary Vote</h2>
-                    <p>The Supplementary Vote electoral system allows voters
-                        to cast a first and second preference vote on one
-                        ballot. If no candidate gains at least half of all first
-                        preference votes, then the two leading candidates go into a run-off round and all other candidates are eliminated.
-                        The second preference votes on the eliminated candidates' ballots are then counted and added to the leading candidates' totals.
 
-                        This is designed to ensure that the elected candidate
-                        has closer to majority support than would be the case
-                        under <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>.
+            <h2>Supplementary Vote</h2>
+            <p>The Supplementary Vote electoral system allows voters
+                to cast a first and second preference vote on one
+                ballot. If no candidate gains at least half of all first
+                preference votes, then the two leading candidates go into a run-off round and all other candidates are eliminated.
+                The second preference votes on the eliminated candidates' ballots are then counted and added to the leading candidates' totals.
 
-                        Voters do not need to cast a second preference vote, and cannot vote for the same candidate twice.
+                This is designed to ensure that the elected candidate
+                has closer to majority support than would be the case
+                under <a href="{% url 'fptp_voting_system_view' %}">First-past-the-post</a>.
 
-                        SV is used for Police and Crime Commissioner elections
-                        in England and Wales, and for the positions of directly-elected
-                        mayors in England, including London, Manchester, and Liverpool.
-                    </p>
-                    <h3>Example election</h3>
-                    <p>
-                        Taking the results of the 2016 Police and Crime Commissioner
-                        election in Nottinghamshire, the Labour candidate won less
-                        than 50% of the first preference vote, so a second round was
-                        needed. The second preference votes from the eliminated
-                        independent and UKIP candidates were counted, and were awarded
-                        to either Labour or Conservatives.
-                    </p>
+                Voters do not need to cast a second preference vote, and cannot vote for the same candidate twice.
 
-                    <div class="ds-table">
-                        <table>
-                            <caption>
-                                <h2>
-                                    2016 Nottinghamshire Police and Crime Commissioner election
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Party</th>
-                                    <th>First Preference Votes</th>
-                                    <th>First + Second Preference Votes</th>
-                                </tr>
-                                <tr>
-                                    <td>Labour</td>
-                                    <td>80,926</td>
-                                    <td>89,749 (Elected)</td>
-                                </tr>
-                                <tr>
-                                    <td>Conservative Party</td>
-                                    <td>48,155</td>
-                                    <td>56,105</td>
-                                </tr>
-                                <tr>
-                                    <td>UKIP</td>
-                                    <td>20,030</td>
-                                    <td>Eliminated</td>
-                                </tr>
-                                <tr>
-                                    <td>Independent</td>
-                                    <td>14,579</td>
-                                    <td>Eliminated</td>
-                                </tr>
-                                <tr>
-                                    <td>Independent</td>
-                                    <td>7,164</td>
-                                    <td>Eliminated</td>
-                                </tr>
-                                <tr>
-                                    <td><b>Total</b></td>
-                                    <td><b>170,854</b></td>
-                                    <td><b></b></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                SV is used for Police and Crime Commissioner elections
+                in England and Wales, and for the positions of directly-elected
+                mayors in England, including London, Manchester, and Liverpool.
+            </p>
+            <h3>Example election</h3>
+            <p>
+                Taking the results of the 2016 Police and Crime Commissioner
+                election in Nottinghamshire, the Labour candidate won less
+                than 50% of the first preference vote, so a second round was
+                needed. The second preference votes from the eliminated
+                independent and UKIP candidates were counted, and were awarded
+                to either Labour or Conservatives.
+            </p>
 
-                    <p>
-                        As you can see, of the 41,773 votes cast for the three eliminated
-                        candidates, only 16,773 cast second preference votes for
-                        either Labour of Conservative. Some voters may have decided
-                        not to cast a second preference vote, or may have voted for
-                        one of the other eliminated candidates as a second preference.
-                    </p>
-                </div>
+            <div class="ds-table">
+                <table>
+                    <caption>
+                        <h2>
+                            2016 Nottinghamshire Police and Crime Commissioner election
+                        </h2>
+                    </caption>
+                    <tbody>
+                        <tr>
+                            <th>Party</th>
+                            <th>First Preference Votes</th>
+                            <th>First + Second Preference Votes</th>
+                        </tr>
+                        <tr>
+                            <td>Labour</td>
+                            <td>80,926</td>
+                            <td>89,749 (Elected)</td>
+                        </tr>
+                        <tr>
+                            <td>Conservative Party</td>
+                            <td>48,155</td>
+                            <td>56,105</td>
+                        </tr>
+                        <tr>
+                            <td>UKIP</td>
+                            <td>20,030</td>
+                            <td>Eliminated</td>
+                        </tr>
+                        <tr>
+                            <td>Independent</td>
+                            <td>14,579</td>
+                            <td>Eliminated</td>
+                        </tr>
+                        <tr>
+                            <td>Independent</td>
+                            <td>7,164</td>
+                            <td>Eliminated</td>
+                        </tr>
+                        <tr>
+                            <td><b>Total</b></td>
+                            <td><b>170,854</b></td>
+                            <td><b></b></td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
+
+            <p>
+                As you can see, of the 41,773 votes cast for the three eliminated
+                candidates, only 16,773 cast second preference votes for
+                either Labour of Conservative. Some voters may have decided
+                not to cast a second preference vote, or may have voted for
+                one of the other eliminated candidates as a second preference.
+            </p>
+
         </div>
     </div>
 

--- a/wcivf/apps/elections/templates/elections/sv_cy.html
+++ b/wcivf/apps/elections/templates/elections/sv_cy.html
@@ -2,75 +2,73 @@
 
     <div class="ds-page">
         <div class="ds-stack">
-            <div class="ds-card ds-padded">
-                <div class="ds-card-body">
-                    <h2>Pleidlais Atodol</h2>
-                    <p>Mae system etholiadol y Bleidlais Atodol yn caniatáu i bleidleiswyr                        fwrw pleidlais ar gyfer eu dewis cyntaf a’u hail ddewis ar yr un                        papur pleidleisio. Os nad fydd ymgeisydd yn ennill o leiaf hanner yr holl                        bleidleisiau dewis cyntaf, yna bydd y ddau ymgeisydd sydd ar y blaen yn mynd ymlaen i ail rownd a bydd pob ymgeisydd arall yn cael eu dileu o’r etholiad.
-                        Yna bydd y pleidleisiau ail ddewis sydd ar bapurau pleidleisio’r ymgeiswyr a ddilëwyd o’r etholiad yn cael eu cyfrif a'u hychwanegu at gyfansymiau'r ymgeiswyr sydd ar y blaen.
 
-                        Nod hyn yw sicrhau bod yr ymgeisydd sy’n cael ei ethol                        yn nes at gael cefnogaeth y mwyafrif o gymharu â’r                        system <a href="{% url 'fptp_voting_system_view' %}">Cyntaf i'r felin</a>.
+            <h2>Pleidlais Atodol</h2>
+            <p>Mae system etholiadol y Bleidlais Atodol yn caniatáu i bleidleiswyr                        fwrw pleidlais ar gyfer eu dewis cyntaf a’u hail ddewis ar yr un                        papur pleidleisio. Os nad fydd ymgeisydd yn ennill o leiaf hanner yr holl                        bleidleisiau dewis cyntaf, yna bydd y ddau ymgeisydd sydd ar y blaen yn mynd ymlaen i ail rownd a bydd pob ymgeisydd arall yn cael eu dileu o’r etholiad.
+                Yna bydd y pleidleisiau ail ddewis sydd ar bapurau pleidleisio’r ymgeiswyr a ddilëwyd o’r etholiad yn cael eu cyfrif a'u hychwanegu at gyfansymiau'r ymgeiswyr sydd ar y blaen.
 
-                        Nid oes rhaid i bleidleiswyr fwrw pleidlais ail ddewis, ac ni allan nhw bleidleisio dros yr un ymgeisydd ddwywaith.
+                Nod hyn yw sicrhau bod yr ymgeisydd sy’n cael ei ethol                        yn nes at gael cefnogaeth y mwyafrif o gymharu â’r                        system <a href="{% url 'fptp_voting_system_view' %}">Cyntaf i'r felin</a>.
 
-                        Defnyddir Pleidlais Atodol ar gyfer etholiadau Comisiynwyr yr Heddlu a Throseddu yng Nghymru a Lloegr, ac ar gyfer meiri a etholir yn uniongyrchol yn Lloegr, gan gynnwys Llundain, Manceinion, a Lerpwl.
-                    </p>
-                    <h3>Enghraifft o etholiad</h3>
-                    <p>
-                        Yn etholiadau Comisiynydd yr Heddlu a Throseddu Swydd Nottingham 2016, enillodd yr ymgeisydd Llafur lai                        na 50% o'r bleidlais ddewis gyntaf, felly roedd angen mynd i ail rownd. Cafodd pleidleisiau ail ddewis yr                        ymgeiswyr annibynnol ac UKIP, a ddilëwyd o’r etholiad, eu cyfrif, a’u dyfarnu naill ai i’r Blaid Lafur neu i’r Ceidwadwyr.
-                    </p>
+                Nid oes rhaid i bleidleiswyr fwrw pleidlais ail ddewis, ac ni allan nhw bleidleisio dros yr un ymgeisydd ddwywaith.
 
-                    <div class="ds-table">
-                        <table>
-                            <caption>
-                                <h2>
-                                    Etholiad Comisiynydd Heddlu a Throsedd Swydd Nottingham 2016
-                                </h2>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Plaid</th>
-                                    <th>Pleidleisiau Dewis Cyntaf</th>
-                                    <th>Pleidleisiau Dewis Cyntaf + Ail Ddewis</th>
-                                </tr>
-                                <tr>
-                                    <td>Llafur</td>
-                                    <td>80,926</td>
-                                    <td>89,749 (Etholwyd)</td>
-                                </tr>
-                                <tr>
-                                    <td>Y Blaid Geidwadol</td>
-                                    <td>48,155</td>
-                                    <td>56,105</td>
-                                </tr>
-                                <tr>
-                                    <td>UKIP</td>
-                                    <td>20,030</td>
-                                    <td>Wedi’u Dileu</td>
-                                </tr>
-                                <tr>
-                                    <td>Annibynnol</td>
-                                    <td>14,579</td>
-                                    <td>Wedi’u Dileu</td>
-                                </tr>
-                                <tr>
-                                    <td>Annibynnol</td>
-                                    <td>7,164</td>
-                                    <td>Wedi’u Dileu</td>
-                                </tr>
-                                <tr>
-                                    <td><b>Cyfanswm</b></td>
-                                    <td><b>170,854</b></td>
-                                    <td><b></b></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                Defnyddir Pleidlais Atodol ar gyfer etholiadau Comisiynwyr yr Heddlu a Throseddu yng Nghymru a Lloegr, ac ar gyfer meiri a etholir yn uniongyrchol yn Lloegr, gan gynnwys Llundain, Manceinion, a Lerpwl.
+            </p>
+            <h3>Enghraifft o etholiad</h3>
+            <p>
+                Yn etholiadau Comisiynydd yr Heddlu a Throseddu Swydd Nottingham 2016, enillodd yr ymgeisydd Llafur lai                        na 50% o'r bleidlais ddewis gyntaf, felly roedd angen mynd i ail rownd. Cafodd pleidleisiau ail ddewis yr                        ymgeiswyr annibynnol ac UKIP, a ddilëwyd o’r etholiad, eu cyfrif, a’u dyfarnu naill ai i’r Blaid Lafur neu i’r Ceidwadwyr.
+            </p>
 
-                    <p>
-                        Fel y gwelwch, o'r 41,773 o bleidleisiau a fwriwyd ar gyfer y tri ymgeisydd a ddilëwyd, dim ond 16,773 o bobl a roddodd eu pleidlais ail ddewis i Lafur neu’r Ceidwadwyr. Efallai fod rhai pleidleiswyr wedi penderfynu                        peidio â bwrw pleidlais ail ddewis, neu efallai eu bod wedi rhoi pleidlais ail ddewis i un o'r ymgeiswyr eraill a ddilëwyd.
-                    </p>
-                </div>
+            <div class="ds-table">
+                <table>
+                    <caption>
+                        <h2>
+                            Etholiad Comisiynydd Heddlu a Throsedd Swydd Nottingham 2016
+                        </h2>
+                    </caption>
+                    <tbody>
+                        <tr>
+                            <th>Plaid</th>
+                            <th>Pleidleisiau Dewis Cyntaf</th>
+                            <th>Pleidleisiau Dewis Cyntaf + Ail Ddewis</th>
+                        </tr>
+                        <tr>
+                            <td>Llafur</td>
+                            <td>80,926</td>
+                            <td>89,749 (Etholwyd)</td>
+                        </tr>
+                        <tr>
+                            <td>Y Blaid Geidwadol</td>
+                            <td>48,155</td>
+                            <td>56,105</td>
+                        </tr>
+                        <tr>
+                            <td>UKIP</td>
+                            <td>20,030</td>
+                            <td>Wedi’u Dileu</td>
+                        </tr>
+                        <tr>
+                            <td>Annibynnol</td>
+                            <td>14,579</td>
+                            <td>Wedi’u Dileu</td>
+                        </tr>
+                        <tr>
+                            <td>Annibynnol</td>
+                            <td>7,164</td>
+                            <td>Wedi’u Dileu</td>
+                        </tr>
+                        <tr>
+                            <td><b>Cyfanswm</b></td>
+                            <td><b>170,854</b></td>
+                            <td><b></b></td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
+
+            <p>
+                Fel y gwelwch, o'r 41,773 o bleidleisiau a fwriwyd ar gyfer y tri ymgeisydd a ddilëwyd, dim ond 16,773 o bobl a roddodd eu pleidlais ail ddewis i Lafur neu’r Ceidwadwyr. Efallai fod rhai pleidleiswyr wedi penderfynu                        peidio â bwrw pleidlais ail ddewis, neu efallai eu bod wedi rhoi pleidlais ail ddewis i un o'r ymgeiswyr eraill a ddilëwyd.
+            </p>
+
         </div>
     </div>
 

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -338,7 +338,8 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = True
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
-        self.assertContains(response, "{}'s Elections".format(self.person.name))
+        # import pdb; pdb.set_trace()
+        self.assertContains(response, "{}'s elections".format(self.person.name))
         self.assertContains(response, "(election cancelled")
 
     def test_previous_elections_elected_with_count(self):
@@ -355,7 +356,7 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = False
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
-        self.assertContains(response, "{}'s Elections".format(self.person.name))
+        self.assertContains(response, "{}'s elections".format(self.person.name))
         self.assertContains(
             response, "{} votes (elected)".format(self.person_post.votes_cast)
         )
@@ -392,7 +393,7 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = False
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
-        self.assertContains(response, "{}'s Elections".format(self.person.name))
+        self.assertContains(response, "{}'s elections".format(self.person.name))
         self.assertContains(response, "Elected (vote count not available")
 
     def test_previous_elections_not_elected_no_count(self):
@@ -409,7 +410,7 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = False
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
-        self.assertContains(response, "{}'s Elections".format(self.person.name))
+        self.assertContains(response, "{}'s elections".format(self.person.name))
         self.assertContains(response, "Not elected (vote count not available)")
 
     def test_deselected_person(self):

--- a/wcivf/apps/feedback/templates/feedback/feedback_form.html
+++ b/wcivf/apps/feedback/templates/feedback/feedback_form.html
@@ -10,7 +10,7 @@
         border-color: #E6007C;
     }
 </style>
-<div class="ds-card">
+<div>
     <form id="feedback_form" method="post" action="{% url 'feedback_form_view' %}" novalidate>
         {% csrf_token %}
         {{ feedback_form.token }}

--- a/wcivf/apps/feedback/templates/feedback/feedback_thanks.html
+++ b/wcivf/apps/feedback/templates/feedback/feedback_thanks.html
@@ -9,17 +9,12 @@
                 {% if object.found_useful == "YES" %}
                     {% blocktrans trimmed %}
                         <p>The information you see here is gathered publicly, by people like you.</p>
-
-                        <p>Help us do more to make democracy work better for everyone!</p>
                     {% endblocktrans %}
                 {% else %}
                     {% blocktrans trimmed %}
-
                         <p>We're sorry you didn't find what you were looking for. We'll read your feedback and pass it on to our volunteers.</p>
 
                         <p>The information you see here is gathered publicly, by people like you.</p>
-
-                        <p>Help us do better in future!</p>
                     {% endblocktrans %}
                 {% endif %}
             </li>

--- a/wcivf/apps/parties/templates/parties/parties_view.html
+++ b/wcivf/apps/parties/templates/parties/parties_view.html
@@ -17,48 +17,44 @@
 
 
     <div class="ds-stack-smaller">
-        <div class="ds-card">
-            <div class="ds-card-body">
-                <h1>{% trans "UK political parties" %}</h1>
-                {% blocktrans trimmed %}
-                    <p>The following is a list of all political parties represented by candidates in Democracy Club's UK election
-                        database (est. 2015). This list includes registered and deregistered parties.</p>
-                    <p>There are two party registers in the UK: a combined Great Britain register for England, Wales and Scotland, and a separate register for Northern Ireland. Parties in Great Britain can only field candidates in the nations they have specified in their entry.</p>
-                    <p>A registered party may field candidates in elections.</p>
-                    <p>A deregistered party may no longer field candidates in elections. A party can become deregistered through choice, or becuase it failed to renew its annual registration status. In some cases, parties have been deregistered and then subsequently reregistered; in these cases, the party will have an entry for each registration.</p>
-                    <p>Party names and emblems are taken from the <a href="http://www.electoralcommission.org.uk/">Electoral
-                        Commission's register of political parties.</a></p>
-                {% endblocktrans %}
-                <aside class="ds-filter" aria-labelledby="filter-label">
-                    <div class="ds-filter-cluster">
-                        <ul>
-                            <li id="filter-label" class="ds-filter-label" aria-hidden="true">Filter:</li>
-                            <li><a href="{{ photo_list_review_url }}" {% if request.get_full_path == photo_list_review_url %}aria-current="true" {% endif %}>All</a></li>
-                            {% for shortcut in shortcuts.list %}
-                                <li><a href="{{ photo_list_review_url }}?{{ shortcut.querystring }}" {% if shortcut.active %}aria-current="true" {% endif %}>{{ shortcut.label }}</a></li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                    <form>
-                        <details {% if filter.data %}open=""{% endif %}>
-                            <summary>Advanced filters</summary>
-                            <div class="ds-advanced-filters">
-                                <div class="ds-filter-cluster">
-                                    {% for field in filter.form.visible_fields %}
-                                        <ul aria-labelledby="adv-filter-label-{{ forloop.counter }}">
-                                            <li id="adv-filter-label-{{ forloop.counter }}" class="ds-filter-label" aria-hidden="true">{{ field.label }}:</li>
-                                            {{ field }}
-                                        </ul>
-                                    {% endfor %}
-
-                                </div>
-                            </div>
-                        </details>
-                    </form>
-                </aside>
-                {% include "parties/party_list.html" with parties=queryset %}
+        <h1>{% trans "UK political parties" %}</h1>
+        {% blocktrans trimmed %}
+            <p>The following is a list of all political parties represented by candidates in Democracy Club's UK election
+                database (est. 2015). This list includes registered and deregistered parties.</p>
+            <p>There are two party registers in the UK: a combined Great Britain register for England, Wales and Scotland, and a separate register for Northern Ireland. Parties in Great Britain can only field candidates in the nations they have specified in their entry.</p>
+            <p>A registered party may field candidates in elections.</p>
+            <p>A deregistered party may no longer field candidates in elections. A party can become deregistered through choice, or becuase it failed to renew its annual registration status. In some cases, parties have been deregistered and then subsequently reregistered; in these cases, the party will have an entry for each registration.</p>
+            <p>Party names and emblems are taken from the <a href="http://www.electoralcommission.org.uk/">Electoral
+                Commission's register of political parties.</a></p>
+        {% endblocktrans %}
+        <aside class="ds-filter" aria-labelledby="filter-label">
+            <div class="ds-filter-cluster">
+                <ul>
+                    <li id="filter-label" class="ds-filter-label" aria-hidden="true">Filter:</li>
+                    <li><a href="{{ photo_list_review_url }}" {% if request.get_full_path == photo_list_review_url %}aria-current="true" {% endif %}>All</a></li>
+                    {% for shortcut in shortcuts.list %}
+                        <li><a href="{{ photo_list_review_url }}?{{ shortcut.querystring }}" {% if shortcut.active %}aria-current="true" {% endif %}>{{ shortcut.label }}</a></li>
+                    {% endfor %}
+                </ul>
             </div>
-        </div>
+            <form>
+                <details {% if filter.data %}open=""{% endif %}>
+                    <summary>Advanced filters</summary>
+                    <div class="ds-advanced-filters">
+                        <div class="ds-filter-cluster">
+                            {% for field in filter.form.visible_fields %}
+                                <ul aria-labelledby="adv-filter-label-{{ forloop.counter }}">
+                                    <li id="adv-filter-label-{{ forloop.counter }}" class="ds-filter-label" aria-hidden="true">{{ field.label }}:</li>
+                                    {{ field }}
+                                </ul>
+                            {% endfor %}
+
+                        </div>
+                    </div>
+                </details>
+            </form>
+        </aside>
+        {% include "parties/party_list.html" with parties=queryset %}
     </div>
 
 {% endblock content %}

--- a/wcivf/apps/people/migrations/0047_person_statement_to_voters_last_updated.py
+++ b/wcivf/apps/people/migrations/0047_person_statement_to_voters_last_updated.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0046_personpost_deselected_personpost_deselected_source"),
     ]

--- a/wcivf/apps/people/migrations/0048_person_blue_sky_url_person_other_url_and_more.py
+++ b/wcivf/apps/people/migrations/0048_person_blue_sky_url_person_other_url_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0047_person_statement_to_voters_last_updated"),
     ]

--- a/wcivf/apps/people/templates/people/includes/_person_contact_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_contact_card.html
@@ -1,6 +1,5 @@
 {% load i18n %}
-<section class="ds-card">
-    <div class="ds-card-body ds-stack-smaller">
+<section class="ds-stack-smaller">
         <h2 class="ds-candidate-name ds-h3">
             {{ object.name }} {% trans "online" %}
         </h2>
@@ -171,5 +170,4 @@
                 <a href="{{ object.get_ynr_url }}">{% trans "Can you add it?" %}</a>
             </div>
         {% endif %}
-    </div>
 </section>

--- a/wcivf/apps/people/templates/people/includes/_person_contact_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_contact_card.html
@@ -1,173 +1,173 @@
 {% load i18n %}
 <section class="ds-stack-smaller">
-        <h2 class="ds-candidate-name ds-h3">
-            {{ object.name }} {% trans "online" %}
-        </h2>
-        {% if object.has_any_contact_info %}
-            <dl class="ds-descriptions">
+    <h2 class="ds-candidate-name ds-h3">
+        {{ object.name }} {% trans "online" %}
+    </h2>
+    {% if object.has_any_contact_info %}
+        <dl class="ds-descriptions">
 
-                {% if object.facebook_page_url or object.facebook_personal_url %}
+            {% if object.facebook_page_url or object.facebook_personal_url %}
+                <div>
+                    <dt>{% trans "Facebook" %}</dt>
                     <div>
-                        <dt>{% trans "Facebook" %}</dt>
-                        <div>
-                            {% if object.facebook_personal_url %}
-                                <dd>
-                                    <a href="{{ object.facebook_personal_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s personal Facebook{% endblocktrans%}">
-                                        {{ object.facebook_personal_username }}
-                                    </a><br />
-                                </dd>
-                            {% endif %}
-                            {% if object.facebook_page_url %}
-                                <dd>
-                                    <a href="{{ object.facebook_page_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s Facebook page{% endblocktrans%}">
-                                        {{ object.facebook_username}}
-                                    </a>
-                                </dd>
-                            {% endif %}
-                        </div>
-                    </div>
-                {% endif %}
-
-                {% if object.twitter_username %}
-                    <div>
-                        <dt>{% trans "Twitter" %}</dt>
-                        <dd>
-                            <a href="https://twitter.com/{{ object.twitter_username }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Twitter profile{% endblocktrans%}">
-                                {{ object.twitter_username}}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.mastodon_username %}
-                    <div>
-                        <dt>{% trans "Mastodon" %}</dt>
-                        <dd>
-                            <a href="{{ object.mastodon_username}}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Mastodon profile{% endblocktrans%}">
-                                {{ object.mastodon_username}}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.linkedin_url %}
-                    <div>
-                        <dt>{% trans "LinkedIn" %}</dt>
-                        <dd>
-                            <a href="{{ object.linkedin_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s LinkedIn profile{% endblocktrans%}">
-                                {{ object.linkedin_username}}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.homepage_url %}
-                    <div>
-                        <dt>{% trans "Home page" %}</dt>
-                        <dd>
-                            <a href="{{ object.homepage_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s home page{% endblocktrans%}">
-                                {{ object.homepage_url }}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.blog_url %}
-                    <div>
-                        <dt>{% trans "Blog" %}</dt>
-                        <dd>
-                            <a href="{{ object.blog_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}">
-                                {% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.instagram_url %}
-                    <div>
-                        <dt>{% trans "Instagram" %}</dt>
-                        <dd>
-                            <a href="{{ object.instagram_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Instagram{% endblocktrans%}">
-                                {{ object.instagram_username }}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.youtube_profile %}
-                    <div>
-                        <dt>{% trans "YouTube" %}</dt>
-                        <dd>
-                            <a href="{{ object.youtube_profile }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s YouTube{% endblocktrans%}">
-                                {{ object.youtube_username }}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.party_ppc_page_url %}
-                    <div>
-                        <dt>{% trans "The party's candidate page for this person" %}</dt>
-                        <dd>
-                            <a href="{{ object.party_ppc_page_url }}" title="{% blocktrans trimmed with person_name=object.name%}Party page for {{ person_name }}{% endblocktrans%}">
-                                {{ object.party_ppc_page_url }}
-                            </a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.tiktok_url %}
-                    <div>
-                        <dt>{% trans "TikTok" %}</dt>
-                        <dd>
-                            <a href="{{ object.tiktok_url }}" title="{% blocktrans trimmed with person_name=object.tiktok_url%}{{ person_name }}'s TikTok{% endblocktrans%}">{{ object.tiktok_url}}</a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.threads_url %}
-                    <div>
-                        <dt>{% trans "Threads" %}</dt>
-                        <dd>
-                            <a href="{{ object.threads_url }}" title="{% blocktrans trimmed with person_name=object.threads_url %}{{ person_name }}'s Threads{% endblocktrans%}">{{ object.threads_url }}</a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.blue_sky_url %}
-                    <div>
-                        <dt>{% trans "BlueSky" %}</dt>
-                        <dd>
-                            <a href="{{ object.blue_sky_url }}" title="{% blocktrans trimmed with person_name=object.blue_sky_url %}{{ person_name }}BlueSky'{% endblocktrans%}">{{ object.blue_sky_url }}</a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-                {% if object.other_url %}
-                    <div>
-                        <dt>{% trans "Other contact info" %}</dt>
-                        <dd>
-                            <a href="{{ object.other_url }}" title="{% blocktrans trimmed with person_name=object.other_url %}{{ person_name }}other contact info{% endblocktrans%}">{{ object.other_url }}</a>
-                        </dd>
-                    </div>
-                {% endif %}
-
-
-                {% if object.current_or_future_candidacies %}
-                    {% if object.email %}
-                        <div>
-                            <dt>{% trans "Email" %}</dt>
+                        {% if object.facebook_personal_url %}
                             <dd>
-                                <a href="mailto:{{ object.email }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s email{% endblocktrans%}">{{ object.email }}</a>
+                                <a href="{{ object.facebook_personal_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s personal Facebook{% endblocktrans%}">
+                                    {{ object.facebook_personal_username }}
+                                </a><br />
                             </dd>
-                        </div>
-                    {% endif %}
+                        {% endif %}
+                        {% if object.facebook_page_url %}
+                            <dd>
+                                <a href="{{ object.facebook_page_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s Facebook page{% endblocktrans%}">
+                                    {{ object.facebook_username}}
+                                </a>
+                            </dd>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if object.twitter_username %}
+                <div>
+                    <dt>{% trans "Twitter" %}</dt>
+                    <dd>
+                        <a href="https://twitter.com/{{ object.twitter_username }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Twitter profile{% endblocktrans%}">
+                            {{ object.twitter_username}}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.mastodon_username %}
+                <div>
+                    <dt>{% trans "Mastodon" %}</dt>
+                    <dd>
+                        <a href="{{ object.mastodon_username}}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Mastodon profile{% endblocktrans%}">
+                            {{ object.mastodon_username}}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.linkedin_url %}
+                <div>
+                    <dt>{% trans "LinkedIn" %}</dt>
+                    <dd>
+                        <a href="{{ object.linkedin_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s LinkedIn profile{% endblocktrans%}">
+                            {{ object.linkedin_username}}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.homepage_url %}
+                <div>
+                    <dt>{% trans "Home page" %}</dt>
+                    <dd>
+                        <a href="{{ object.homepage_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s home page{% endblocktrans%}">
+                            {{ object.homepage_url }}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.blog_url %}
+                <div>
+                    <dt>{% trans "Blog" %}</dt>
+                    <dd>
+                        <a href="{{ object.blog_url }}" title="{% blocktrans with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}">
+                            {% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s blog{% endblocktrans%}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.instagram_url %}
+                <div>
+                    <dt>{% trans "Instagram" %}</dt>
+                    <dd>
+                        <a href="{{ object.instagram_url }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s Instagram{% endblocktrans%}">
+                            {{ object.instagram_username }}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.youtube_profile %}
+                <div>
+                    <dt>{% trans "YouTube" %}</dt>
+                    <dd>
+                        <a href="{{ object.youtube_profile }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s YouTube{% endblocktrans%}">
+                            {{ object.youtube_username }}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.party_ppc_page_url %}
+                <div>
+                    <dt>{% trans "The party's candidate page for this person" %}</dt>
+                    <dd>
+                        <a href="{{ object.party_ppc_page_url }}" title="{% blocktrans trimmed with person_name=object.name%}Party page for {{ person_name }}{% endblocktrans%}">
+                            {{ object.party_ppc_page_url }}
+                        </a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.tiktok_url %}
+                <div>
+                    <dt>{% trans "TikTok" %}</dt>
+                    <dd>
+                        <a href="{{ object.tiktok_url }}" title="{% blocktrans trimmed with person_name=object.tiktok_url%}{{ person_name }}'s TikTok{% endblocktrans%}">{{ object.tiktok_url}}</a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.threads_url %}
+                <div>
+                    <dt>{% trans "Threads" %}</dt>
+                    <dd>
+                        <a href="{{ object.threads_url }}" title="{% blocktrans trimmed with person_name=object.threads_url %}{{ person_name }}'s Threads{% endblocktrans%}">{{ object.threads_url }}</a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.blue_sky_url %}
+                <div>
+                    <dt>{% trans "BlueSky" %}</dt>
+                    <dd>
+                        <a href="{{ object.blue_sky_url }}" title="{% blocktrans trimmed with person_name=object.blue_sky_url %}{{ person_name }}BlueSky'{% endblocktrans%}">{{ object.blue_sky_url }}</a>
+                    </dd>
+                </div>
+            {% endif %}
+
+            {% if object.other_url %}
+                <div>
+                    <dt>{% trans "Other contact info" %}</dt>
+                    <dd>
+                        <a href="{{ object.other_url }}" title="{% blocktrans trimmed with person_name=object.other_url %}{{ person_name }}other contact info{% endblocktrans%}">{{ object.other_url }}</a>
+                    </dd>
+                </div>
+            {% endif %}
+
+
+            {% if object.current_or_future_candidacies %}
+                {% if object.email %}
+                    <div>
+                        <dt>{% trans "Email" %}</dt>
+                        <dd>
+                            <a href="mailto:{{ object.email }}" title="{% blocktrans trimmed with person_name=object.name%}{{ person_name }}'s email{% endblocktrans%}">{{ object.email }}</a>
+                        </dd>
+                    </div>
                 {% endif %}
-            </dl>
-        {% else %}
-            <div>
-                {% blocktrans trimmed with person_name=object.name %}<dt>We don't have {{ person_name }}'s contact info.</dt>{% endblocktrans %}
-                <a href="{{ object.get_ynr_url }}">{% trans "Can you add it?" %}</a>
-            </div>
-        {% endif %}
+            {% endif %}
+        </dl>
+    {% else %}
+        <div>
+            {% blocktrans trimmed with person_name=object.name %}<dt>We don't have {{ person_name }}'s contact info.</dt>{% endblocktrans %}
+            <a href="{{ object.get_ynr_url }}">{% trans "Can you add it?" %}</a>
+        </div>
+    {% endif %}
 </section>

--- a/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
@@ -2,28 +2,24 @@
 {% load i18n %}
 
 {% if object.current_or_future_candidacies %}
-    <section class="ds-card">
-        <div class="ds-card-body">
-            <h3>{% trans "That's all we know! Will you help us find more about this candidate?" %}</h3>
-            <p>{% trans "Our volunteers have been working hard to add information on as many candidates as possible, but they need help." %}</p>
-            <p>
-                {% trans "If you can add information that should be on this page" %}
+    <h2 class="ds-h3">{% trans "That's all we know! Will you help us find more about this candidate?" %}</h2>
+    <p>{% trans "Our volunteers have been working hard to add information on as many candidates as possible, but they need help." %}</p>
+    <p>
+        {% trans "If you can add information that should be on this page" %}
 
-                {% if object.cta_example_details %}
-                    {% blocktrans trimmed with person=object.name cta=object.cta_example_details|join:", "%}- such as {{ person }}'s
-                        {{ cta }} - {% endblocktrans %}
-                {% endif %}
-                {% trans "please use our crowdsourcing website to add it." %}
-            </p>
-            <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">
-                {% trans "Add or edit details &raquo;" %}
-            </a>
+        {% if object.cta_example_details %}
+            {% blocktrans trimmed with person=object.name cta=object.cta_example_details|join:", "%}- such as {{ person }}'s
+                {{ cta }} - {% endblocktrans %}
+        {% endif %}
+        {% trans "please use our crowdsourcing website to add it." %}
+    </p>
+    <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">
+        {% trans "Add or edit details &raquo;" %}
+    </a>
 
-            {#    <h4>Upload your leaflets</h4>#}
-            {#    <p>If you've received election leaflets from {{ object.name }}, please take a photo#}
-            {#      of them and upload them to ElectionLeaflets.org</p>#}
-            {#    <p><a class="ds-button ds-cta ds-cta-blue" type="button" href="https://electionleaflets.org/">Add leaflets</a>#}
-            {#    </p>#}
-        </div>
-    </section>
+    {#    <h4>Upload your leaflets</h4>#}
+    {#    <p>If you've received election leaflets from {{ object.name }}, please take a photo#}
+    {#      of them and upload them to ElectionLeaflets.org</p>#}
+    {#    <p><a class="ds-button ds-cta ds-cta-blue" type="button" href="https://electionleaflets.org/">Add leaflets</a>#}
+    {#    </p>#}
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_local_party_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_local_party_card.html
@@ -1,65 +1,61 @@
 {% load i18n %}
 {% if person.local_party %}
-    <div class="ds-card">
-        <div class="ds-card-body">
-            <h4 class="ds-h3">{{ party}}</h4>
-            <p>
-                {% if person.local_party.is_local %}
-                    {% blocktrans trimmed with person=person.name party_label=person.local_party.label %}{{ person }}'s local party is {{ party_label }}.{% endblocktrans %}
-                {% else %}
-                    {% blocktrans trimmed with person=person.name %}{{ person }} is a {{ party }} candidate.{% endblocktrans %}
-                {% endif %}
-            </p>
-            <dl class="ds-descriptions">
-                {% if person.local_party.twitter %}
-                    <div>
-                        <dt>Twitter</dt>
-                        <a href="https://twitter.com/{{ person.local_party.twitter }}">
-                            {{ person.local_party.twitter }}
-                        </a>
-                    </div>
-                {% endif %}
-                {% if person.local_party.facebook_page %}
-                    <div>
-                        <dt>Facebook</dt>
-                        <a href="{{ person.local_party.facebook_page }}">
-                            {{ person.local_party.facebook_page }}
-                        </a>
-                    </div>
-                {% endif %}
-                {% if person.local_party.homepage %}
-                    <div>
-                        <dt>{% trans "Party Homepage" %}</dt>
-                        <a href="{{ person.local_party.homepage }}">
-                            {% blocktrans trimmed %}{{ party }}'s website{% endblocktrans %}
-                        </a>
-                    </div>
-                {% endif %}
-                {% if person.local_party.email %}
-                    <div>
-                        <dt>{% trans "Email" %}</dt>
-                        <a href="mailto:{{ person.local_party.email }}">
-                            {% blocktrans %}{{ party }}'s email{% endblocktrans %}
-                        </a>
-                    </div>
-                {% endif %}
-                {% if person.local_party.contact_page_url %}
-                    <div>
-                        <dt>{% trans "Contact page" %}</dt>
-                        <a href="{{ person.local_party.contact_page_url }}">
-                            {% blocktrans trimmed %}{{ party }}'s contact page{% endblocktrans %}
-                        </a>
-                    </div>
-                {% endif %}
-                {% if person.local_party.youtube_profile_url %}
-                    <div>
-                        <dt>{% trans "Youtube page" %}</dt>
-                        <a href="{{ person.local_party.youtube_profile_url }}">
-                            {% blocktrans trimmed %}{{ party }}'s Youtube profile{% endblocktrans %}
-                        </a>
-                    </div>
-                {% endif %}
-            </dl>
-        </div>
-    </div>
+    <h4 class="ds-h3">{{ party}}</h4>
+    <p>
+        {% if person.local_party.is_local %}
+            {% blocktrans trimmed with person=person.name party_label=person.local_party.label %}{{ person }}'s local party is {{ party_label }}.{% endblocktrans %}
+        {% else %}
+            {% blocktrans trimmed with person=person.name %}{{ person }} is a {{ party }} candidate.{% endblocktrans %}
+        {% endif %}
+    </p>
+    <dl class="ds-descriptions">
+        {% if person.local_party.twitter %}
+            <div>
+                <dt>Twitter</dt>
+                <a href="https://twitter.com/{{ person.local_party.twitter }}">
+                    {{ person.local_party.twitter }}
+                </a>
+            </div>
+        {% endif %}
+        {% if person.local_party.facebook_page %}
+            <div>
+                <dt>Facebook</dt>
+                <a href="{{ person.local_party.facebook_page }}">
+                    {{ person.local_party.facebook_page }}
+                </a>
+            </div>
+        {% endif %}
+        {% if person.local_party.homepage %}
+            <div>
+                <dt>{% trans "Party Homepage" %}</dt>
+                <a href="{{ person.local_party.homepage }}">
+                    {% blocktrans trimmed %}{{ party }}'s website{% endblocktrans %}
+                </a>
+            </div>
+        {% endif %}
+        {% if person.local_party.email %}
+            <div>
+                <dt>{% trans "Email" %}</dt>
+                <a href="mailto:{{ person.local_party.email }}">
+                    {% blocktrans %}{{ party }}'s email{% endblocktrans %}
+                </a>
+            </div>
+        {% endif %}
+        {% if person.local_party.contact_page_url %}
+            <div>
+                <dt>{% trans "Contact page" %}</dt>
+                <a href="{{ person.local_party.contact_page_url }}">
+                    {% blocktrans trimmed %}{{ party }}'s contact page{% endblocktrans %}
+                </a>
+            </div>
+        {% endif %}
+        {% if person.local_party.youtube_profile_url %}
+            <div>
+                <dt>{% trans "Youtube page" %}</dt>
+                <a href="{{ person.local_party.youtube_profile_url }}">
+                    {% blocktrans trimmed %}{{ party }}'s Youtube profile{% endblocktrans %}
+                </a>
+            </div>
+        {% endif %}
+    </dl>
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_policy_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_policy_card.html
@@ -3,84 +3,80 @@
 {% load i18n %}
 
 {% if object.statement_to_voters or object.leaflet_set.exists or object.twfy_id %}
-    <section class="ds-card">
-        <div class="ds-card-body">
-            <h2 class="ds-candidate-name ds-h3">
-                {% blocktrans with person_name=object.name %}{{ person_name }}'s policies{% endblocktrans %}
-            </h2>
+    <h2 class="ds-candidate-name ds-h3">
+        {% blocktrans with person_name=object.name %}{{ person_name }}'s policies{% endblocktrans %}
+    </h2>
+    {% if object.statement_to_voters %}
+        <h4>{% trans "Statement to voters" %}</h4>
+        {% if object.long_statement %}
+            <div class="ds-details">
+                <blockquote class="ds-stack-smaller">
+                    <p>{{ object.statement_intro }}</p>
+                    <details>
+                        <summary>{% trans "Full statement" %}</summary>
+                        <p>{{ object.statement_remainder|linebreaksbr }}</p>
+                    </details>
+                </blockquote>
+            </div>
+        {% else %}
+            <blockquote>{{ object.statement_to_voters|linebreaks }}</blockquote>
+        {% endif %}
+        {% if object.statement_to_voters_last_updated %}
+            <p>{% blocktrans with date=object.statement_to_voters_last_updated|naturalday %}This statement was last updated on {{ date }}{% endblocktrans %}</p>
+        {% endif %}
+        <p class="small">
+            {% blocktrans trimmed with person_name=object.name %}
+                This statement was added by {{ person_name }}, their team, or by a
+                <a href="https://candidates.democracyclub.org.uk/volunteer/{{ object.ynr_id }}">
+                    Democracy Club volunteer</a>, based on
+                information published by the candidate elsewhere.
+            {% endblocktrans %}</p>
+    {% endif %}
 
-            {% if object.statement_to_voters %}
-                <h4>{% trans "Statement to voters" %}</h4>
-                {% if object.long_statement %}
-                    <div class="ds-details">
-                        <blockquote class="ds-stack-smaller">
-                            <p>{{ object.statement_intro }}</p>
-                            <details>
-                                <summary>{% trans "Full statement" %}</summary>
-                                <p>{{ object.statement_remainder|linebreaksbr }}</p>
-                            </details>
-                        </blockquote>
-                    </div>
-                {% else %}
-                    <blockquote>{{ object.statement_to_voters|linebreaks }}</blockquote>
-                {% endif %}
-                {% if object.statement_to_voters_last_updated %}
-                    <p>{% blocktrans with date=object.statement_to_voters_last_updated|naturalday %}This statement was last updated on {{ date }}{% endblocktrans %}</p>
-                {% endif %}
-                <p class="small">
-                    {% blocktrans trimmed with person_name=object.name %}
-                        This statement was added by {{ person_name }}, their team, or by a
-                        <a href="https://candidates.democracyclub.org.uk/volunteer/{{ object.ynr_id }}">
-                            Democracy Club volunteer</a>, based on
-                        information published by the candidate elsewhere.
-                    {% endblocktrans %}</p>
-            {% endif %}
-
-            <!-- leaflets -->
-            {% if object.leaflet_set.exists %}
-                <h4>
-                    {% blocktrans with person_name=object.name %}Recent leaflets from {{ person_name }}{% endblocktrans %}
-                </h4>
-                <ul class="ds-grid">
-                    {% for leaflet in object.leaflet_set.latest_four %}
-                        <li>
-                            {% if leaflet.thumb_url %}
-                                <a href="https://electionleaflets.org/leaflets/{{ leaflet.leaflet_id }}">
-                                    <img src="{{ leaflet.thumb_url }}" alt="{% blocktrans with person_name=object.name %}Thumbnail of leaflet from {{ person_name }}{% endblocktrans %}" />
-                                </a>
-                            {% endif %}
-                            <p>
-                                {% blocktrans trimmed with leaflet_id=leaflet.leaflet_id date=leaflet.date_uploaded_to_electionleaflets|naturalday:"j M Y" %}
-                                    Uploaded {{ date }}<br />
-                                    <a href="https://electionleaflets.org/leaflets/{{ leaflet_id }}" class="cta">See leaflet</a>
-                                {% endblocktrans %}
-                            </p>
-                        </li>
-                    {% endfor %}
-                </ul>
-                <div class="ds-cluster">
-                    <div>
-                        {% blocktrans trimmed with person_name=object.name person_id=object.ynr_id %}
-                            <a class="ds-cta" href="https://electionleaflets.org/person/{{ person_id }}">
-                                More leaflets from {{ person_name }}</a>
-                            <a class="ds-cta" href="https://electionleaflets.org/leaflets/add/">
-                                Upload a leaflet
-                            </a>
+    <!-- leaflets -->
+    {% if object.leaflet_set.exists %}
+        <h4>
+            {% blocktrans with person_name=object.name %}Recent leaflets from {{ person_name }}{% endblocktrans %}
+        </h4>
+        <ul class="ds-grid">
+            {% for leaflet in object.leaflet_set.latest_four %}
+                <li>
+                    {% if leaflet.thumb_url %}
+                        <a href="https://electionleaflets.org/leaflets/{{ leaflet.leaflet_id }}">
+                            <img src="{{ leaflet.thumb_url }}"
+                                alt="{% blocktrans with person_name=object.name %}Thumbnail of leaflet from {{ person_name }}{% endblocktrans %}"/>
+                        </a>
+                    {% endif %}
+                    <p>
+                        {% blocktrans trimmed with leaflet_id=leaflet.leaflet_id date=leaflet.date_uploaded_to_electionleaflets|naturalday:"j M Y" %}
+                            Uploaded {{ date }}<br/>
+                            <a href="https://electionleaflets.org/leaflets/{{ leaflet_id }}" class="cta">See leaflet</a>
                         {% endblocktrans %}
-                    </div>
-                </div>
-
-            {% endif %}
-
-            <!-- TWFY  -->
-            {% if object.twfy_id %}
-                <h4>{% trans "Record in office" %}</h4>
-                <p>{% trans "See this candidate's " %}
-                    <a href="https://www.theyworkforyou.com/mp/{{ object.twfy_id }}">
-                        {% trans "record on TheyWorkForYou" %}</a> -
-                    {% trans "their speeches, voting history and more" %}
-                </p>
-            {% endif %}
+                    </p>
+                </li>
+            {% endfor %}
+        </ul>
+        <div class="ds-cluster">
+            <div>
+                {% blocktrans trimmed with person_name=object.name person_id=object.ynr_id %}
+                    <a class="ds-cta" href="https://electionleaflets.org/person/{{ person_id }}">
+                        More leaflets from {{ person_name }}</a>
+                    <a class="ds-cta" href="https://electionleaflets.org/leaflets/add/">
+                        Upload a leaflet
+                    </a>
+                {% endblocktrans %}
+            </div>
         </div>
-    </section>
+
+    {% endif %}
+
+    <!-- TWFY  -->
+    {% if object.twfy_id %}
+        <h4>{% trans "Record in office" %}</h4>
+        <p>{% trans "See this candidate's " %}
+            <a href="https://www.theyworkforyou.com/mp/{{ object.twfy_id }}">
+                {% trans "record on TheyWorkForYou" %}</a> -
+            {% trans "their speeches, voting history and more" %}
+        </p>
+    {% endif %}
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -2,52 +2,48 @@
 {% load i18n %}
 
 {% if object.personpost_set.exists %}
-    <section class="ds-card">
-        <div class="ds-table">
-            <table>
-                <caption style="font-style: normal;">
-                    <h3 class="ds-padded">{{ object.name }}'s {% trans "Elections" %}</h3>
-                </caption>
-                <tr>
-                    <th>{% trans "Date" %}</th>
-                    <th>{% trans "Election" %}</th>
-                    <th>{% trans "Party" %}</th>
-                    <th>{% trans "Results" %}</th>
-                    {% if object.previous_party_count %}
-                        <th>{% trans "Other party affiliations in the past 12 months" %}</th>
-                    {% endif %}
-                    <th>{% trans "Position" %}</th>
-                </tr>
+    <div class="ds-table">
+        <h2 class="ds-h3">{{ object.name }}'s {% trans "elections" %}</h2>
+        <table>
+            <tr>
+                <th>{% trans "Date" %}</th>
+                <th>{% trans "Election" %}</th>
+                <th>{% trans "Party" %}</th>
+                <th>{% trans "Results" %}</th>
+                {% if object.previous_party_count %}
+                    <th>{% trans "Other party affiliations in the past 12 months" %}</th>
+                {% endif %}
+                <th>{% trans "Position" %}</th>
+            </tr>
 
-                {% for person_post in object.personpost_set.all %}
-                    <tr>
-                        <td>{{ person_post.election.election_date|date:"Y" }}</td>
+            {% for person_post in object.personpost_set.all %}
+                <tr>
+                    <td>{{ person_post.election.election_date|date:"Y" }}</td>
+                    <td>
+                        <a href="{{ person_post.post_election.get_absolute_url }}">
+                            {{ person_post.post.label }}: {{ person_post.election }}
+                        </a>
+                    </td>
+                    <td>{{ person_post.party_name }}</td>
+                    <td>
+                        {{ person_post.get_results_text }}
+                    </td>
+                    {% if object.previous_party_count %}
                         <td>
-                            <a href="{{ person_post.post_election.get_absolute_url }}">
-                                {{ person_post.post.label}}: {{ person_post.election }}
-                            </a>
+                            {% for previous_party_affiliation in person_post.previous_party_affiliations.all %}
+                                {{ previous_party_affiliation.party_name }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
                         </td>
-                        <td>{{ person_post.party_name }}</td>
-                        <td>
-                            {{ person_post.get_results_text }}
-                        </td>
-                        {% if object.previous_party_count %}
-                            <td>
-                                {% for previous_party_affiliation in person_post.previous_party_affiliations.all %}
-                                    {{ previous_party_affiliation.party_name }}{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
-                            </td>
+                    {% endif %}
+                    <td>
+                        {% if person_post.votes_cast %}
+                            {{ person_post.get_results_rank }}
+                        {% else %}
+                            Position not available
                         {% endif %}
-                        <td>
-                            {% if person_post.votes_cast %}
-                                {{ person_post.get_results_rank }}
-                            {% else %}
-                                Position not available
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </table>
-        </div>
-    </section>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
 {% endif %}

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -359,7 +359,7 @@ class PersonViewTests(TestCase):
             votes_cast=1000,
         )
         response = self.client.get(self.person_url, follow=True)
-        self.assertContains(response, f"{self.person.name}'s Elections")
+        self.assertContains(response, f"{self.person.name}'s elections")
 
     def test_no_statement_to_voters(self):
         PersonPostWithPartyFactory(person=self.person, election=ElectionFactory())

--- a/wcivf/apps/ppc_2024/templates/ppc_2024/home.html
+++ b/wcivf/apps/ppc_2024/templates/ppc_2024/home.html
@@ -22,7 +22,7 @@
 
     <p>Spotted an error? Think we’ve missed a candidate? Get in touch: <a href="mailto:hello@democracyclub.org.uk">hello@democracyclub.org.uk</a></p>
 
-    <details class="ds-details ds-stack ds-stack-smaller">
+    <details class="ds-details ds-stack-smaller">
         <summary>More information about the general election</summary>
 
         <p>There are 650 constituencies in the House of Commons, and each constituency elects one Member of Parliament

--- a/wcivf/apps/referendums/templates/referendums/detail.html
+++ b/wcivf/apps/referendums/templates/referendums/detail.html
@@ -10,7 +10,7 @@
 {% block content %}
     {% include "elections/includes/_post_breadcrumbs.html" %}
 
-    <div class="ds-stack-smaller">
+    <div>
         {% include "referendums/includes/_card.html" with referendum=object.referendum %}
 
         {% include "elections/includes/_postcode_search_form.html" %}

--- a/wcivf/assets/js/scripts.js
+++ b/wcivf/assets/js/scripts.js
@@ -2,6 +2,8 @@ document.addEventListener("DOMContentLoaded", function(event) {
 	var feedback_form = document.forms[1]
 	var feedback_form_token = feedback_form.elements[1].value
 	var csrfmiddlewaretoken = feedback_form.elements[0].value
+	var found_useful_label = feedback_form.elements[3].label
+	found_useful_label.style.display = 'none'
 	document.querySelector('[name=found_useful]').click(function(el) {
 	    var found_useful = document.querySelector(this).value;
 	    fetch('/feedback/submit_initial/', {

--- a/wcivf/assets/scss/style.scss
+++ b/wcivf/assets/scss/style.scss
@@ -167,3 +167,8 @@ input[type=radio] {
     font-size: inherit;
 }
 
+@media (max-width: 738px) {
+    .emblem-for-candidate-list {
+        display: none;
+    }
+}

--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -7,23 +7,20 @@
 
 {% block content %}
 
-    <div class="ds-card">
-        <div class="ds-card-body ds-text-centered">
-            <h4>{% trans "Find out about candidates in your area" %}</h4>
-            <div class="ds-field">
-                <form method="post">
-                    {% csrf_token %}
-                    {{ form|dc_form }}
-                    {% if request.GET.invalid_postcode %}
-                        <p>
-                            <strong>{% blocktrans trimmed with postcode=request.GET.postcode %}Sorry, we don't know the postcode {{ postcode }}.
-                                Is there another one you can try?{% endblocktrans %}</strong>
-                        </p>
-                    {% endif %}
-                    <button class="ds-button-pink" type="submit">{% trans "Find your candidates" %}</button>
-                </form>
-            </div>
-        </div>
+    <h1 class="ds-h2">{% trans "Find out about candidates in your area" %}</h1>
+    <div class="ds-field">
+        <form method="post">
+            {% csrf_token %}
+            {{ form|dc_form }}
+            {% if request.GET.invalid_postcode %}
+                <p>
+                    <strong>{% blocktrans trimmed with postcode=request.GET.postcode %}Sorry, we don't know the postcode
+                        {{ postcode }}.
+                        Is there another one you can try?{% endblocktrans %}</strong>
+                </p>
+            {% endif %}
+            <button class="ds-button-pink" type="submit">{% trans "Find your candidates" %}</button>
+        </form>
     </div>
     {% if show_results_chart %}
         <div class="flourish-embed flourish-chart" data-src="visualisation/13653636">
@@ -31,45 +28,42 @@
         </div>
     {% endif %}
     {% if show_gb_id_messaging %}
-        <div class="ds-card">
-            <div class="ds-card-body ds-text-centered">
-                <h2>
-                    <span aria-hidden="true">ℹ️</span>
-                    {% trans "Photographic identification" %}
-                </h2>
-                <p>{% trans "Photographic identification will be required to vote in English local elections, and parliamentary elections across the UK, on and after 4 May 2023." %}</p>
-                <p><a href="https://www.electoralcommission.org.uk/i-am-a/voter/voter-id" aria-label="{% trans 'Learn more about photographic identification for voters on the website of the Electoral Commission.' %}">{% trans "Learn more on the website of the Electoral Commission." %}</a></p>
+        <h2>
+            <span aria-hidden="true">ℹ️</span>
+            {% trans "Photographic identification" %}
+        </h2>
+        <p>{% trans "Photographic identification will be required to vote in English local elections, and parliamentary elections across the UK, on and after 4 May 2023." %}</p>
+        <p><a href="https://www.electoralcommission.org.uk/i-am-a/voter/voter-id"
+            aria-label="{% trans 'Learn more about photographic identification for voters on the website of the Electoral Commission.' %}">{% trans "Learn more on the website of the Electoral Commission." %}</a>
+        </p>
 
-                <p>{% trans "You can apply for a free 'Voter Authority Certificate' if you do not already possess a valid ID." %}</p>
-                <p><a href="https://www.gov.uk/apply-for-photo-id-voter-authority-certificate">{% trans "Apply for free voter ID." %}</a></p>
-                <p>{% trans "You do not need photo ID to vote by post." %}</p>
-            </div>
-        </div>
+        <p>{% trans "You can apply for a free 'Voter Authority Certificate' if you do not already possess a valid ID." %}</p>
+        <p>
+            <a href="https://www.gov.uk/apply-for-photo-id-voter-authority-certificate">{% trans "Apply for free voter ID." %}</a>
+        </p>
+        <p>{% trans "You do not need photo ID to vote by post." %}</p>
     {% endif %}
     {% if upcoming_elections %}
-        <div class="ds-card">
-            <div class="ds-card-body">
-                <h2>{% trans "Upcoming Elections" %}</h2>
-                {% regroup upcoming_elections by election.election_date as elections_by_date %}
 
-                {% for election_group in elections_by_date %}
-                    <h3>{{ election_group.grouper }}</h3>
-                    {% regroup election_group.list by election.nice_election_name as named_postelections %}
-                    <ul>
-                        {% for election in named_postelections %}
-                            <li><strong>{{ election.grouper }}{{ election.list|length|pluralize }}</strong>
-                                {% for postelection in election.list %}
-                                    <br><a href="{{ postelection.get_absolute_url }}">{{ postelection.friendly_name }}</a>
-                                    {% if postelection.cancelled %}
-                                        {{ postelection.short_cancelled_message_html }}
-                                    {% endif %}
-                                {% endfor %}
-                            </li>
+        <h2 class="ds-h3">{% trans "Upcoming Elections" %}</h2>
+        {% regroup upcoming_elections by election.election_date as elections_by_date %}
+
+        {% for election_group in elections_by_date %}
+            <h3 class="ds-h4">{{ election_group.grouper }}</h3>
+            {% regroup election_group.list by election.nice_election_name as named_postelections %}
+            <ul>
+                {% for election in named_postelections %}
+                    <li><strong>{{ election.grouper }}{{ election.list|length|pluralize }}</strong>
+                        {% for postelection in election.list %}
+                            <br><a href="{{ postelection.get_absolute_url }}">{{ postelection.friendly_name }}</a>
+                            {% if postelection.cancelled %}
+                                {{ postelection.short_cancelled_message_html }}
+                            {% endif %}
                         {% endfor %}
-                    </ul>
+                    </li>
                 {% endfor %}
-            </div>
-        </div>
+            </ul>
+        {% endfor %}
     {% endif %}
 
 {% endblock content %}

--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -7,8 +7,8 @@
 
 {% block content %}
 
-    <h1 class="ds-h2">{% trans "Find out about candidates in your area" %}</h1>
-    <div class="ds-field">
+    <h1 class="ds-h2 ds-text-centered">{% trans "Find out about candidates in your area" %}</h1>
+    <div class="ds-field ds-text-centered">
         <form method="post">
             {% csrf_token %}
             {{ form|dc_form }}


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1537
Ref for broken format on PCC 'About this position' component (aka "explainers") https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1807

- Remove the `ds-card` from a load o pages. This is especially noticeable on the ballot and postcode results pages on mobile. This change includes some general reformatting and spacing edits. 
- Put voter FAQs into details list and add anchors to those in the elections list
- Hide party emblem on candidate lists for small mobile devices 

Changes are available to view on https://dev.wcivf.club/

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206863292550553