### PR TITLE
Don't show upcoming elections on home page

### DIFF
--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -1,13 +1,11 @@
 import datetime
 import os
 
-
 from django import http
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.views.generic import FormView, TemplateView, View
-
 
 from .forms import PostcodeLookupForm
 

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -1,13 +1,13 @@
 import datetime
 import os
 
-from core.helpers import may_election_day_this_year
+
 from django import http
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.views.generic import FormView, TemplateView, View
-from elections.models import PostElection
+
 
 from .forms import PostcodeLookupForm
 
@@ -18,9 +18,7 @@ class TranslatedTemplateView(TemplateView):
         base_template_name, ext = self.template_name.rsplit(".", 1)
         current_language = translation.get_language()
         if current_language != "en":
-            templates.insert(
-                0, f"{base_template_name}_{current_language}.{ext}"
-            )
+            templates.insert(0, f"{base_template_name}_{current_language}.{ext}")
         return templates
 
 
@@ -28,10 +26,7 @@ class PostcodeFormView(FormView):
     form_class = PostcodeLookupForm
 
     def get(self, request, *args, **kwargs):
-        if (
-            request.GET.get("postcode")
-            and "invalid_postcode" not in self.request.GET
-        ):
+        if request.GET.get("postcode") and "invalid_postcode" not in self.request.GET:
             redirect_url = reverse(
                 "postcode_view", kwargs={"postcode": request.GET["postcode"]}
             )
@@ -57,9 +52,7 @@ class PostcodeFormView(FormView):
 
     def form_valid(self, form):
         postcode = form.cleaned_data["postcode"]
-        self.success_url = reverse(
-            "postcode_view", kwargs={"postcode": postcode}
-        )
+        self.success_url = reverse("postcode_view", kwargs={"postcode": postcode})
         return super().form_valid(form)
 
 
@@ -69,21 +62,24 @@ class HomePageView(PostcodeFormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        today = datetime.datetime.today()
-        delta = datetime.timedelta(weeks=4)
-        cut_off_date = today + delta
+        # Comment in this code to hide upcoming elections on the homepage
+        context["upcoming_elections"] = None
 
-        context["upcoming_elections"] = (
-            PostElection.objects.filter(
-                election__election_date__gte=today,
-                election__election_date__lte=cut_off_date,
-                # Temporarily removed following May elections #
-                election__any_non_by_elections=False,
-            )
-            .exclude(election__election_date=may_election_day_this_year())
-            .select_related("election", "post")
-            .order_by("election__election_date")
-        )
+        # Comment in this code to show upcoming elections on the homepage
+        # today = datetime.datetime.today()
+        # delta = datetime.timedelta(weeks=4)
+        # cut_off_date = today + delta
+        # context["upcoming_elections"] = (
+        #     PostElection.objects.filter(
+        #         election__election_date__gte=today,
+        #         election__election_date__lte=cut_off_date,
+        #         # Temporarily removed following May elections #
+        #         election__any_non_by_elections=False,
+        #     )
+        #     .exclude(election__election_date=may_election_day_this_year())
+        #     .select_related("election", "post")
+        #     .order_by("election__election_date")
+        # )
         polls_open = timezone.make_aware(
             datetime.datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
         )
@@ -99,9 +95,7 @@ class HomePageView(PostcodeFormView):
         context["show_gb_id_messaging"] = getattr(
             settings, "SHOW_GB_ID_MESSAGING", False
         )
-        context["show_results_chart"] = getattr(
-            settings, "SHOW_RESULTS_CHART", False
-        )
+        context["show_results_chart"] = getattr(settings, "SHOW_RESULTS_CHART", False)
 
         return context
 
@@ -121,9 +115,7 @@ class StatusCheckView(View):
     @property
     def server_is_dirty(self):
         if getattr(settings, "CHECK_HOST_DIRTY", False):
-            dirty_file_path = os.path.expanduser(
-                getattr(settings, "DIRTY_FILE_PATH")
-            )
+            dirty_file_path = os.path.expanduser(getattr(settings, "DIRTY_FILE_PATH"))
 
             if os.path.exists(dirty_file_path):
                 return True

--- a/wcivf/apps/people/templates/people/includes/_person_about_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_about_card.html
@@ -1,21 +1,18 @@
 {% load i18n %}
 {% if object.wikipedia_bio or object.favourite_biscuit %}
-    <div class="ds-card">
-        <div class="ds-card-body">
-            <h2 class="ds-candidate-name ds-h3">
-                {% blocktrans trimmed with name=object.name %}About {{ name }}{% endblocktrans %}
-            </h2>
-            {% if object.wikipedia_bio %}
-                <h4>{% trans "Wikipedia" %}</h4>
-                <p>{{ object.wikipedia_bio }}</p>
-                <a href="{{ object.wikipedia_url }}" class="link-button">{% trans "Read more on Wikipedia" %}</a>
-            {% endif %}
-            {% if object.favourite_biscuit %}
-                {% blocktrans trimmed with biscuit=object.favourite_biscuit%}
-                    <h4>Favourite Biscuit</h4>
-                    <p>{{ biscuit }}</p>
-                {% endblocktrans %}
-            {% endif %}
-        </div>
-    </div>
+    <h2 class="ds-candidate-name ds-h3">
+        {% blocktrans trimmed with name=object.name %}About {{ name }}{% endblocktrans %}
+    </h2>
+    {% if object.wikipedia_bio %}
+        <h4>{% trans "Wikipedia" %}</h4>
+        <p>{{ object.wikipedia_bio }}</p>
+        <a href="{{ object.wikipedia_url }}" class="link-button">{% trans "Read more on Wikipedia" %}</a>
+    {% endif %}
+    {% if object.favourite_biscuit %}
+        {% blocktrans trimmed with biscuit=object.favourite_biscuit%}
+            <h4>Favourite Biscuit</h4>
+            <p>{{ biscuit }}</p>
+        {% endblocktrans %}
+    {% endif %}
+
 {% endif %}


### PR DESCRIPTION
This change removes upcoming elections from the home page and removes the 'About candidate' section from `ds-card`. 

<img width="518" alt="Screenshot 2024-04-10 at 4 48 34 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/0e72ccb2-c7a2-4f57-a7a0-31ade444070f">

<img width="967" alt="Screenshot 2024-04-10 at 4 50 24 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/d180b413-ca91-4903-8a14-1cb67d42f436">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207039191197818