### PR TITLE
Fix typo on gunicorn upgrade

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-gunicorn[gevent]==22.0.0.
+gunicorn[gevent]==22.0.0
 ec2_tag_conditional==0.1.2


### PR DESCRIPTION
Follow up from https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1834, removes a pesky `.` at the end of the version.