### PR TITLE
Help users understand pre-sopn day candidate info

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -57,194 +57,186 @@
                         {# Display different messages depending on the number of candidates #}
                         {# Case: No candidates for a contested election #}
                         {% if not postelection.people and postelection.contested %}
-                            {% trans "We don't know of any candidates standing yet. You can help improve this page:" %} <a href="{{ postelection.ynr_link }}">
+                            {% blocktrans trimmed with expected_sopn_date=postelection.expected_sopn_date|date:"j F Y" %}
+                                We don't know of any candidates standing yet.
+                                The official candidate list will be published by {{ expected_sopn_date }}, when this page will be updated.
+                                You can help improve this page:
+                            {% endblocktrans %}
+                            <a href="{{ postelection.ynr_link }}">
                                 {% trans "add information about candidates to our database" %}</a>.
+
                         {% else %}
-                            {# Display different messages depending on the number of candidates #}
-                            {# Case: No candidates for a contested election #}
-                            {% if not postelection.people and postelection.contested %}
-                                {% trans "We don't know of any candidates standing yet." %}
-                                {% trans "You can help improve this page:" %} <a href="{{ postelection.ynr_link }}">
-                                    {% trans "add information about candidates to our database" %}</a>.
-                            {% else %}
-                                {% if postelection.locked %}
-                                    {# Case: Candidates and the post is locked #}
-                                    {% if postelection.get_voting_system.slug == "PR-CL" %}
-                                        {% trans "You will have one vote, and can vote for a single party list or independent candidate." %}
-                                    {% else %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
-                                            {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber plural=postelection.winner_count|pluralize num_candidates=postelection.people.count|apnumber plural_candidates=postelection.people|pluralize%}
-                                                You will have <strong>{{ winner_count }} vote{{ plural }}</strong>,
-                                                and can choose from <strong>{{ num_candidates }} candidate{{ plural_candidates }}</strong>.
+                            {% if postelection.locked %}
+                                {# Case: Candidates and the post is locked #}
+                                {% if postelection.get_voting_system.slug == "PR-CL" %}
+                                    {% trans "You will have one vote, and can vote for a single party list or independent candidate." %}
+                                {% else %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'FPTP' %}
+                                        {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber plural=postelection.winner_count|pluralize num_candidates=postelection.people.count|apnumber plural_candidates=postelection.people|pluralize%}
+                                            You will have <strong>{{ winner_count }} vote{{ plural }}</strong>,
+                                            and can choose from <strong>{{ num_candidates }} candidate{{ plural_candidates }}</strong>.
+                                        {% endblocktrans %}
+                                    {% endif %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
+                                        {% blocktrans trimmed with num_ballots=postelection.party_ballot_count postelection=postelection.friendly_name %}
+                                            You will have <strong>one vote</strong>, and can choose from <strong>{{ num_ballots }}</strong>
+                                            in the {{ postelection }}.{% endblocktrans %}
+                                    {% endif %}
+                                    {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
+                                        {% blocktrans trimmed with num_ballots=postelection.party_ballot_count postelection=postelection.friendly_name %}
+                                            You will have <strong>two votes</strong>, and can choose from <strong>{{ num_ballots }}</strong>
+                                            in the {{ postelection}}.
+                                        {% endblocktrans %}
+                                    {% endif %}
+                                    {% if postelection.get_voting_system.slug == 'STV' %}
+                                        {% if postelection.winner_count == 1 %}
+                                            {% blocktrans trimmed with num_ballots=postelection.party_ballot_count %}
+                                                There is <strong>one seat</strong>  up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
                                             {% endblocktrans %}
-                                        {% endif %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'AMS' %}
-                                            {% blocktrans trimmed with num_ballots=postelection.party_ballot_count postelection=postelection.friendly_name %}
-                                                You will have <strong>one vote</strong>, and can choose from <strong>{{ num_ballots }}</strong>
-                                                in the {{ postelection }}.{% endblocktrans %}
-                                        {% endif %}
-                                        {% if postelection.winner_count and postelection.get_voting_system.slug == 'sv' %}
-                                            {% blocktrans trimmed with num_ballots=postelection.party_ballot_count postelection=postelection.friendly_name %}
-                                                You will have <strong>two votes</strong>, and can choose from <strong>{{ num_ballots }}</strong>
-                                                in the {{ postelection}}.
+                                        {% else %}
+                                            {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber num_ballots=postelection.party_ballot_count %}
+                                                There are <strong>{{ winner_count }} seats</strong>  up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
                                             {% endblocktrans %}
-                                        {% endif %}
-                                        {% if postelection.get_voting_system.slug == 'STV' %}
-                                            {% if postelection.winner_count == 1 %}
-                                                {% blocktrans trimmed with num_ballots=postelection.party_ballot_count %}
-                                                    There is <strong>one seat</strong>  up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
-                                                {% endblocktrans %}
-                                            {% else %}
-                                                {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber num_ballots=postelection.party_ballot_count %}
-                                                    There are <strong>{{ winner_count }} seats</strong>  up for election, and you can choose from <strong>{{ num_ballots }}</strong>.
-                                                {% endblocktrans %}
-                                            {% endif %}
                                         {% endif %}
                                     {% endif %}
-
-                                    {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
-
-                                {% else %}
-                                    {# Case: Candidates and the post is NOT locked (add CTA) #}
-                                    {% blocktrans trimmed with expected_sopn_date=postelection.expected_sopn_date|date:"j F Y"  count counter=postelection.people.count %}
-                                        This candidate will not be confirmed until the council publishes
-                                        the official candidate list on {{ expected_sopn_date }}.
-                                    {% plural %}
-                                        These candidates will not be confirmed until the council publishes
-                                        the official candidate list on {{ expected_sopn_date }}.
-                                    {% endblocktrans %}
-
-
-                                    {% blocktrans trimmed with ynr_link=postelection.ynr_link %}
-                                        Once nomination papers are published, we will manually verify each candidate.
-                                        You can help improve this page: <a href="{{ ynr_link }}">
-                                            add information about candidates to our database</a>.
-                                    {% endblocktrans %}
-
-
                                 {% endif %}
 
+                                {% include "elections/includes/_how-to-vote.html" with voting_system=postelection.get_voting_system %}
+
+                            {% else %}
+                                {# Case: Candidates and the post is NOT locked (add CTA) #}
+                                {% blocktrans trimmed with num_candidates=postelection.people|length|apnumber plural_candidates=postelection.people|pluralize %}
+                                    We are currently aware of {{ num_candidates }} candidate{{plural_candidates}} for this position.
+                                {% endblocktrans %}
+
+                                {% blocktrans trimmed with expected_sopn_date=postelection.expected_sopn_date|date:"j F Y" ynr_link=postelection.ynr_link %}
+                                    The official candidate list will be published by {{expected_sopn_date}}, when this page will be updated.
+                                    Once nomination papers are published, we will manually verify each candidate.
+                                    You can help improve this page: <a href="{{ ynr_link }}">
+                                        add information about candidates to our database</a>.
+                                {% endblocktrans %}
                             {% endif %}
+
                         {% endif %}
                     {% endif %}
-                </p>
             {% endif %}
-            {% if postelection.election.election_booklet %}
-                <h4>
-                    <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
-                </h4>
-            {% endif %}
+        </p>
+        {% if postelection.election.election_booklet %}
+            <h4>
+                <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
+            </h4>
+        {% endif %}
 
-            {% if postelection.election.description %}
-                <div class="ds-card">
-                    <div class="ds-card-body">
-                        <h3>About this position</h3>
-                        <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
-                    </div>
+        {% if postelection.election.description %}
+            <div class="ds-card">
+                <div class="ds-card-body">
+                    <h3>About this position</h3>
+                    <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
                 </div>
+            </div>
+        {% endif %}
+
+        {% if postelection.election.in_past and postelection.has_results %}
+            <section class="ds-card ds-width-half-text">
+                <div class="ds-table">
+                    <table id="results-table">
+                        {% if postelection.electorate %}
+                            <tr>
+                                <th>{% trans "Electorate" %}</th>
+                                <td>{{ postelection.electorate | intcomma }}</td>
+                            </tr>
+                        {% endif %}
+
+                        {% if postelection.ballot_papers_issued %}
+                            <tr>
+                                <th>{% trans "Ballot Papers Issued" %}</th>
+                                <td>{{ postelection.ballot_papers_issued | intcomma }}</td>
+                            </tr>
+                        {% endif %}
+
+                        {% if postelection.spoilt_ballots %}
+                            <tr>
+                                <th>{% trans "Spoilt Ballots" %}</th>
+                                <td>{{ postelection.spoilt_ballots | intcomma}}</td>
+                            </tr>
+                        {% endif %}
+
+                        {% if postelection.turnout %}
+                            <tr>
+                                <th>{% trans "Turnout" %}</th>
+                                <td>{{ postelection.turnout|stringformat:"d%%" }}</td>
+                            </tr>
+                        {% endif %}
+
+                    </table>
+                </div>
+            </section>
+        {% endif %}
+        {% if postelection.people and postelection.should_show_candidates %}
+            {% if postelection.display_as_party_list %}
+                {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
+            {% else %}
+                {% include "elections/includes/_people_list.html" with people=postelection.people  %}
+
             {% endif %}
+        {% endif %}
 
-            {% if postelection.election.in_past and postelection.has_results %}
-                <section class="ds-card ds-width-half-text">
-                    <div class="ds-table">
-                        <table id="results-table">
-                            {% if postelection.electorate %}
-                                <tr>
-                                    <th>{% trans "Electorate" %}</th>
-                                    <td>{{ postelection.electorate | intcomma }}</td>
-                                </tr>
-                            {% endif %}
-
-                            {% if postelection.ballot_papers_issued %}
-                                <tr>
-                                    <th>{% trans "Ballot Papers Issued" %}</th>
-                                    <td>{{ postelection.ballot_papers_issued | intcomma }}</td>
-                                </tr>
-                            {% endif %}
-
-                            {% if postelection.spoilt_ballots %}
-                                <tr>
-                                    <th>{% trans "Spoilt Ballots" %}</th>
-                                    <td>{{ postelection.spoilt_ballots | intcomma}}</td>
-                                </tr>
-                            {% endif %}
-
-                            {% if postelection.turnout %}
-                                <tr>
-                                    <th>{% trans "Turnout" %}</th>
-                                    <td>{{ postelection.turnout|stringformat:"d%%" }}</td>
-                                </tr>
-                            {% endif %}
-
-                        </table>
-                    </div>
-                </section>
-            {% endif %}
-            {% if postelection.people and postelection.should_show_candidates %}
-                {% if postelection.display_as_party_list %}
-                    {% include "elections/includes/_people_list_with_lists.html" with people=postelection.people %}
+        {% if postelection.should_display_sopn_info and not postelection.should_show_candidates %}
+            <p>
+                {% if postelection.locked %}
+                    {% blocktrans trimmed with sopn_url=postelection.ynr_sopn_link %}
+                        The <a href="{{ sopn_url }}">official candidate list</a> has been published.
+                    {% endblocktrans%}
                 {% else %}
-                    {% include "elections/includes/_people_list.html" with people=postelection.people  %}
-
-                {% endif %}
-            {% endif %}
-
-            {% if postelection.should_display_sopn_info and not postelection.should_show_candidates %}
-                <p>
-                    {% if postelection.locked %}
-                        {% blocktrans trimmed with sopn_url=postelection.ynr_sopn_link %}
-                            The <a href="{{ sopn_url }}">official candidate list</a> has been published.
-                        {% endblocktrans%}
+                    {% if postelection.past_expected_sopn_day %}
+                        {% trans "The official candidate list should have been published on" %}
                     {% else %}
-                        {% if postelection.past_expected_sopn_day %}
-                            {% trans "The official candidate list should have been published on" %}
-                        {% else %}
-                            {% trans "The official candidate list should be published on" %}
-                        {% endif %}
-                        {{ postelection.expected_sopn_date|date:"j F Y" }}.
+                        {% trans "The official candidate list should be published on" %}
                     {% endif %}
-                </p>
+                    {{ postelection.expected_sopn_date|date:"j F Y" }}.
+                {% endif %}
+            </p>
 
-                {%  if not postelection.cancelled %}
-                    {% if postelection.election.voter_age %}
-                        <ul class="ds-details">
-                            <li>
-                                <details>
-                                    <summary>{% trans "Can you vote in this election?" %}</summary>
-                                    <h5>{% trans "Age" %}</h5>
-                                    <p>
-                                        {% blocktrans trimmed with voter_age=postelection.election.voter_age voter_age_date=postelection.election.election_date|date:"jS" election_date=postelection.election.election_date|date:"F Y" %}
-                                            You need to be over {{ voter_age }} on the {{ voter_age_date }} of {{ election_date }} in order to vote in this election.
-                                        {% endblocktrans %}
-                                    </p>
-                                    {% if postelection.election.voter_citizenship %}
-                                        <h5>{% trans "Citizenship" %}</h5>
-                                        {{ postelection.election.voter_citizenship|markdown }}
-                                    {% endif %}
-                                </details>
-                            </li>
-                        </ul>
-                    {% endif %}
+            {%  if not postelection.cancelled %}
+                {% if postelection.election.voter_age %}
+                    <ul class="ds-details">
+                        <li>
+                            <details>
+                                <summary>{% trans "Can you vote in this election?" %}</summary>
+                                <h5>{% trans "Age" %}</h5>
+                                <p>
+                                    {% blocktrans trimmed with voter_age=postelection.election.voter_age voter_age_date=postelection.election.election_date|date:"jS" election_date=postelection.election.election_date|date:"F Y" %}
+                                        You need to be over {{ voter_age }} on the {{ voter_age_date }} of {{ election_date }} in order to vote in this election.
+                                    {% endblocktrans %}
+                                </p>
+                                {% if postelection.election.voter_citizenship %}
+                                    <h5>{% trans "Citizenship" %}</h5>
+                                    {{ postelection.election.voter_citizenship|markdown }}
+                                {% endif %}
+                            </details>
+                        </li>
+                    </ul>
                 {% endif %}
             {% endif %}
+        {% endif %}
 
-            {% if postelection.ballotnewsarticle_set.exists %}
-                {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}
-            {% endif %}
+        {% if postelection.ballotnewsarticle_set.exists %}
+            {% include "news_mentions/news_articles.html" with news_articles=postelection.ballotnewsarticle_set.all %}
+        {% endif %}
 
-            {% if postelection.wikipedia_bio %}
-                <div class="ds-card">
-                    <div class="ds-card-body">
-                        <h3>{% trans "Wikipedia" %}</h3>
-                        <p>{{ postelection.wikipedia_bio }}</p>
-                        <p><a href="{{ postelection.wikipedia_url }}">{% trans "Read more on Wikipedia" %}</a></p>
-                    </div>
+        {% if postelection.wikipedia_bio %}
+            <div class="ds-card">
+                <div class="ds-card-body">
+                    <h3>{% trans "Wikipedia" %}</h3>
+                    <p>{{ postelection.wikipedia_bio }}</p>
+                    <p><a href="{{ postelection.wikipedia_url }}">{% trans "Read more on Wikipedia" %}</a></p>
                 </div>
-            {% endif %}
-            {% include "elections/includes/_ld_election.html" with election=postelection %}
-        </div>
+            </div>
+        {% endif %}
+        {% include "elections/includes/_ld_election.html" with election=postelection %}
     </div>
-    {% if postelection.husting_set.displayable %}
-        {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
-    {% endif %}
+</div>
+{% if postelection.husting_set.displayable %}
+    {% include "hustings/includes/_ballot.html" with hustings=postelection.husting_set.displayable %}
+{% endif %}
 </div>

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -46,9 +46,7 @@ class ElectionViewTests(TestCase):
             self.assertContains(response, self.election.nice_election_name)
 
     def test_election_detail_view(self):
-        response = self.client.get(
-            self.election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/election_view.html")
         self.assertContains(response, self.election.nice_election_name)
@@ -69,13 +67,9 @@ class ElectionViewTests(TestCase):
             (not_city_of_london, "Polls are open from 7a.m. till 10p.m."),
         ]:
             with self.subTest(election=election):
-                response = self.client.get(
-                    election[0].get_absolute_url(), follow=True
-                )
+                response = self.client.get(election[0].get_absolute_url(), follow=True)
                 self.assertEqual(response.status_code, 200)
-                self.assertTemplateUsed(
-                    response, "elections/election_view.html"
-                )
+                self.assertTemplateUsed(response, "elections/election_view.html")
                 self.assertContains(response, election[0].nice_election_name)
                 self.assertContains(response, election[1])
 
@@ -91,12 +85,8 @@ class ElectionViewTests(TestCase):
                 ballot__post__division_type=division_type[0]
             )
             with self.subTest(election=election):
-                response = self.client.get(
-                    election.get_absolute_url(), follow=True
-                )
-                self.assertContains(
-                    response, election.pluralized_division_name.title()
-                )
+                response = self.client.get(election.get_absolute_url(), follow=True)
+                self.assertContains(response, election.pluralized_division_name.title())
 
     def test_election_type_filters(self):
         """
@@ -162,9 +152,7 @@ class ElectionPostViewTests(TestCase):
             slug="local.adur.churchill.2021-05-06",
         )
         self.post = PostFactory(label="Adur local election")
-        self.post_election = PostElectionFactory(
-            election=self.election, post=self.post
-        )
+        self.post_election = PostElectionFactory(election=self.election, post=self.post)
 
     def test_pre_sopn_text_with_candidates(self):
         future_election = ElectionFactory(
@@ -187,32 +175,29 @@ class ElectionPostViewTests(TestCase):
             post=future_post,
             person=person,
         )
-        response = self.client.get(
-            future_post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(future_post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(future_post_election.locked)
         self.assertEqual(len(future_post_election.personpost_set.all()), 1)
         self.assertEqual(
             future_post_election.expected_sopn_date, datetime.date(2024, 4, 10)
         )
-
-        pre_sopn_text = """This candidate will not be confirmed until the council publishes the official candidate list on 10 April 2024."""
-        self.assertContains(response, pre_sopn_text)
+        pre_sopn_text_1 = (
+            """We are currently aware of one candidate for this position."""
+        )
+        pre_sopn_text_2 = """The official candidate list will be published by 10 April 2024, when this page will be updated."""
+        self.assertContains(response, pre_sopn_text_1)
+        self.assertContains(response, pre_sopn_text_2)
         self.assertContains(
             response,
             """Once nomination papers are published, we will manually verify each candidate.""",
         )
 
     def test_zero_candidates(self):
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
@@ -228,40 +213,28 @@ class ElectionPostViewTests(TestCase):
                 person=person,
             )
 
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
         self.assertContains(response, f"The 5 candidates in {self.post.label}")
-        self.assertContains(
-            response, f"See all 5 candidates in the {self.post.label}"
-        )
+        self.assertContains(response, f"See all 5 candidates in the {self.post.label}")
 
     def test_cancellation_reason_candidate_death(self):
         self.post_election.cancelled = True
         self.post_election.cancellation_reason = "CANDIDATE_DEATH"
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
-        self.assertTemplateUsed(
-            response, "elections/includes/_cancelled_election.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_cancelled_election.html")
         self.assertNotContains(response, "No candidates known yet.")
         self.assertContains(
             response,
@@ -272,20 +245,14 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = True
         self.post_election.cancellation_reason = "NO_CANDIDATES"
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
-        self.assertTemplateUsed(
-            response, "elections/includes/_cancelled_election.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_cancelled_election.html")
         self.assertNotContains(response, "No candidates known yet.")
         self.assertContains(
             response,
@@ -296,20 +263,14 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = True
         self.post_election.cancellation_reason = "EQUAL_CANDIDATES"
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
-        self.assertTemplateUsed(
-            response, "elections/includes/_cancelled_election.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_cancelled_election.html")
         self.assertNotContains(response, "No candidates known yet.")
         self.assertContains(
             response,
@@ -320,20 +281,14 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = True
         self.post_election.cancellation_reason = "UNDER_CONTESTED"
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
-        self.assertTemplateUsed(
-            response, "elections/includes/_cancelled_election.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_cancelled_election.html")
         self.assertNotContains(response, "No candidates known yet.")
         self.assertContains(
             response,
@@ -354,20 +309,14 @@ class ElectionPostViewTests(TestCase):
             )
         self.post_election.cancelled = True
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/post_view.html")
-        self.assertTemplateUsed(
-            response, "elections/includes/_post_meta_title.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_post_meta_title.html")
         self.assertTemplateUsed(
             response, "elections/includes/_post_meta_description.html"
         )
-        self.assertTemplateUsed(
-            response, "elections/includes/_cancelled_election.html"
-        )
+        self.assertTemplateUsed(response, "elections/includes/_cancelled_election.html")
         self.assertNotContains(response, "No candidates known yet.")
         self.assertContains(
             response,
@@ -475,9 +424,7 @@ class ElectionPostViewTests(TestCase):
             deselected=True,
             deselected_source="www.google.com",
         )
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertContains(
             response,
             "This candidate has been deselected by their party",
@@ -647,9 +594,7 @@ class TestPostViewTemplateName:
 
 class TestPostElectionView(TestCase):
     def setUp(self):
-        self.post_election = PostElectionFactory(
-            election__election_date="2017-03-23"
-        )
+        self.post_election = PostElectionFactory(election__election_date="2017-03-23")
 
     def test_results_table(self):
         """check that the table containing the electorate,
@@ -659,9 +604,7 @@ class TestPostElectionView(TestCase):
         self.post_election.electorate = 100
         self.post_election.spoilt_ballots = 5
         self.post_election.save()
-        response = self.client.get(
-            self.post_election.get_absolute_url(), follow=True
-        )
+        response = self.client.get(self.post_election.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
 
         self.assertTrue(self.post_election.has_results)
@@ -688,9 +631,7 @@ class TestPostElectionsToPeopleMixin(TestCase):
                 person__name=person["name"],
                 person__sort_name=person["sort_name"],
             )
-        candidates = list(
-            PostelectionsToPeopleMixin().people_for_ballot(post_election)
-        )
+        candidates = list(PostelectionsToPeopleMixin().people_for_ballot(post_election))
         self.assertEqual(candidates[0].person.name, "Jane Adams")
         self.assertEqual(candidates[1].person.name, "John Middle")
         self.assertEqual(candidates[2].person.name, "Jane Smith")
@@ -750,9 +691,7 @@ class TestPostelectionsToPeopleMixin(TestCase):
         all_queries_without_pledge = self.ALL_QUERIES.copy()
         all_queries_without_pledge.remove(self.PLEDGE_QUERY)
         with self.assertNumQueries(sum(all_queries_without_pledge)):
-            queryset = self.mixin.people_for_ballot(
-                self.post_election, compact=True
-            )
+            queryset = self.mixin.people_for_ballot(self.post_election, compact=True)
             # resolve queryset to execute the queries
             candidates = list(queryset)
             self.assertEqual(len(candidates), 10)

--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -12,8 +12,8 @@
         {% endcomment %}
         {% if object.future_candidacies.all.count > 1 %}
             <h5>{{ object.name }}
-                {% blocktrans trimmed with party_name=object.future_candidacies.0.party_name a_or_an=object.future_candidacies.0.party.is_independent|yesno:_("an,a") %}
-                    is {{ a_or_an }} {{ party_name }} candidate in the following elections:
+                {% blocktrans trimmed with party_name=object.future_candidacies.0.party_name a_or_an=object.future_candidacies.0.party.is_independent|yesno:_("an,a") party_link=object.future_candidacies.0.party.get_absolute_url %}
+                    is {{ a_or_an }} <a href="{{ party_link }}">{{ party_name }}</a> candidate in the following elections:
                 {% endblocktrans %}
             </h5>
 

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -160,7 +160,7 @@ class PersonViewTests(TestCase):
         )
         self.assertEqual(self.person.future_candidacies.count(), 2)
         response = self.client.get(self.person_url, follow=True)
-        expected = "is a Liberal Democrat candidate in the following elections:"
+        expected = """is a <a href="/parties/foo/liberal-democrat">Liberal Democrat</a> candidate in the following elections:"""
         self.assertContains(response, expected)
 
     def test_multiple_independent_candidacies_intro(self):
@@ -203,7 +203,7 @@ class PersonViewTests(TestCase):
         )
         self.assertEqual(self.person.future_candidacies.count(), 2)
         response = self.client.get(self.person_url, follow=True)
-        expected = "is an Independent candidate in the following elections:"
+        expected = """is an <a href="/parties/ynmp-party:2/independent">Independent</a> candidate in the following elections:"""
         self.assertContains(response, expected)
 
     def test_one_candidacy_intro(self):


### PR DESCRIPTION
This change updates pre-SoPN day text and adds a party link to the person intro where more than once candidacy exists. 

Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1814 
<img width="973" alt="Screenshot 2024-04-04 at 11 16 57 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/a916ab6e-8950-4cad-91e7-cafe0c2ab604">
<img width="958" alt="Screenshot 2024-04-04 at 11 18 28 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/262fdb0e-64bc-4834-b6d2-851edaeba022">

Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1810
<img width="939" alt="Screenshot 2024-04-04 at 11 39 24 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/e799d472-ab6f-40ec-8dc0-3acc404987b3">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206969399601788