### PR TITLE
All details elements should have h2 tags

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_calendar.html
+++ b/wcivf/apps/elections/templates/elections/includes/_calendar.html
@@ -4,10 +4,10 @@
 <li>
     <details>
         <summary>
-            <h4 id="calendar">
+            <h2 id="calendar">
                 <span aria-hidden="true"></span>
                 {% blocktrans trimmed %}Add future elections in {{ postcode }} to your calendar{% endblocktrans %}
-            </h4>
+            </h2>
         </summary>
         <p>
             <p>{% trans "Manually subscribe by following these simple steps for your chosen calendar tool:" %}</p>

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -10,71 +10,78 @@ sv: Supplementary Vote
 STV: Single Transferable Vote
 PR-CL: Closed List 
 {% endcomment %}
-
-<details>
-    <summary>{% trans 'How to vote' %}</summary>
-    <p>
-        {% if voting_system.get_absolute_url %}
-            {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.get_name %}
-                This election uses <a href="{{ voting_system_url }}">{{ voting_system_name }}</a>.
-            {% endblocktrans %}
-        {% else %}
-            {% blocktrans trimmed with voting_system_name=voting_system.get_name %}
-                This election uses {{ voting_system_name }}.
-            {% endblocktrans %}
-        {% endif %}
-    </p>
-
-    {% if voting_system.slug == "FPTP" %}
-        <p>
-            {% if postelection.winner_count == 1 %}
-                {% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}
-            {% else %}
-                {% blocktrans trimmed %}Mark an X in the box for your preferred candidates.{% endblocktrans %}
-            {% endif %}
-        </p>
-        {% if postelection.people|length > 1 %}
+<ul class="ds-details">
+    <li>
+        <details>
+            <summary>
+                <h2>
+                    {% trans 'How to vote' %}
+                </h2>
+            </summary>
             <p>
-                {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber count counter=postelection.winner_count %}
-                    You can mark up to {{ winner_count}} candidate.
-                {% plural %}
-                    You can mark up to {{ winner_count }} candidates.
-                {% endblocktrans %}
+                {% if voting_system.get_absolute_url %}
+                    {% blocktrans trimmed with voting_system_url=voting_system.get_absolute_url voting_system_name=voting_system.get_name %}
+                        This election uses <a href="{{ voting_system_url }}">{{ voting_system_name }}</a>.
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed with voting_system_name=voting_system.get_name %}
+                        This election uses {{ voting_system_name }}.
+                    {% endblocktrans %}
+                {% endif %}
             </p>
-        {% endif %}
-    {% endif %}
 
-    {% if voting_system.slug == "STV" %}
-        <p>
-            {% blocktrans trimmed %}
-                Rank the candidates by your preference: 1, 2, 3…
-                You don't have to rank all the candidates, but you must at least mark your first choice.
-            {% endblocktrans %}
-        </p>
-    {% endif %}
+            {% if voting_system.slug == "FPTP" %}
+                <p>
+                    {% if postelection.winner_count == 1 %}
+                        {% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}
+                    {% else %}
+                        {% blocktrans trimmed %}Mark an X in the box for your preferred candidates.{% endblocktrans %}
+                    {% endif %}
+                </p>
+                {% if postelection.people|length > 1 %}
+                    <p>
+                        {% blocktrans trimmed with winner_count=postelection.winner_count|apnumber count counter=postelection.winner_count %}
+                            You can mark up to {{ winner_count}} candidate.
+                        {% plural %}
+                            You can mark up to {{ winner_count }} candidates.
+                        {% endblocktrans %}
+                    </p>
+                {% endif %}
+            {% endif %}
 
-    {% if voting_system.slug == "sv" %}
-        <p>
-            {% blocktrans trimmed %}
-                Mark an X in the first column for your first choice.
-                Mark an X in the second column for your second choice.
-                You do not have to mark a second choice.
-            {% endblocktrans %}
-        </p>
-    {% endif %}
+            {% if voting_system.slug == "STV" %}
+                <p>
+                    {% blocktrans trimmed %}
+                        Rank the candidates by your preference: 1, 2, 3…
+                        You don't have to rank all the candidates, but you must at least mark your first choice.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
 
-    {% if voting_system.slug == "AMS" or voting_system.slug == "PR-CL"%}
-        <p>
-            {% blocktrans trimmed %}
-                Mark an X in the box for one party or independent candidate.
-            {% endblocktrans %}
-        </p>
-    {% endif %}
+            {% if voting_system.slug == "sv" %}
+                <p>
+                    {% blocktrans trimmed %}
+                        Mark an X in the first column for your first choice.
+                        Mark an X in the second column for your second choice.
+                        You do not have to mark a second choice.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
 
-    {% if is_constituency %}
-        <p>{% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}</p>
-    {% endif %}
+            {% if voting_system.slug == "AMS" or voting_system.slug == "PR-CL"%}
+                <p>
+                    {% blocktrans trimmed %}
+                        Mark an X in the box for one party or independent candidate.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
 
-    <p>{% blocktrans trimmed %}Read the instructions at the top of your ballot paper carefully.{% endblocktrans %}</p>
-    <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
-</details>
+            {% if is_constituency %}
+                <p>{% blocktrans trimmed %}Mark an X in the box for your preferred candidate.{% endblocktrans %}</p>
+            {% endif %}
+
+            <p>{% blocktrans trimmed %}Read the instructions at the top of your ballot paper carefully.{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
+        </details>
+    </li>
+</ul>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -50,7 +50,12 @@
             {% if postelection.election.description %}
                 <div class="ds-details">
                     <details>
-                        <summary>{% trans "About this position" %}</summary>
+                        <summary>
+                            <h2>
+                                <span aria-hidden="true">{% trans "About this position" %}
+                                </span>
+                            </h2>
+                        </summary>
                         <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
                     </details>
                 </div>
@@ -136,9 +141,9 @@
         {% endif %}
 
         {% if postelection.election.election_booklet %}
-            <h4>
+            <b>
                 <a href="{% static postelection.election.election_booklet %}">{% trans "Read the official candidate booklet for this election." %}</a>
-            </h4>
+            </b>
         {% endif %}
 
         {% if postelection.election.in_past and postelection.has_results %}

--- a/wcivf/apps/parties/templates/parties/party_detail.html
+++ b/wcivf/apps/parties/templates/parties/party_detail.html
@@ -132,7 +132,7 @@
                 <li>
                     <details>
                         <summary>
-                            {% trans "Previous Descriptions" %}
+                            <h2>{% trans "Previous Descriptions" %}</h2>
                         </summary>
                         <p>{% trans "These descriptions are no longer registered with the Electoral Commission and cannot be used:" %}</p>
                         <ul>
@@ -163,7 +163,7 @@
                 <li>
                     <details>
                         <summary>
-                            {% trans "Previous Emblems" %}
+                            <h2>{% trans "Previous Emblems" %}</h2>
                         </summary>
                         <p>{% trans "These emblems are no longer registered with the Electoral Commission and cannot be used:" %}</p>
                         <ul class="ds-grid" style="--gridCellMin: 5em;">


### PR DESCRIPTION
All details elements should have h2 tags and be nested within `ds-details` except for the case of blockquotes

This also changes the size of the booklet to be more consistent with surrounding elements. 
<img width="966" alt="Screenshot 2024-04-11 at 3 13 28 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/d77f43ce-8b9e-49e0-bcda-aa581e7ca44f">
