### PR TITLE
Open details elements when URL hash links to them

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_voter_id.html
+++ b/wcivf/apps/elections/templates/elections/includes/_voter_id.html
@@ -3,10 +3,10 @@
 {% load static %}
 {% load i18n %}
 
-<li id="requirements">
+<li>
     <details>
         <summary>
-            <h2>
+            <h2 id="requirements">
                 <span aria-hidden="true"></span>️
                 {% trans "You will need to take photo ID to vote at a polling station in this election" %}
             </h2>

--- a/wcivf/assets/js/scripts.js
+++ b/wcivf/assets/js/scripts.js
@@ -28,3 +28,25 @@ if (found_useful.value = undefined) {
 		comments.style.display = ''
 	})
 }
+
+
+
+// TODO: this could be move to the design system in theory
+function checkAndOpenDetails() {
+  const hash = window.location.hash; // Get the current hash.
+  if (hash) {
+    const targetElement = document.querySelector(hash); // Find the element with the ID.
+    if (targetElement) {
+      // Check if the target is within a <details> element.
+      const parentDetails = targetElement.closest('details');
+      if (parentDetails) {
+        parentDetails.open = true; // Open the <details> element.
+      }
+    }
+  }
+}
+// Run the function on page load.
+window.onload = checkAndOpenDetails;
+
+// Optional: if you want to open the details when the hash changes without reloading the page.
+window.onhashchange = checkAndOpenDetails;


### PR DESCRIPTION
The new TOC on WCIVF is great, but it's a bit of a odd experience clicking on a link to find a closed `details` element. 

This change opens them when they're clicked on :tada: 