### PR TITLE
Postal vote hand in - voter needs to fill out a form

### DIFF
--- a/fixtures/vcr_cassettes/test_mayor_elections.yaml
+++ b/fixtures/vcr_cassettes/test_mayor_elections.yaml
@@ -15,7 +15,7 @@ interactions:
       "dates": [{
           "date": "2018-05-03",
           "polling_station": {
-              "polling_station_known": false
+              "polling_station_known": true
           },
           "ballots": [{
                   "ballot_paper_id": "local.tower-hamlets.bow-east.2018-05-03"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -553,15 +553,43 @@ msgstr "a"
 msgid "You don't need to take your poll card with you."
 msgstr "Nid oes angen i chi ddod â'ch cerdyn pleidleisio gyda chi."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:77
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:79
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
-"election day up to 10pm"
+"election day up to 10pm. When handing in postal votes, you will need to "
+"complete a form, giving your name, address, how many postal votes you are "
+"handing in, and why you are handing in those postal votes."
+msgstr ""
+"Os oes gennych bleidlais bost, gallwch ei chyflwyno yn yr orsaf bleidleisio "
+"hon ar ddiwrnod yr etholiad hyd at 10pm. Wrth gyflwyno pleidleisiau post, "
+"bydd angen i chi wneud hynnyllenwi ffurflen, gan roi eich enw, cyfeiriad, "
+"faint o bleidleisiau post yr ydych yn eucyflwyno, a pham yr ydych yn "
+"cyflwyno'r pleidleisiau post hynny."
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:89
+#, fuzzy
+#| msgid ""
+#| "If you have a postal vote, you can hand it in at this polling station on "
+#| "election day up to 10pm"
+msgid ""
+"If you have a postal vote, you can hand it in at this polling station on "
+"election day up to 10pm."
 msgstr ""
 "Os oes gennych bleidlais bost, gallwch ei chyflwyno yn yr orsaf bleidleisio "
 "hondiwrnod etholiad hyd at 10pm"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:84
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:93
+msgid ""
+"Postal votes cannot be accepted at polling stations in Northern Ireland."
+msgstr ""
+"Ni ellir derbyn pleidleisiau post mewn gorsafoedd pleidleisio yng Ngogledd "
+"Iwerddon."
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:95
+msgid "Learn more about voting by post."
+msgstr "Darllenwch fwy am sut i bleidleisio"
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:99
 #, python-format
 msgid ""
 "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
@@ -570,7 +598,7 @@ msgstr ""
 "<p>Gallwch ddod o hyd i'ch gorsaf bleidleisio drwy <a "
 "href=\"%(custom_finder)s\"> ddilyn y ddolen hon</a>.</p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:92
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:107
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
@@ -579,7 +607,7 @@ msgstr ""
 "<strong>Bydd gorsafoedd pleidleisio ar agor o %(open_time)s tan "
 "%(close_time)s heddiw.</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:112
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -590,14 +618,14 @@ msgstr ""
 "<a href=\"https://wheredoivote.co.uk/postcode/%(postcode)s/\">Gwiriwch yr "
 "orsaf bleidleisio gywir ar gyfer eich cyfeiriad&raquo;</a></p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:117
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 "Dylech dderbyn \"cerdyn pleidleisio\" drwy'r post yn dweud ble y dylech chi "
 "bleidleisio."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:105
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:120
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call the "
@@ -607,7 +635,7 @@ msgstr ""
 "ffonio'r Swyddfa Cofrestru Etholiadol <a href=\"tel:"
 "%(council_phone)s\">%(council_phone)s</a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:125
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
@@ -616,7 +644,7 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "%(council_name)s ar <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:130
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council"
@@ -624,25 +652,25 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "eich cyngor lleol"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:124
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:139
 msgid "You will need photographic identification."
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:130
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:145
 msgid "Read more about how to vote in Northern Ireland"
 msgstr "Darllenwch fwy am sut i bleidleisio yng Ngogledd Iwerddon"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:134
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:149
 msgid "Read more about how to vote"
 msgstr "Darllenwch fwy am sut i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:143
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:158
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions"
 msgstr "Cael cyfarwyddiadau cerdded o"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:147
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:162
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions from"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-23 18:04+0100\n"
+"POT-Creation-Date: 2024-04-25 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2003,31 +2003,52 @@ msgstr ""
 msgid "It will be open from <strong>7am to 10pm</strong>"
 msgstr ""
 
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:64
+msgid "and"
+msgstr ""
+
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:72
 msgid "You don't need to take your poll card with you."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:77
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:79
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
-"election day up to 10pm"
+"election day up to 10pm. When handing in postal votes, you will need to "
+"complete a form, giving your name, address, how many postal votes you are "
+"handing in, and why you are handing in those postal votes."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:84
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:89
+msgid ""
+"If you have a postal vote, you can hand it in at this polling station on "
+"election day up to 10pm."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:93
+msgid ""
+"Postal votes cannot be accepted at polling stations in Northern Ireland."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:95
+msgid "Learn more about voting by post."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:99
 #, python-format
 msgid ""
 "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
 "following this link</a>. </p>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:92
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:107
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
 "today.</strong>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:112
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -2035,48 +2056,48 @@ msgid ""
 "polling station for your address &raquo;</a></p>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:117
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:105
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:120
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call the "
 "Electoral Office on <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:125
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
 "%(council_name)s on <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:130
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:124
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:139
 msgid "You will need photographic identification."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:130
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:145
 msgid "Read more about how to vote in Northern Ireland"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:134
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:149
 msgid "Read more about how to vote"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:143
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:158
 msgid "Get directions"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:147
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:162
 msgid "Get directions from"
 msgstr ""
 
@@ -2504,6 +2525,14 @@ msgstr ""
 
 #: wcivf/apps/elections/templates/elections/post_view.html:35
 msgid "due to take place on"
+msgstr ""
+
+#: wcivf/apps/feedback/models.py:7 wcivf/apps/feedback/models.py:8
+msgid "Yes"
+msgstr ""
+
+#: wcivf/apps/feedback/models.py:7 wcivf/apps/feedback/models.py:8
+msgid "No"
 msgstr ""
 
 #: wcivf/apps/feedback/templates/feedback/feedback_form.html:20

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -468,6 +468,20 @@ class PostElection(TimeStampedModel):
         ).postal_vote_application_deadline
 
     @property
+    def postal_vote_requires_form(self):
+        matcher = PostalVotingRequirementsMatcher(
+            election_id=self.election.slug, nation=self.post.territory
+        )
+
+        voting_requirements_legislation = (
+            matcher.get_postal_voting_requirements()
+        )
+
+        if voting_requirements_legislation == "EA-2022":
+            return True
+        return False
+
+    @property
     def is_mayoral(self):
         """
         Return a boolean for if this is a mayoral election, determined by

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -72,12 +72,27 @@
                     {% trans "You don't need to take your poll card with you." %}
                 </p>
             {% endif %}
-            {% if not postcode|ni_postcode %}
-                <p>
-                    {% blocktrans %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm{% endblocktrans %}
-                </p>
-            {% endif %}
 
+            {% if not postcode|ni_postcode %}
+                {% if postelections.0.postal_vote_requires_form %}
+                    <p>
+                        {% blocktrans trimmed %}
+                            If you have a postal vote, you can hand it in at this polling
+                            station on election day up to 10pm. When handing in postal votes,
+                            you will need to complete a form, giving your name, address,
+                            how many postal votes you are handing in,
+                            and why you are handing in those postal votes.
+                        {% endblocktrans %}
+                    </p>
+                {% else %}
+                    <p>
+                        {% blocktrans trimmed %}If you have a postal vote, you can hand it in at this polling station on election day up to 10pm.{% endblocktrans %}
+                    </p>
+                {% endif %}
+            {% else %}
+                <p>{% blocktrans trimmed %}Postal votes cannot be accepted at polling stations in Northern Ireland.{% endblocktrans%}</p>
+            {% endif %}
+            <p><a href="https://www.electoralcommission.org.uk/voting-and-elections/ways-vote/how-vote-post">{% trans "Learn more about voting by post." %}</a></p>
 
         {% else %}
             {% if polling_station.custom_finder %}

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -44,7 +44,7 @@
             <ul class="ds-details">
                 {# Add this at the top of the page if it's known, or at the bottom if it's not #}
                 {% if show_polling_card %}
-                    {% include "elections/includes/_polling_place.html" with elections_by_date=elections_by_date %}
+                    {% include "elections/includes/_polling_place.html" with postelections=postelections elections_by_date=elections_by_date %}
                 {% endif %}
 
                 {% if requires_voter_id %}

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -362,6 +362,19 @@ class TestPostElectionModel:
             == "six parties or independent candidates"
         )
 
+    @pytest.mark.django_db
+    def test_postal_vote_requires_form(self):
+        election = ElectionWithPostFactory(
+            election_date="2025-01-01",
+            current=True,
+            election_type="parl",
+            slug="parl.place.2025-01-01",
+        )
+        post_election = PostElectionFactory(election=election)
+        post_election.ballot_paper_id = "parl.place.2025-01-01"
+        assert post_election.get_postal_voting_requirements == "EA-2022"
+        assert post_election.postal_vote_requires_form is True
+
     def test_should_display_sopn_info_in_past(self, post_election):
         post_election.locked = True
         post_election.election.election_date = fake.past_date()

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -36,7 +36,9 @@ class PostcodeViewTests(TestCase):
 
     @vcr.use_cassette("fixtures/vcr_cassettes/test_uprn_view.yaml")
     def test_uprn_view(self):
-        response = self.client.get("/elections/WV15 6EG/10003417754/", follow=True)
+        response = self.client.get(
+            "/elections/WV15 6EG/10003417754/", follow=True
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "elections/postcode_view.html")
 
@@ -248,12 +250,16 @@ class TestPostcodeViewPolls:
                 {
                     "date": local_london.election.election_date,
                     "polling_station": {"polling_station_known": False},
-                    "ballots": [{"ballot_paper_id": local_london.ballot_paper_id}],
+                    "ballots": [
+                        {"ballot_paper_id": local_london.ballot_paper_id}
+                    ],
                 },
                 {
                     "date": parl_london.election.election_date,
                     "polling_station": {"polling_station_known": False},
-                    "ballots": [{"ballot_paper_id": parl_london.ballot_paper_id}],
+                    "ballots": [
+                        {"ballot_paper_id": parl_london.ballot_paper_id}
+                    ],
                 },
             ]
         )
@@ -338,7 +344,9 @@ class TestPostcodeViewPolls:
         asserts.assertTemplateUsed(
             response, "elections/includes/inline_elections_nav_list.html"
         )
-        asserts.assertTemplateUsed(response, "elections/includes/_single_ballot.html")
+        asserts.assertTemplateUsed(
+            response, "elections/includes/_single_ballot.html"
+        )
 
 
 class TestPostcodeViewMethods:
@@ -348,7 +356,9 @@ class TestPostcodeViewMethods:
         Returns an instance of PostcodeView
         """
         view = PostcodeView()
-        request = rf.get(reverse("postcode_view", kwargs={"postcode": "s11 8qe"}))
+        request = rf.get(
+            reverse("postcode_view", kwargs={"postcode": "s11 8qe"})
+        )
         view.setup(request=request)
 
         return view
@@ -476,7 +486,9 @@ class TestPostcodeViewMethods:
     def test_num_ballots_no_parish_election(self, view_obj, mocker):
         future_post_election = mocker.MagicMock(spec=PostElection, past_date=0)
         past_post_election = mocker.MagicMock(spec=PostElection, past_date=1)
-        view_obj.ballot_dict = {"ballots": [future_post_election, past_post_election]}
+        view_obj.ballot_dict = {
+            "ballots": [future_post_election, past_post_election]
+        }
         assert view_obj.num_ballots() == 1
 
     def test_num_ballots_with_contested_parish_election(self, view_obj, mocker):
@@ -487,11 +499,15 @@ class TestPostcodeViewMethods:
             in_past=False,
             is_contested=True,
         )
-        view_obj.ballot_dict = {"ballots": [future_post_election, past_post_election]}
+        view_obj.ballot_dict = {
+            "ballots": [future_post_election, past_post_election]
+        }
         view_obj.parish_council_election = parish_council_election
         assert view_obj.num_ballots() == 2
 
-    def test_num_ballots_with_uncontested_parish_election(self, view_obj, mocker):
+    def test_num_ballots_with_uncontested_parish_election(
+        self, view_obj, mocker
+    ):
         future_post_election = mocker.MagicMock(spec=PostElection, past_date=0)
         past_post_election = mocker.MagicMock(spec=PostElection, past_date=1)
         parish_council_election = mocker.MagicMock(
@@ -499,11 +515,15 @@ class TestPostcodeViewMethods:
             in_past=False,
             is_contested=False,
         )
-        view_obj.ballot_dict = {"ballots": [future_post_election, past_post_election]}
+        view_obj.ballot_dict = {
+            "ballots": [future_post_election, past_post_election]
+        }
         view_obj.parish_council_election = parish_council_election
         assert view_obj.num_ballots() == 1
 
-    def test_num_ballots_with_is_contested_none_parish_election(self, view_obj, mocker):
+    def test_num_ballots_with_is_contested_none_parish_election(
+        self, view_obj, mocker
+    ):
         future_post_election = mocker.MagicMock(spec=PostElection, past_date=0)
         past_post_election = mocker.MagicMock(spec=PostElection, past_date=1)
         parish_council_election = mocker.MagicMock(
@@ -511,7 +531,9 @@ class TestPostcodeViewMethods:
             in_past=False,
             is_contested=None,
         )
-        view_obj.ballot_dict = {"ballots": [future_post_election, past_post_election]}
+        view_obj.ballot_dict = {
+            "ballots": [future_post_election, past_post_election]
+        }
         view_obj.parish_council_election = parish_council_election
         assert view_obj.num_ballots() == 1
 
@@ -523,11 +545,15 @@ class TestPostcodeViewMethods:
             in_past=True,
             is_contested=True,
         )
-        view_obj.ballot_dict = {"ballots": [future_post_election, past_post_election]}
+        view_obj.ballot_dict = {
+            "ballots": [future_post_election, past_post_election]
+        }
         view_obj.parish_council_election = parish_council_election
         assert view_obj.num_ballots() == 1
 
-    def test_get_parish_council_election_when_already_assigned(self, view_obj, mocker):
+    def test_get_parish_council_election_when_already_assigned(
+        self, view_obj, mocker
+    ):
         """
         Test if view has a parish_council_election set it is returned
         """
@@ -593,7 +619,9 @@ class TestPostcodeViewMethods:
         post_election_no_id = mocker.MagicMock(
             spec=PostElection, requires_voter_id=None, cancelled=False
         )
-        view_obj.ballot_dict = {"ballots": [post_election_no_id, post_election_no_id]}
+        view_obj.ballot_dict = {
+            "ballots": [post_election_no_id, post_election_no_id]
+        }
         assert view_obj.get_voter_id_status() is None
 
 


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1206863706261602/f

> 
> For non-devolved elections: 
> "If you have a postal vote, you can hand it in at this polling station on election day up to 10pm."
![Screenshot 2024-04-25 at 2 34 48 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/b7797b1f-fb3d-4d49-a978-1ffb7faf4c5a)

> For parl., PCC, London and English locals: 
> "If you have a postal vote, you can hand it in at this polling station on election day up to 10pm. When handing in postal votes, you will need to complete a form, giving your name, address, how many postal votes you are handing in, and why you are handing in those postal votes."

![Screenshot 2024-04-25 at 2 33 56 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/e505ed71-0b48-420b-bd80-30f04f7edb6d)

> For Northern Ireland: 
> "Postal votes cannot be accepted at polling stations in Northern Ireland."
> Each of the above should end with a "Learn more about voting by post.", linking to https://www.electoralcommission.org.uk/voting-and-elections/ways-vote/how-vote-post

![Screenshot 2024-04-25 at 2 35 37 PM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/1a67bde6-29ee-4db1-a9a2-250c8ca9a5a0)

