### PR TITLE
Election day misc improvements

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -445,9 +445,11 @@ msgstr "Etholwyd"
 #: wcivf/apps/elections/templates/elections/includes/_person_card.html:23
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:42
 msgid ""
-"This candidate has been deselected by their party, but will remain on the "
-"ballot paper."
+"This candidate has been deselected by their party, but their original party "
+"description will remain on the ballot paper."
 msgstr ""
+"Mae’r ymgeisydd hwn wedi’i ddad-ddewis gan ei blaid, ond ei blaid wreiddiol "
+"bydd y disgrifiad yn aros ar y papur pleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/_person_card.html:24
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:43

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -2589,14 +2589,6 @@ msgstr ""
 "Rydym yn casglu canlyniadau wrth iddynt gael eu cyhoeddi. Gwiriwch yn ôl yn "
 "nes ymlaen."
 
-#: wcivf/templates/base.html:103
-msgid "All Parties"
-msgstr "Pob plaid"
-
-#: wcivf/templates/base.html:104
-msgid "Standing as a candidate?"
-msgstr "Sefyll fel ymgeisydd?"
-
 #: wcivf/templates/base.html:105
 #, python-format
 msgid "About %(SITE_TITLE)s"
@@ -2636,31 +2628,6 @@ msgstr "Pob plaid"
 #: wcivf/templates/base.html:104
 msgid "Standing as a candidate?"
 msgstr "Sefyll fel ymgeisydd?"
-
-#: wcivf/templates/base.html:105
-#, python-format
-msgid "About %(SITE_TITLE)s"
-msgstr "Ynglŷn %(SITE_TITLE)s"
-
-#: wcivf/templates/base.html:106
-msgid "Privacy"
-msgstr "Preifatrwydd"
-
-#: wcivf/templates/base.html:107
-msgid "Source code"
-msgstr "Cod ffynhonnell"
-
-#: wcivf/templates/base.html:108
-msgid "About Democracy Club"
-msgstr "Ynglŷn â'r Clwb Democratiaeth"
-
-#: wcivf/templates/base.html:109
-msgid "Contact Us"
-msgstr "Cysylltwch â Ni"
-
-#: wcivf/templates/base.html:112
-msgid "GitHub"
-msgstr "GitHub"
 
 #: wcivf/templates/home.html:5 wcivf/templates/home.html:6
 msgid "Who Can I Vote For?"

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -999,13 +999,16 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_voter_id.html:15
 msgid ""
 "You do not need your poll card to vote. You must vote at your assigned "
-"polling station. Read more about <a href=\"https://www.gov.uk/voting-in-the-"
-"uk/polling-stations\">voting in Great Britain</a>."
+"polling station. <ul> <li>Read more about <a href=\"https://www.gov.uk/"
+"voting-in-the-uk/polling-stations\">voting in Great Britain</a>.</li> "
+"<li>Read more about <a href=\"https://www.gov.uk/how-to-vote/photo-id-youll-"
+"need\">photo ID</a>.</li> </ul>"
 msgstr ""
 "Nid oes angen eich cerdyn pleidleisio arnoch i bleidleisio. Rhaid i chi "
 "bleidleisio yn yr un a neilltuwyd i chiorsaf bleidleisio. Darllenwch fwy am "
 "<a href=\" https://www.gov.uk/voting-in-the-uk/polling-"
-"stations\">pleidleisio ym Mhrydain Fawr</a>."
+"stations\">pleidleisio ym Mhrydain Fawr</a>.<li>Darllenwch fwy am <a href=\" "
+"https://www.gov.uk/how-to-vote/photo-id-youll-angen \">ID llun</a>.</li></ul>"
 
 #: wcivf/apps/elections/templates/elections/includes/eu_results.html:7
 #: wcivf/apps/elections/templates/elections/includes/eu_results.html:15

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -29,19 +29,46 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
-#: wcivf/apps/elections/models.py:735
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:53
+msgid "Join our mailing list"
+msgstr "Ymunwch â'n rhestr bostio"
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
+msgid "democracy"
+msgstr "democratiaeth"
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
+msgid "club"
+msgstr "clwb"
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:69
+msgid "Copyright"
+msgstr "Hawlfraint"
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:70
+msgid "Democracy Club Community Interest Company"
+msgstr "Cwmni Buddiannau Cymunedol y Clwb Democratiaeth"
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:71
+msgid "Company No: "
+msgstr "Rhif y Cwmni: "
+
+#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:73
+msgid "Building digital infrastructure for a 21st century democracy."
+msgstr "Adeiladu seilwaith digidol ar gyfer democratiaeth yn yr 21ain ganrif."
+
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
-#: wcivf/apps/elections/models.py:737
+#: wcivf/apps/elections/models.py:743
 msgid "Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
 
-#: wcivf/apps/elections/models.py:739
+#: wcivf/apps/elections/models.py:745
 msgid "Supplementary Vote"
 msgstr "Pleidlais Atodol"
 
-#: wcivf/apps/elections/models.py:741
+#: wcivf/apps/elections/models.py:747
 msgid "Single Transferable Vote"
 msgstr "Pleidlais Sengl Drosglwyddadwy"
 
@@ -511,7 +538,7 @@ msgid "<address>%(polling_station_address)s</address>"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:57
-msgid "It will be open from <strong>7am to 10pm</strong>"
+msgid "It will be open from <strong>7am to 10pm</strong>."
 msgstr "Bydd ar agor o <strong>7am tan 10pm</strong>."
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:63
@@ -1116,8 +1143,8 @@ msgid "Tweets by"
 msgstr "Trydariadau gan"
 
 #: wcivf/apps/elections/templates/elections/party_list_view.html:71
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:66
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:91
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:67
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:92
 msgid "Candidates"
 msgstr "Ymgeiswyr"
 
@@ -2035,7 +2062,7 @@ msgid "Election"
 msgstr "Etholiad"
 
 #: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:11
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:90
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:91
 #: wcivf/apps/ppc_2024/templates/ppc_2024/ppcperson_list.html:45
 msgid "Party"
 msgstr "Plaid"
@@ -2350,24 +2377,19 @@ msgid "Timetable"
 msgstr "Amserlen"
 
 #: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:43
-#, fuzzy
-#| msgid "About Democracy Club"
-msgid "Democracy Club's"
-msgstr "Ynglŷn â'r Clwb Democratiaeth"
+msgid ""
+"Democracy Club's <a href=\"%(election_timetable_url)s\">general election "
+"timetable generator</a> provides an election timetable for any given date"
+msgstr ""
+"<a href=\"%(election_timetable_url)s\">Etholiad cyffredinol Clwb "
+"Democratiaeth Mae cynhyrchydd amserlen</a> yn darparu amserlen etholiad ar "
+"gyfer unrhyw ddyddiad penodol"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:44
-msgid "general election timetable generator"
-msgstr "cynhyrchydd amserlen etholiad cyffredinol"
-
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:44
-msgid "provides an election timetable for any given date"
-msgstr "yn darparu amserlen etholiad ar gyfer unrhyw ddyddiad penodol"
-
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:50
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:51
 msgid "The data"
 msgstr "Y data"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:54
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:55
 #, python-format
 msgid ""
 "The full list of prospective parliamentary candidates is available as a <a "
@@ -2399,27 +2421,27 @@ msgstr ""
 msgid "Number of candidates announced per UK region or nation"
 msgstr "Nifer yr ymgeiswyr a gyhoeddwyd fesul rhanbarth neu wlad yn y DU"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:65
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:66
 msgid "Region / nation"
 msgstr "Rhanbarth / cenedl"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:67
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:68
 msgid "Total seats in region"
 msgstr "Cyfanswm y seddi yn y rhanbarth"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:88
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:89
 msgid "Candidate selections by political party"
 msgstr "Dethol ymgeiswyr yn ôl plaid wleidyddol"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:100
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:101
 msgid "Total"
 msgstr "Cyfanswm"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:108
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:109
 msgid "Support our work"
 msgstr "Cefnogwch ein gwaith"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:109
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:110
 msgid ""
 "Democracy Club is a non-profit Community Interest Company. If you've found "
 "this resource useful, please consider a donation"
@@ -2428,7 +2450,7 @@ msgstr ""
 "wedi darganfod mae'r adnodd hwn yn ddefnyddiol, ystyriwch rodd os gwelwch yn "
 "dda"
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:111
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:112
 msgid "Donate now"
 msgstr "Cyfrannwch nawr"
 

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -29,34 +29,7 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich cod post"
 
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:53
-msgid "Join our mailing list"
-msgstr "Ymunwch â'n rhestr bostio"
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
-msgid "democracy"
-msgstr "democratiaeth"
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
-msgid "club"
-msgstr "clwb"
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:69
-msgid "Copyright"
-msgstr "Hawlfraint"
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:70
-msgid "Democracy Club Community Interest Company"
-msgstr "Cwmni Buddiannau Cymunedol y Clwb Democratiaeth"
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:71
-msgid "Company No: "
-msgstr "Rhif y Cwmni: "
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:73
-msgid "Building digital infrastructure for a 21st century democracy."
-msgstr "Adeiladu seilwaith digidol ar gyfer democratiaeth yn yr 21ain ganrif."
-
+#: wcivf/apps/elections/models.py:741
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
@@ -144,7 +117,7 @@ msgid "All Elections in the UK"
 msgstr "Pob Etholiad yn y DU"
 
 #: wcivf/apps/elections/templates/elections/elections_view.html:16
-#: wcivf/templates/base.html:106
+#: wcivf/templates/base.html:102
 msgid "All Elections"
 msgstr "Pob Etholiad"
 
@@ -366,7 +339,7 @@ msgstr "Rydych chi yma"
 #: wcivf/apps/parties/templates/parties/party_detail.html:17
 #: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:17
 #: wcivf/apps/people/templates/people/person_detail.html:31
-#: wcivf/templates/base.html:105
+#: wcivf/templates/base.html:101
 msgid "Home"
 msgstr "Cartref"
 
@@ -433,10 +406,15 @@ msgid "Read the instructions at the top of your ballot paper carefully."
 msgstr "Darllenwch y cyfarwyddiadau ar frig eich papur pleidleisio yn ofalus."
 
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:84
+#, fuzzy
+#| msgid ""
+#| "For more information, visit <a href=\"https://www.electoralcommission.org."
+#| "uk/i-am-a/voter/how-cast-your-vote\">The Electoral Commission's website</"
+#| "a> or ask an official at your polling station."
 msgid ""
 "For more information, visit <a href=\"https://www.electoralcommission.org.uk/"
-"i-am-a/voter/how-cast-your-vote\">The Electoral Commission's website</a> or "
-"ask an official at your polling station."
+"i-am-a/voter\">The Electoral Commission's website</a> or ask an official at "
+"your polling station."
 msgstr ""
 "Am fwy o wybodaeth, ewch i <href=\"https://www.electoralcommission.org.uk/i-"
 "am-a/voter/how-cast-your-vote\">Wefan y Comisiwn Etholiadol</a> neu "
@@ -1051,8 +1029,8 @@ msgid ""
 "Commission website</a>."
 msgstr ""
 "Am fwy o wybodaeth, ewch i <href=\"https://www.electoralcommission.org.uk/i-"
-"am-a/voter/how-cast-your-vote\">Wefan y Comisiwn Etholiadol</a> neu "
-"gofynnwch i swyddog yn eich gorsaf bleidleisio."
+"am-a/voter/\">Wefan y Comisiwn Etholiadol</a> neu gofynnwch i swyddog yn "
+"eich gorsaf bleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:11
 msgid "Select your address"
@@ -1719,7 +1697,7 @@ msgid "%(person_name)s's Facebook page"
 msgstr "Tudalen Facebook %(person_name)s"
 
 #: wcivf/apps/people/templates/people/includes/_person_contact_card.html:33
-#: wcivf/templates/base.html:115
+#: wcivf/templates/base.html:111
 msgid "Twitter"
 msgstr "Trydar"
 
@@ -1754,7 +1732,7 @@ msgid "%(person_name)s's home page"
 msgstr "Hafan %(person_name)s"
 
 #: wcivf/apps/people/templates/people/includes/_person_contact_card.html:77
-#: wcivf/templates/base.html:114
+#: wcivf/templates/base.html:110
 msgid "Blog"
 msgstr "Blog"
 
@@ -2055,7 +2033,7 @@ msgstr "ar TheyWorkForYou"
 msgid "their speeches, voting history and more"
 msgstr "eu hareithiau, eu hanes pleidleisio a mwy"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:6
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:7
 #, python-format
 msgid "%(person_name)s's elections"
 msgstr "Etholiadau %(person_name)s"
@@ -2082,9 +2060,24 @@ msgstr ""
 msgid "Position"
 msgstr "Sefyllfa"
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:42
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
+msgid "We do not collect voting data for Supplementary Vote elections."
+msgstr ""
+"Nid ydym yn casglu data pleidleisio ar gyfer etholiadau Pleidlais Atodol."
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:32
+msgid "We do not collect voting data for Single Transferable Vote elections."
+msgstr ""
+"Nid ydym yn casglu data pleidleisio ar gyfer etholiad Pleidlais Sengl "
+"Drosglwyddadwy."
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:48
 msgid "Position not available"
 msgstr "Nid yw'r cyfrif pleidleisiau ar gael"
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:54
+msgid "Please note our local elections database only goes back to 2016."
+msgstr "Sylwch fod ein cronfa ddata etholiadau lleol yn mynd yn ôl i 2016 yn unig."
 
 #: wcivf/apps/people/templates/people/includes/intros/_constituency.html:5
 #, python-format
@@ -2380,6 +2373,7 @@ msgid "Timetable"
 msgstr "Amserlen"
 
 #: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:43
+#, python-format
 msgid ""
 "Democracy Club's <a href=\"%(election_timetable_url)s\">general election "
 "timetable generator</a> provides an election timetable for any given date"
@@ -2592,6 +2586,46 @@ msgstr "Iaith:"
 
 #: wcivf/templates/base.html:87
 msgid ""
+"We're collecting results as they are published. Please check back later."
+msgstr ""
+"Rydym yn casglu canlyniadau wrth iddynt gael eu cyhoeddi. Gwiriwch yn ôl yn "
+"nes ymlaen."
+
+#: wcivf/templates/base.html:103
+msgid "All Parties"
+msgstr "Pob plaid"
+
+#: wcivf/templates/base.html:104
+msgid "Standing as a candidate?"
+msgstr "Sefyll fel ymgeisydd?"
+
+#: wcivf/templates/base.html:105
+#, python-format
+msgid "About %(SITE_TITLE)s"
+msgstr "Ynglŷn %(SITE_TITLE)s"
+
+#: wcivf/templates/base.html:106
+msgid "Privacy"
+msgstr "Preifatrwydd"
+
+#: wcivf/templates/base.html:107
+msgid "Source code"
+msgstr "Cod ffynhonnell"
+
+#: wcivf/templates/base.html:108
+msgid "About Democracy Club"
+msgstr "Ynglŷn â'r Clwb Democratiaeth"
+
+#: wcivf/templates/base.html:109
+msgid "Contact Us"
+msgstr "Cysylltwch â Ni"
+
+#: wcivf/templates/base.html:112
+msgid "GitHub"
+msgstr "GitHub"
+
+#: wcivf/templates/base.html:113
+msgid ""
 "Browse the list of people and parties standing in the next general election"
 msgstr ""
 "Porwch y rhestr o bobl a phleidiau sy'n sefyll yn yr etholiad cyffredinol "
@@ -2687,3 +2721,25 @@ msgstr ""
 #: wcivf/templates/home.html:48
 msgid "Upcoming Elections"
 msgstr "Etholiadau i ddod"
+
+#~ msgid "Join our mailing list"
+#~ msgstr "Ymunwch â'n rhestr bostio"
+
+#~ msgid "democracy"
+#~ msgstr "democratiaeth"
+
+#~ msgid "club"
+#~ msgstr "clwb"
+
+#~ msgid "Copyright"
+#~ msgstr "Hawlfraint"
+
+#~ msgid "Democracy Club Community Interest Company"
+#~ msgstr "Cwmni Buddiannau Cymunedol y Clwb Democratiaeth"
+
+#~ msgid "Company No: "
+#~ msgstr "Rhif y Cwmni: "
+
+#~ msgid "Building digital infrastructure for a 21st century democracy."
+#~ msgstr ""
+#~ "Adeiladu seilwaith digidol ar gyfer democratiaeth yn yr 21ain ganrif."

--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -1021,18 +1021,14 @@ msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:7
 #, fuzzy
-#| msgid ""
-#| "For more information, visit <a href=\"https://www.electoralcommission.org."
-#| "uk/i-am-a/voter/how-cast-your-vote\">The Electoral Commission's website</"
-#| "a> or ask an official at your polling station."
 msgid ""
 "Learn more about elections in the UK <a href=\"https://www."
-"electoralcommission.org.uk/i-am-a/voter/types-elections\">on the Electoral "
+"electoralcommission.org.uk/i-am-a/voter/\">on the Electoral "
 "Commission website</a>."
 msgstr ""
 "Am fwy o wybodaeth, ewch i <href=\"https://www.electoralcommission.org.uk/i-"
-"am-a/voter/\">Wefan y Comisiwn Etholiadol</a> neu gofynnwch i swyddog yn "
-"eich gorsaf bleidleisio."
+"am-a/voter/\">Wefan y Comisiwn Etholiadol</a> neu "
+"gofynnwch i swyddog yn eich gorsaf bleidleisio."
 
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:11
 msgid "Select your address"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -54,15 +54,15 @@ msgstr ""
 msgid "First-past-the-post"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:737
+#: wcivf/apps/elections/models.py:743
 msgid "Additional Member System"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:739
+#: wcivf/apps/elections/models.py:745
 msgid "Supplementary Vote"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:741
+#: wcivf/apps/elections/models.py:747
 msgid "Single Transferable Vote"
 msgstr ""
 
@@ -439,7 +439,7 @@ msgid "<address>%(polling_station_address)s</address>"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:57
-msgid "It will be open from <strong>7am to 10pm</strong>"
+msgid "It will be open from <strong>7am to 10pm</strong>."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:63
@@ -936,8 +936,8 @@ msgid "Tweets by"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/party_list_view.html:71
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:66
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:91
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:67
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:92
 msgid "Candidates"
 msgstr ""
 
@@ -1352,7 +1352,6 @@ msgid ""
 "\">their role in elections</a> on the parliament.uk website."
 msgstr ""
 
-
 #: wcivf/apps/people/models.py:78
 msgid "Elected unopposed"
 msgstr "Etholwyd yn ddiwrthwynebiad"
@@ -1725,7 +1724,7 @@ msgid "Election"
 msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:11
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:90
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:91
 #: wcivf/apps/ppc_2024/templates/ppc_2024/ppcperson_list.html:45
 msgid "Party"
 msgstr ""
@@ -1979,22 +1978,17 @@ msgid "Timetable"
 msgstr ""
 
 #: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:43
-msgid "Democracy Club's"
+#, python-format
+msgid ""
+"Democracy Club's <a href=\"%(election_timetable_url)s\">general election "
+"timetable generator</a> provides an election timetable for any given date"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:44
-msgid "general election timetable generator"
-msgstr ""
-
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:44
-msgid "provides an election timetable for any given date"
-msgstr ""
-
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:50
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:51
 msgid "The data"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:54
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:55
 #, python-format
 msgid ""
 "The full list of prospective parliamentary candidates is available as a <a "
@@ -2017,33 +2011,33 @@ msgstr ""
 msgid "Number of candidates announced per UK region or nation"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:65
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:66
 msgid "Region / nation"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:67
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:68
 msgid "Total seats in region"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:88
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:89
 msgid "Candidate selections by political party"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:100
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:101
 msgid "Total"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:108
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:109
 msgid "Support our work"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:109
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:110
 msgid ""
 "Democracy Club is a non-profit Community Interest Company. If you've found "
 "this resource useful, please consider a donation"
 msgstr ""
 
-#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:111
+#: wcivf/apps/ppc_2024/templates/ppc_2024/home.html:112
 msgid "Donate now"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -315,8 +315,8 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:84
 msgid ""
 "For more information, visit <a href=\"https://www.electoralcommission.org.uk/"
-"i-am-a/voter\">The Electoral Commission's website</a> or ask an official at "
-"your polling station."
+"i-am-a/voter/\">The Electoral Commission's website</a> or "
+"ask an official at your polling station."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1715,15 +1715,15 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:43
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:30
 msgid "We do not collect voting data for Supplementary Vote elections."
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:45
-msgid "We do not collect voting data for Single Transferable Vote election"
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:32
+msgid "We do not collect voting data for Single Transferable Vote elections."
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:47
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:48
 msgid "Position not available"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -344,8 +344,8 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_person_card.html:23
 #: wcivf/apps/people/templates/people/includes/_person_intro_card.html:42
 msgid ""
-"This candidate has been deselected by their party, but will remain on the "
-"ballot paper."
+"This candidate has been deselected by their party, but their original party "
+"description will remain on the ballot paper."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_person_card.html:24
@@ -1715,7 +1715,15 @@ msgstr ""
 msgid "Position"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:42
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:43
+msgid "We do not collect voting data for Supplementary Vote elections."
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:45
+msgid "We do not collect voting data for Single Transferable Vote election"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:47
 msgid "Position not available"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2182,11 +2182,6 @@ msgstr ""
 msgid "GitHub"
 msgstr ""
 
-#: wcivf/templates/base.html:113
-msgid ""
-"Browse the list of people and parties standing in the next general election"
-msgstr ""
-
 #: wcivf/templates/home.html:5 wcivf/templates/home.html:6
 msgid "Who Can I Vote For?"
 msgstr ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -810,8 +810,10 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_voter_id.html:15
 msgid ""
 "You do not need your poll card to vote. You must vote at your assigned "
-"polling station. Read more about <a href=\"https://www.gov.uk/voting-in-the-"
-"uk/polling-stations\">voting in Great Britain</a>."
+"polling station. <ul> <li>Read more about <a href=\"https://www.gov.uk/"
+"voting-in-the-uk/polling-stations\">voting in Great Britain</a>.</li> "
+"<li>Read more about <a href=\"https://www.gov.uk/how-to-vote/photo-id-youll-"
+"need\">photo ID</a>.</li> </ul>"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/eu_results.html:7

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -22,35 +22,7 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr ""
 
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:53
-msgid "Join our mailing list"
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
-msgid "democracy"
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:64
-msgid "club"
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:69
-msgid "Copyright"
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:70
-msgid "Democracy Club Community Interest Company"
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:71
-msgid "Company No: "
-msgstr ""
-
-#: env/lib/python3.10/site-packages/dc_utils/templates/dc_base.html:73
-msgid "Building digital infrastructure for a 21st century democracy."
-msgstr ""
-
-#: wcivf/apps/elections/models.py:735
+#: wcivf/apps/elections/models.py:741
 msgid "First-past-the-post"
 msgstr ""
 
@@ -131,7 +103,7 @@ msgid "All Elections in the UK"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/elections_view.html:16
-#: wcivf/templates/base.html:106
+#: wcivf/templates/base.html:102
 msgid "All Elections"
 msgstr ""
 
@@ -280,7 +252,7 @@ msgstr ""
 #: wcivf/apps/parties/templates/parties/party_detail.html:17
 #: wcivf/apps/parties/templates/parties/speaker_seeking_reelection.html:17
 #: wcivf/apps/people/templates/people/person_detail.html:31
-#: wcivf/templates/base.html:105
+#: wcivf/templates/base.html:101
 msgid "Home"
 msgstr ""
 
@@ -343,8 +315,8 @@ msgstr ""
 #: wcivf/apps/elections/templates/elections/includes/_how-to-vote.html:84
 msgid ""
 "For more information, visit <a href=\"https://www.electoralcommission.org.uk/"
-"i-am-a/voter/how-cast-your-vote\">The Electoral Commission's website</a> or "
-"ask an official at your polling station."
+"i-am-a/voter\">The Electoral Commission's website</a> or ask an official at "
+"your polling station."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html:15
@@ -1414,7 +1386,7 @@ msgid "%(person_name)s's Facebook page"
 msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/_person_contact_card.html:33
-#: wcivf/templates/base.html:115
+#: wcivf/templates/base.html:111
 msgid "Twitter"
 msgstr ""
 
@@ -1447,7 +1419,7 @@ msgid "%(person_name)s's home page"
 msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/_person_contact_card.html:77
-#: wcivf/templates/base.html:114
+#: wcivf/templates/base.html:110
 msgid "Blog"
 msgstr ""
 
@@ -1716,7 +1688,7 @@ msgstr ""
 msgid "their speeches, voting history and more"
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:6
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:7
 #, python-format
 msgid "%(person_name)s's elections"
 msgstr ""
@@ -1745,6 +1717,10 @@ msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:42
 msgid "Position not available"
+msgstr ""
+
+#: wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html:54
+msgid "Please note our local elections database only goes back to 2016."
 msgstr ""
 
 #: wcivf/apps/people/templates/people/includes/intros/_constituency.html:5
@@ -2196,6 +2172,11 @@ msgstr ""
 
 #: wcivf/templates/base.html:112
 msgid "GitHub"
+msgstr ""
+
+#: wcivf/templates/base.html:113
+msgid ""
+"Browse the list of people and parties standing in the next general election"
 msgstr ""
 
 #: wcivf/templates/home.html:5 wcivf/templates/home.html:6

--- a/wcivf/apps/elections/dummy_models.py
+++ b/wcivf/apps/elections/dummy_models.py
@@ -1,21 +1,32 @@
 from datetime import date
 from random import randint
 
-from elections.models import Election, Post, PostElection
+from elections.models import Election, Post, PostElection, VotingSystem
 from people.dummy_models import DummyCandidacy, DummyPerson
 
 
 class DummyPostElection(PostElection):
     party_ballot_count = 5
     display_as_party_list = False
+    locked = True
+    voting_system_id = "FPTP"
+    ballot_paper_id = "local.faketown.made-up-ward.2024-07-04"
+    cancelled = False
+    show_polling_card = True
+    contested = True
+    requires_voter_id = "EA-2022"
 
     election = Election(
         name="Llantalbot local election",
-        election_date=date(2022, 5, 5),
+        election_date=date(2024, 7, 4),
         any_non_by_elections=True,
-        slug="local.faketown.2022-05-05",
+        slug="local.faketown.2024-07-04",
+        voting_system=VotingSystem(slug="FPTP"),
+        current=True,
     )
+
     post = Post(label="Made-Up-Ward")
+    post.territory = "ENG"
     pk = randint(1, 100000)
 
     class Meta:
@@ -23,7 +34,7 @@ class DummyPostElection(PostElection):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.ballot_paper_id = "local.faketown.made-up-ward.2022-05-05"
+        self.ballot_paper_id = "local.faketown.made-up-ward.2024-07-04"
         self.election.get_absolute_url = self.election_get_absolute_url
 
     def election_get_absolute_url(self):
@@ -37,6 +48,8 @@ class DummyPostElection(PostElection):
                 ),
                 election=self.election,
                 party_name="Yellow Party",
+                deselected=True,
+                deselected_source="www.google.com",
             ),
             DummyCandidacy(
                 person=DummyPerson(

--- a/wcivf/apps/elections/templates/elections/ams.html
+++ b/wcivf/apps/elections/templates/elections/ams.html
@@ -30,7 +30,8 @@
                     want them elected, and voters get no choice over this order
                     (this is known as a 'closed list').
                 </p>
-
+            </div>
+            <div class="ds-padded">
                 <h3>Seat allocation</h3>
                 <p>The overall number of constituency seats that a party wins will have
                     an effect on how many regional representatives it is allocated.
@@ -49,6 +50,8 @@
                         after the above formula has been applied.
                     </p>
                 </p>
+            </div>
+            <div class="ds-padded">
                 <h3>Example election</h3>
                 <p>
                     In the 2016 West Scotland region, the result for the major parties was
@@ -171,7 +174,6 @@
                     15,091.
                 </p>
             </div>
-
         </div>
 
 {% endblock content %}

--- a/wcivf/apps/elections/templates/elections/ams.html
+++ b/wcivf/apps/elections/templates/elections/ams.html
@@ -2,10 +2,16 @@
 {% load markdown_filter %}
 {% load humanize %}
 {% load i18n %}
+{% block page_title %}The Additional Member System{% endblock page_title %}
+{% block og_title_content  %}The Additional Member System{% endblock og_title_content  %}
+{% block og_description_content %}
+    The Additional Member System{% endblock og_description_content %}
+{% block twitter_title_content %}The Additional Member System{% endblock twitter_title_content %}
+{% block twitter_description_content %}The Additional Member System{% endblock twitter_description_content %}
 
 {% block content %}
 
-    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="The Additional Member System" %}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/templates/elections/ams_cy.html
+++ b/wcivf/apps/elections/templates/elections/ams_cy.html
@@ -1,4 +1,16 @@
-{% extends "base.html" %}{% load markdown_filter %}{% load humanize %}{% load i18n %}{% block content %}    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+{% extends "base.html" %}
+{% load markdown_filter %}
+{% load humanize %}
+{% load i18n %}
+
+{% block page_title %}Y System Aelodau Ychwanegol{% endblock page_title %}
+{% block og_title_content  %}Y System Aelodau Ychwanegol{% endblock og_title_content  %}
+{% block og_description_content %}Y System Aelodau Ychwanegol{% endblock og_description_content %}
+{% block twitter_title_content %}Y System Aelodau Ychwanegol{% endblock twitter_title_content %}
+{% block twitter_description_content %}Y System Aelodau Ychwanegol{% endblock twitter_description_content %}
+
+{% block content %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="Y System Aelodau Ychwanegol" %}
 
     <div class="ds-page">
         <div class="ds-stack">
@@ -12,7 +24,8 @@
 
                     Er enghraifft, bydd pleidleisiwr yn Paisley yn yr Alban yn derbyn papur pleidleisio sy'n rhestru'r holl ymgeiswyr sydd am gynrychioli Paisley yn Senedd yr Alban. Byddan nhw hefyd yn cael papur pleidleisio sy'n                        rhestru'r pleidiau a/neu ymgeiswyr annibynnol sy'n sefyll                        am y saith sedd ar gyfer Gorllewin yr Alban. Mae'r ymgeiswyr ar y papur pleidleisio rhanbarthol                         yn cael eu rhestru yn y drefn y mae eu pleidiau gwleidyddol am iddyn nhw gael eu hethol, ac nid yw pleidleiswyr yn cael unrhyw ddewis dros y drefn hon                        (gelwir hyn yn 'restr gaeedig').
                 </p>
-
+            </div>
+            <div class="ds-padded">
                 <h3>Dyrannu seddau</h3>
                 <p>Bydd nifer cyffredinol y seddi etholaethol y mae plaid yn eu hennill yn cael                        effaith ar faint o gynrychiolwyr rhanbarthol a ddyrennir i’r blaid honno.
                     Bwriad hyn yw dod â nifer y seddi a enillir gan blaid yn nes at y                        ganran o’r bleidlais gyffredinol a dderbyniwyd ganddyn nhw yn y rhanbarth.
@@ -24,100 +37,104 @@
                         Dyrennir seddi ar ôl rowndiau cyfrif. Y pleidiau sydd â’r nifer uchaf o bleidleisiau                            ar ôl cymhwyso’r fformiwla uchod                             sy’n ennill y seddau rhanbarthol.
                     </p>
                 </p>
+            </div>
+            <div class="ds-padded">
                 <h3>Enghraifft o etholiad</h3>
                 <p>
                     Yn rhanbarth Gorllewin yr Alban 2016, roedd canlyniadau’r prif bleidiau oedd                        fel a ganlyn (gyda chyfanswm y cwota pleidleisio ar gyfer rowndiau dilynol mewn cromfachau):
                 </p>
-                <div class="ds-table ds-padded">
-                    <table>
-                        <caption>
-                            <h2>
-                                Rhanbarth Gorllewin yr Alban, etholiadau Senedd yr Alban 2016
-                            </h2>
-                        </caption>
-                        <tbody>
-                            <tr>
-                                <th>Plaid</th>
-                                <th>Seddi etholaethol a enillwyd (cyfanswm o 10)</th>
-                                <th>Pleidleisiau a enillwyd</th>
-                                <th>Cwota rownd gyntaf</th>
-                                <th>Cwota'r ail rownd</th>
-                                <th>Cwota'r drydedd rownd</th>
-                                <th>Cwota'r bedwaredd rownd</th>
-                                <th>Cwota'r bumed rownd</th>
-                                <th>Cwota'r chweched rownd</th>
-                                <th>Cwota'r seithfed rownd</th>
-                                <th>Seddi Rhanbarthol a Enillwyd</th>
-                            </tr>
-                            <tr>
-                                <td>SNP</td>
-                                <td>8</td>
-                                <td>135,827</td>
-                                <td>15,091</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>0</td>
-                            </tr>
-                            <tr>
-                                <td>Llafur</td>
-                                <td>1</td>
-                                <td>72,544</td>
-                                <td>36,272 (etholwyd)</td>
-                                <td>24,181</td>
-                                <td>18,136</td>
-                                <td>Dim newid (etholwyd)</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid (etholwyd)</td>
-                                <td>Dim newi</td>
-                                <td>3</td>
-                            </tr>
-                            <tr>
-                                <td>Ceidwadwyr</td>
-                                <td>1</td>
-                                <td>71,528</td>
-                                <td>35,764</td>
-                                <td>Dim newid (etholwyd)</td>
-                                <td>23,842 (etholwyd)</td>
-                                <td>17,882</td>
-                                <td>Dim newid (etholwyd)</td>
-                                <td>3,576</td>
-                                <td>Dim newid</td>
-                                <td>3</td>
-                            </tr>
-                            <tr>
-                                <td>Y Blaid Werdd</td>
-                                <td>0</td>
-                                <td>17,218</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid (etholwyd)</td>
-                                <td>1</td>
-                            </tr>
-                            <tr>
-                                <td>Dem. Rhydd.</td>
-                                <td>0</td>
-                                <td>12,097</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>Dim newid</td>
-                                <td>0</td>
-                            </tr>
+            </div>
+            <div class="ds-table ds-padded">
+                <table>
+                    <caption>
+                        <h2>
+                            Rhanbarth Gorllewin yr Alban, etholiadau Senedd yr Alban 2016
+                        </h2>
+                    </caption>
+                    <tbody>
+                        <tr>
+                            <th>Plaid</th>
+                            <th>Seddi etholaethol a enillwyd (cyfanswm o 10)</th>
+                            <th>Pleidleisiau a enillwyd</th>
+                            <th>Cwota rownd gyntaf</th>
+                            <th>Cwota'r ail rownd</th>
+                            <th>Cwota'r drydedd rownd</th>
+                            <th>Cwota'r bedwaredd rownd</th>
+                            <th>Cwota'r bumed rownd</th>
+                            <th>Cwota'r chweched rownd</th>
+                            <th>Cwota'r seithfed rownd</th>
+                            <th>Seddi Rhanbarthol a Enillwyd</th>
+                        </tr>
+                        <tr>
+                            <td>SNP</td>
+                            <td>8</td>
+                            <td>135,827</td>
+                            <td>15,091</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>0</td>
+                        </tr>
+                        <tr>
+                            <td>Llafur</td>
+                            <td>1</td>
+                            <td>72,544</td>
+                            <td>36,272 (etholwyd)</td>
+                            <td>24,181</td>
+                            <td>18,136</td>
+                            <td>Dim newid (etholwyd)</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid (etholwyd)</td>
+                            <td>Dim newi</td>
+                            <td>3</td>
+                        </tr>
+                        <tr>
+                            <td>Ceidwadwyr</td>
+                            <td>1</td>
+                            <td>71,528</td>
+                            <td>35,764</td>
+                            <td>Dim newid (etholwyd)</td>
+                            <td>23,842 (etholwyd)</td>
+                            <td>17,882</td>
+                            <td>Dim newid (etholwyd)</td>
+                            <td>3,576</td>
+                            <td>Dim newid</td>
+                            <td>3</td>
+                        </tr>
+                        <tr>
+                            <td>Y Blaid Werdd</td>
+                            <td>0</td>
+                            <td>17,218</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid (etholwyd)</td>
+                            <td>1</td>
+                        </tr>
+                        <tr>
+                            <td>Dem. Rhydd.</td>
+                            <td>0</td>
+                            <td>12,097</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>Dim newid</td>
+                            <td>0</td>
+                        </tr>
 
-                        </tbody>
-                    </table>
-                </div>
+                    </tbody>
+                </table>
+            </div>
+            <div class="ds-padded">
                 <p>
                     Er mai'r SNP enillodd y nifer fwyaf o bleidleisiau,                        gan eu bod wedi ennill wyth allan o'r deg                        sedd etholaethol, roedd eu cwota o 15,092, yn is na               bron pob un o'r pleidiau eraill.
                     O ganlyniad, ni chawson nhw                        unrhyw seddi rhanbarthol.

--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -5,9 +5,9 @@
 {% block page_title %}{{ object.name }}{% endblock page_title %}
 {% block og_title_content  %}{{ object.name }}{% endblock og_title_content  %}
 {% block og_description_content %}
-    {% blocktrans trimmed with was_or_will_be=object.in_past|yesno:"was, will be" election=object.name date=object.election_date %}The {{ election }} {{ was_or_will_be }} held on {{ date }}.{% endblocktrans %}{% endblock og_description_content %}
+    {% blocktrans trimmed with was_or_will_be=object.in_past|yesno:"was, will be" election=object.name date=object.election_date|date:"j M Y"  %}The {{ election }} {{ was_or_will_be }} held on {{ date }}.{% endblocktrans %}{% endblock og_description_content %}
 {% block twitter_title_content %}{{ object.name }}{% endblock twitter_title_content %}>
-{% block twitter_description_content %}{% blocktrans trimmed with was_or_will_be=object.in_past|yesno:"was, will be" election=object.name date=object.election_date %}The {{ election }} {{ was_or_will_be }} held on {{ date }}.{% endblocktrans %}{% endblock twitter_description_content %}/>
+{% block twitter_description_content %}{% blocktrans trimmed with was_or_will_be=object.in_past|yesno:"was, will be" election=object.name date=object.election_date|date:"j M Y" %}The {{ election }} {{ was_or_will_be }} held on {{ date }}.{% endblocktrans %}{% endblock twitter_description_content %}/>
 
 {% block content %}
 

--- a/wcivf/apps/elections/templates/elections/fptp.html
+++ b/wcivf/apps/elections/templates/elections/fptp.html
@@ -3,9 +3,15 @@
 {% load humanize %}
 {% load i18n %}
 
+{% block page_title %}First-past-the-post (FPTP){% endblock page_title %}
+{% block og_title_content  %}YFirst-past-the-post (FPTP){% endblock og_title_content  %}
+{% block og_description_content %}YFirst-past-the-post (FPTP){% endblock og_description_content %}
+{% block twitter_title_content %}YFirst-past-the-post (FPTP){% endblock twitter_title_content %}
+{% block twitter_description_content %}YFirst-past-the-post (FPTP){% endblock twitter_description_content %}
+
 {% block content %}
 
-    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="First-past-the-post (FPTP)"%}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/templates/elections/fptp_cy.html
+++ b/wcivf/apps/elections/templates/elections/fptp_cy.html
@@ -1,4 +1,16 @@
-{% extends "base.html" %}{% load markdown_filter %}{% load humanize %}{% load i18n %}{% block content %}    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+{% extends "base.html" %}
+{% load markdown_filter %}
+{% load humanize %}
+{% load i18n %}
+
+{% block page_title %}Cyntaf i'r felin (FPTP){% endblock page_title %}
+{% block og_title_content  %}Cyntaf i'r felin (FPTP){% endblock og_title_content  %}
+{% block og_description_content %}Cyntaf i'r felin (FPTP){% endblock og_description_content %}
+{% block twitter_title_content %}Cyntaf i'r felin (FPTP){% endblock twitter_title_content %}
+{% block twitter_description_content %}Cyntaf i'r felin (FPTP){% endblock twitter_description_content %}
+
+{% block content %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="Cyntaf i'r felin (FPTP)"%}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/templates/elections/includes/_election_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/_election_list.html
@@ -1,8 +1,10 @@
 {% load i18n %}
+
 {% regroup elections by election_date as elections_by_type %}
 {% for election_group in elections_by_type %}
     <h3 class="grouper-date">
-        {{ election_group.grouper }}
+        {{ election_group.grouper|date:"j F Y" }}
+    </h3>
     </h3>
     <div id="election-urls" >
         {% for election in election_group.list %}

--- a/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
+++ b/wcivf/apps/elections/templates/elections/includes/_how-to-vote.html
@@ -81,7 +81,7 @@ PR-CL: Closed List
             {% endif %}
 
             <p>{% blocktrans trimmed %}Read the instructions at the top of your ballot paper carefully.{% endblocktrans %}</p>
-            <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter/how-cast-your-vote">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}For more information, visit <a href="https://www.electoralcommission.org.uk/i-am-a/voter">The Electoral Commission's website</a> or ask an official at your polling station.{% endblocktrans %}</p>
         </details>
     </li>
 </ul>

--- a/wcivf/apps/elections/templates/elections/includes/_person_card.html
+++ b/wcivf/apps/elections/templates/elections/includes/_person_card.html
@@ -20,7 +20,7 @@
         {% endif %}
         {% if person_post.deselected %}
             <p>
-                {% trans "This candidate has been deselected by their party, but will remain on the ballot paper." %}
+                {% trans "This candidate has been deselected by their party, but their original party description will remain on the ballot paper." %}
                 <a href="{{ person_post.deselected_source }}" target="_blank">{% trans "Learn more" %}.</a>
             </p>
         {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_polling_place.html
+++ b/wcivf/apps/elections/templates/elections/includes/_polling_place.html
@@ -54,7 +54,7 @@
                 <address>{{ polling_station_address }}</address>
             {% endblocktrans %}
             <p>
-                {% blocktrans trimmed %}It will be open from <strong>7am to 10pm</strong>{% endblocktrans %}
+                {% blocktrans trimmed %}It will be open from <strong>7am to 10pm</strong>.{% endblocktrans %}
 
                 {% for election in elections_by_date %}
                     {{ election.grouper|naturalday:"\o\n l j F Y" }}

--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -4,7 +4,7 @@
     {% blocktrans with election_name=object.election.name %}{{ election_name }}: This election has been cancelled. {% endblocktrans %}
 {% elif postelection.people|length %}
     {% autoescape off %}
-        {% blocktrans trimmed with election_name=object.election.name num_candidates=postelection.people|length election_date=object.election.election_date %}
+        {% blocktrans trimmed with election_name=object.election.name num_candidates=postelection.people|length election_date=object.election.election_date|date:"j M Y" %}
             See all {{ num_candidates }} candidates in the {{ election_name }} on {{ election_date }}:{% endblocktrans %}
         {% for pp in postelection.people %}
             {{ pp.person.name|safe }} ({{ pp.party_name }})

--- a/wcivf/apps/elections/templates/elections/includes/_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_registration_details.html
@@ -22,7 +22,7 @@
         </p>
         {% if postelection %}
             <p>
-                {% blocktrans trimmed with registration_deadline=postelection.registration_deadline election_date=postelection.election.election_date%}
+                {% blocktrans trimmed with registration_deadline=postelection.registration_deadline election_date=postelection.election.election_date|date:"j M Y" %}
                     Register before midnight on {{ registration_deadline }} to vote on {{ election_date }}.
                 {% endblocktrans %}
             </p>

--- a/wcivf/apps/elections/templates/elections/includes/_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_registration_details.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 
 <li>
-    <details>
+    <details open>
         <summary>
             <h2 id='register'>
                 <span aria-hidden="true"></span>

--- a/wcivf/apps/elections/templates/elections/includes/_voter_id.html
+++ b/wcivf/apps/elections/templates/elections/includes/_voter_id.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 <li>
-    <details>
+    <details open>
         <summary>
             <h2 id="requirements">
                 <span aria-hidden="true"></span>️

--- a/wcivf/apps/elections/templates/elections/includes/_voter_id.html
+++ b/wcivf/apps/elections/templates/elections/includes/_voter_id.html
@@ -13,7 +13,10 @@
         </summary>
         <p>
             {% blocktrans trimmed %}You do not need your poll card to vote. You must vote at your assigned polling station.
-                Read more about <a href="https://www.gov.uk/voting-in-the-uk/polling-stations">voting in Great Britain</a>.
+                <ul>
+                    <li>Read more about <a href="https://www.gov.uk/voting-in-the-uk/polling-stations">voting in Great Britain</a>.</li>
+                    <li>Read more about <a href="https://www.gov.uk/how-to-vote/photo-id-youll-need">photo ID</a>.</li>
+                </ul>
             {% endblocktrans %}
         </p>
     </details>

--- a/wcivf/apps/elections/templates/elections/stv.html
+++ b/wcivf/apps/elections/templates/elections/stv.html
@@ -3,6 +3,13 @@
 {% load humanize %}
 {% load i18n %}
 
+{% block page_title %}Single Transferable Vote (STV){% endblock page_title %}
+{% block og_title_content %}Single Transferable Vote (STV){% endblock og_title_content  %}
+{% block og_description_content %}Single Transferable Vote (STV){% endblock og_description_content %}
+{% block twitter_title_content %}Single Transferable Vote (STV){% endblock twitter_title_content %}
+{% block twitter_description_content %}Single Transferable Vote (STV){% endblock twitter_description_content %}
+
+
 {% block content %}
     {% include "elections/includes/_voting_system_breadcrumbs.html" %}
 

--- a/wcivf/apps/elections/templates/elections/stv_cy.html
+++ b/wcivf/apps/elections/templates/elections/stv_cy.html
@@ -3,8 +3,14 @@
 {% load humanize %}
 {% load i18n %}
 
+{% block page_title %}Pleidlais Sengl Drosglwyddadwy (PSD){% endblock page_title %}
+{% block og_title_content %}Pleidlais Sengl Drosglwyddadwy (PSD){% endblock og_title_content  %}
+{% block og_description_content %}Pleidlais Sengl Drosglwyddadwy (PSD){% endblock og_description_content %}
+{% block twitter_title_content %}Pleidlais Sengl Drosglwyddadwy (PSD){% endblock twitter_title_content %}
+{% block twitter_description_content %}Pleidlais Sengl Drosglwyddadwy (PSD){% endblock twitter_description_content %}
+
 {% block content %}
-    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="Pleidlais Sengl Drosglwyddadwy (PSD)"%}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/templates/elections/sv.html
+++ b/wcivf/apps/elections/templates/elections/sv.html
@@ -3,9 +3,15 @@
 {% load humanize %}
 {% load i18n %}
 
+{% block page_title %}Supplementary Vote{% endblock page_title %}
+{% block og_title_content  %}Supplementary Vote{% endblock og_title_content  %}
+{% block og_description_content %}Supplementary Vote{% endblock og_description_content %}
+{% block twitter_title_content %}Supplementary Vote{% endblock twitter_title_content %}
+{% block twitter_description_content %}Supplementary Vote{% endblock twitter_description_content %}
+
 {% block content %}
 
-    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="Supplementary Vote" %}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/templates/elections/sv_cy.html
+++ b/wcivf/apps/elections/templates/elections/sv_cy.html
@@ -1,4 +1,17 @@
-{% extends "base.html" %}{% load markdown_filter %}{% load humanize %}{% load i18n %}{% block content %}    {% include "elections/includes/_voting_system_breadcrumbs.html" %}
+{% extends "base.html" %}
+{% load markdown_filter %}
+{% load humanize %}
+{% load i18n %}
+
+{% block page_title %}Pleidlais Atodol{% endblock page_title %}
+{% block og_title_content  %}Pleidlais Atodol{% endblock og_title_content  %}
+{% block og_description_content %}Pleidlais Atodol{% endblock og_description_content %}
+{% block twitter_title_content %}Pleidlais Atodol{% endblock twitter_title_content %}
+{% block twitter_description_content %}Pleidlais Atodol{% endblock twitter_description_content %}
+
+
+{% block content %}
+    {% include "elections/includes/_voting_system_breadcrumbs.html" with voting_system="Pleidlais Atodol" %}
 
     <div class="ds-page">
         <div class="ds-stack">

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -319,6 +319,7 @@ class PostcodeiCalView(
 
 class DummyPostcodeView(PostcodeView):
     postcode = None
+    uprn = None
 
     def get(self, request, *args, **kwargs):
         kwargs["postcode"] = self.postcode
@@ -329,12 +330,40 @@ class DummyPostcodeView(PostcodeView):
         context = kwargs
         self.postcode = clean_postcode(kwargs["postcode"])
         context["postcode"] = self.postcode
+        self.uprn = self.kwargs.get("uprn")
+        context["uprn"] = self.uprn
+
         context["postelections"] = self.get_ballot_dict()
         context["show_polling_card"] = True
-        context["polling_station"] = {}
+        context["polling_station"] = self.get_polling_station()
+        context["requires_voter_id"] = "EA-2022"
         context["num_ballots"] = 1
-
         return context
 
     def get_ballot_dict(self):
         return [DummyPostElection()]
+
+    def get_polling_station(self):
+        return {
+            "polling_station_known": True,
+            "custom_finder": False,
+            "report_problem_url": "http://wheredoivote.co.uk/report_problem/?source=testing&source_url=testing",
+            "station": {
+                "id": "w06000015.QK",
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-3.119229, 51.510885],
+                },
+                "properties": {
+                    "address": "1 Made Up Street\nMade Up Town\nMade Up County",
+                    "postcode": "MA1 1AA",
+                },
+            },
+            "geometry": {
+                "coordinates": [-0.127758, 51.507351],
+            },
+            "properties": {
+                "address": "1 Made Up Street\nMade Up Town\nMade Up County",
+            },
+        }

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -138,9 +138,10 @@ class PersonPost(models.Model):
                     ].votes_cast
                 ):
                     return f"Joint {ordinal(candidate.rank)} / {candidate_count} candidates"
-
+                if candidate_count > 1:
+                    return f"{ordinal(candidate.rank)} / {candidate_count} candidates"
                 return (
-                    f"{ordinal(candidate.rank)} / {candidate_count} candidates"
+                    f"{ordinal(candidate.rank)} / {candidate_count} candidate"
                 )
         return None
 

--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -37,7 +37,7 @@
         {% for candidacy in object.future_candidacies %}
             {% if candidacy.deselected %}
                 <p>
-                    {% trans "This candidate has been deselected by their party, but will remain on the ballot paper." %}
+                    {% trans "This candidate has been deselected by their party, but their original party description will remain on the ballot paper." %}
                     <a href="{{ candidacy.deselected_source }}" target="_blank">{% trans "Learn more" %}.</a>
                 </p>
             {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -26,7 +26,13 @@
                     </td>
                     <td>{{ person_post.party_name }}</td>
                     <td>
-                        {{ person_post.get_results_text }}
+                        {% if person_post.election.voting_system.slug == "sv" %}
+                            {% trans "We do not collect voting data for Supplementary Vote elections." %}
+                        {% elif person_post.election.voting_system.slug == "STV" %}
+                            {% trans "We do not collect voting data for Single Transferable Vote elections." %}
+                        {% else  %}
+                            {{ person_post.get_results_text }}
+                        {% endif %}
                     </td>
                     {% if object.previous_party_count %}
                         <td>

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -3,8 +3,8 @@
 
 {% if object.personpost_set.exists %}
     <div class="ds-table ds-stack">
-        <h2 class="ds-h3">{% blocktrans trimmed with person_name=object.name %}{{ person_name }}'s elections{% endblocktrans %}</h2>
         <table>
+            <caption><h2>{% blocktrans trimmed with person_name=object.name %}{{ person_name }}'s elections{% endblocktrans %}</h2></caption>
             <tr>
                 <th>{% trans "Date" %}</th>
                 <th>{% trans "Election" %}</th>
@@ -45,5 +45,6 @@
                 </tr>
             {% endfor %}
         </table>
+        <small>{% trans "Please note our local elections database only goes back to 2016." %}</small>
     </div>
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -21,7 +21,7 @@
                     <td>{{ person_post.election.election_date|date:"Y" }}</td>
                     <td>
                         <a href="{{ person_post.post_election.get_absolute_url }}">
-                            {{ person_post.post.label }}: {{ person_post.election }}
+                            {{ person_post.post.label }}: {{ person_post.election.nice_election_name }}
                         </a>
                     </td>
                     <td>{{ person_post.party_name }}</td>

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -681,7 +681,7 @@ class PersonViewTests(TestCase):
         response = self.client.get(self.person_url, follow=True)
         self.assertContains(
             response,
-            "This candidate has been deselected by their party, but will remain on the ballot paper.",
+            "This candidate has been deselected by their party, but their original party description will remain on the ballot paper.",
         )
         self.assertContains(response, "www.candidate-party-page.co.uk")
 
@@ -690,7 +690,7 @@ class PersonViewTests(TestCase):
         )
         self.assertContains(
             response,
-            "This candidate has been deselected by their party, but will remain on the ballot paper.",
+            "This candidate has been deselected by their party, but their original party description will remain on the ballot paper.",
         )
         self.assertContains(response, "www.candidate-party-page.co.uk")
 

--- a/wcivf/apps/ppc_2024/templates/ppc_2024/home.html
+++ b/wcivf/apps/ppc_2024/templates/ppc_2024/home.html
@@ -40,10 +40,11 @@
                 {% trans "Visit the website of the Institute for Government for a full list" %}</a>.</p>
 
         <h2 class="ds-h4">{% trans "Timetable" %}</h2>
-        <p>{% trans "Democracy Club's" %} <a href="https://election-timetable.democracyclub.org.uk/">
-            {% trans "general election timetable generator" %}</a> {% trans "provides an election timetable for any given date" %}.</p>
-
-
+        <p>{% blocktrans trimmed with election_timetable_url="https://election-timetable.democracyclub.org.uk/" %}
+            Democracy Club's <a href="{{election_timetable_url}}">general election timetable generator</a>
+            provides an election timetable for any given date
+        {% endblocktrans %}
+        </p>
     </details>
 
 


### PR DESCRIPTION
[dev.wcivf.club](https://dev.wcivf.club/)

These changes are visible using [edits to the DummyPostElection](https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1850/commits/3186db2f7c4e04aa83ac818164158d7c9be5db28) which we could keep or drop with this PR, once reviewed. I personally think it's useful to keep.

**Requires postcode search (`TE1 1ST`)**
- [x] Differentiates election titles in prev election table; Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1819
- [x] Clarify prev election list is 2016 onwards; Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1819
- [x] Clarify candidate deselection text; Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1837
- [x] Keep voter reg and id sections open by default 
- [x] We don't collect results for SV and STV; Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1561
- [x] Update EC link to learn more about elections; Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1454
Note: Footer translations will be fixed here https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1874


**No postcode search required**
- [x] Improves the tag formatting for ppcs page election timetable link https://dev.wcivf.club/ppcs/
- [x] Adds a photo id link to the voter id section with translations; Ref https://app.asana.com/0/1204880927741389/1207218844713566/f Test with a postcode search
- [ ]  Reformats dates as DD MM YYYY  https://dev.wcivf.club/elections/
- [x]  Tidy up voting system pages https://dev.wcivf.club/elections/voting_system/STV/ 

![Screenshot 2024-05-23 at 10 35 32 AM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/44fcd841-b374-4073-8e92-d1489c3356e9)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207218844713566