### PR TITLE
Fix key error for statement_to_voters_last_updated

### DIFF
--- a/wcivf/apps/people/managers.py
+++ b/wcivf/apps/people/managers.py
@@ -120,6 +120,11 @@ class PersonManager(models.Manager):
             "death_date": person["death_date"] or None,
             "last_updated": last_updated,
             "delisted": person.get("delisted", False),
+            "statement_to_voters": person["statement_to_voters"] or None,
+            "statement_to_voters_last_updated": person[
+                "statement_to_voters_last_updated"
+            ]
+            or None,
         }
 
         for value_type in VALUE_TYPES_TO_IMPORT:
@@ -137,11 +142,6 @@ class PersonManager(models.Manager):
                 else:
                     defaults[value_type] = identifier["value"]
 
-        defaults["statement_to_voters"] = person["statement_to_voters"]
-        if defaults["statement_to_voters"]:
-            defaults["statement_to_voters_last_updated"] = person[
-                "statement_to_voters_last_updated"
-            ]
         defaults["favourite_biscuit"] = person["favourite_biscuit"]
 
         if "thumbnail" in person:


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1799

This change adds `statement_to_voters_last_updated`  and `statement_to_voters` by default during recently updated people imports. I think this will need a full import to pull in these dates. 

![Screenshot 2024-03-26 at 4 01 30 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/ef939c8e-ee9c-4ca4-aa2b-ffe8f4ee2082)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206929625991192