### PR TITLE
Return of the map in where to vote

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -2,7 +2,7 @@
 {% load humanize %}
 {% load i18n %}
 
-<li id="polling_place">
+<li>
     <details {% if polling_station.polling_station_known %}open{% endif %}>
         <summary>
             <h2 id='where'>
@@ -148,16 +148,18 @@
                 {% endif %}
             </p>
         {% endif %}
-
-
         {% if not polling_station.custom_finder and polling_station.polling_station_known and polling_station.station.geometry %}
-            <div id="area_map" class="ds-card-image"></div>
 
+            <div class="ds-card">
+                <div class="ds-card-image" id="area_map"></div>
+            </div>
             <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
             <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
 
             <script type="text/javascript">
                 // Maps
+
+
                 window.create_area_map = function(polling_station_point) {
                     var polling_station_location = polling_station_point;
                     window.polling_station_location = polling_station_location;

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% if object.personpost_set.exists %}
-    <div class="ds-table">
+    <div class="ds-table ds-stack">
         <h2 class="ds-h3">{{ object.name }}'s {% trans "elections" %}</h2>
         <table>
             <tr>

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -44,11 +44,11 @@
 
         {% include "people/includes/_person_manifesto_card.html" with party=object.featured_candidacy.party party_name=object.featured_candidacy.party.name %}
 
+        {% include "people/includes/_person_contact_card.html" %}
+
         {% if object.current_or_future_candidacies %}
             {% include "people/includes/_person_about_card.html" %}
         {% endif %}
-
-        {% include "people/includes/_person_contact_card.html" %}
 
         {% include "people/includes/_person_local_party_card.html" with party=person.local_party.name %}
 


### PR DESCRIPTION
This change:
- fixes the missing map in the new 'Where to vote' details section 
- reorders fav biscuit after contact details
- adds whitespace below previous elections table header
<img width="1052" alt="Screenshot 2024-04-08 at 3 07 52 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/a9da2ef6-5344-41b5-af44-a69ab508c355">

before
<img width="952" alt="Screenshot 2024-04-08 at 4 05 38 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/4c3298c7-db36-4ba8-a861-8c75ca807171">

after
<img width="984" alt="Screenshot 2024-04-08 at 4 06 51 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/91b39ff6-1dee-4067-a467-d81c7f7c3fe1">
