### PR TITLE
Hotfix/dont show voter info after election day

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -26,13 +26,13 @@
         {% endif %}
         {% for election_group in header_elections_by_date %}
 
-            {% if election_group.list.0.past_date %}
-                {% ifchanged election_group.list.0.past_date %}
+            {% if election_group.list.0.election.in_past %}
+                {% ifchanged election_group.list.0.election.past_date %}
                     <h3>{% trans "Recently past elections" %}</h3>
                 {% endifchanged %}
             {% endif %}
 
-            {% if election_group.list.0.past_date %}
+            {% if election_group.list.0.election.in_past %}
                 <h4>
                     {{ election_group.grouper|naturalday:"l j F Y"|title }}
                 </h4>
@@ -74,22 +74,23 @@
                     </li>
                 {% endif %}
             </ul>
+            {% if postelections_with_future_dates %}
+                {% if show_polling_card or requires_voter_id %}
+                    <p>{% trans "Get ready to vote" %}:</p>
+                    <ul>
+                        {% if show_polling_card %}
+                            <li><a href="#where">{% trans "Where to vote" %}</a></li>
+                        {% endif %}
 
-            {% if show_polling_card or requires_voter_id %}
-                <p>{% trans "Get ready to vote" %}:</p>
-                <ul>
-                    {% if show_polling_card %}
-                        <li><a href="#where">{% trans "Where to vote" %}</a></li>
-                    {% endif %}
+                        {% if requires_voter_id %}
+                            <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
+                        {% endif %}
 
-                    {% if requires_voter_id %}
-                        <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
-                    {% endif %}
-
-                    {% if is_before_registration_deadline %}
-                        <li><a href="#register">{% trans "Register to vote" %}</a></li>
-                    {% endif %}
-                </ul>
+                        {% if is_before_registration_deadline %}
+                            <li><a href="#register">{% trans "Register to vote" %}</a></li>
+                        {% endif %}
+                    </ul>
+                {% endif %}
             {% endif %}
 
         {% endfor %}

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load humanize %}
 {% load i18n %}
+{% load postcode_tags %}
 
 {% block page_title %}{% include "elections/includes/_postcode_meta_title.html" %}{% endblock page_title %}
 {% block page_description %}{% include "elections/includes/_postcode_meta_description.html" %}{% endblock page_description %}
@@ -40,26 +41,26 @@
                 {% include "parishes/includes/_card.html" with parish_council_election=parish_council_election %}
             {% endif %}
 
+            {% if postelections_with_future_dates %}
+                <ul class="ds-details">
+                    {# Add this at the top of the page if it's known, or at the bottom if it's not #}
+                    {% if show_polling_card %}
+                        {% include "elections/includes/_polling_place.html" with postelections=postelections elections_by_date=elections_by_date %}
+                    {% endif %}
 
-            <ul class="ds-details">
-                {# Add this at the top of the page if it's known, or at the bottom if it's not #}
-                {% if show_polling_card %}
-                    {% include "elections/includes/_polling_place.html" with postelections=postelections elections_by_date=elections_by_date %}
-                {% endif %}
+                    {% if requires_voter_id %}
+                        {% include "elections/includes/_voter_id.html" %}
+                    {% endif %}
 
-                {% if requires_voter_id %}
-                    {% include "elections/includes/_voter_id.html" %}
-                {% endif %}
+                    {% if is_before_registration_deadline %}
+                        {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %}
+                    {% endif %}
 
-                {% if is_before_registration_deadline %}
-                    {% include "elections/includes/_registration_details.html" with postelection=postelections.first council=polling_station.council %}
-                {% endif %}
-
-                {% if not messages %}
-                    {% include "elections/includes/_calendar.html" %}
-                {% endif %}
-            </ul>
-
+                    {% if not messages %}
+                        {% include "elections/includes/_calendar.html" %}
+                    {% endif %}
+                </ul>
+            {% endif %}
             {% if postelections %}
                 {% include "feedback/feedback_form.html" %}
             {% endif %}

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -76,6 +76,9 @@ class PostcodeView(
             return context
 
         context["postelections"] = ballot_dict.get("ballots")
+        context["postelections_with_future_dates"] = (
+            self.check_any_future_dates(context["postelections"])
+        )
         context["show_polling_card"] = self.show_polling_card(
             context["postelections"]
         )
@@ -84,20 +87,26 @@ class PostcodeView(
             postelection.people = self.people_for_ballot(postelection)
         context["polling_station"] = self.ballot_dict.get("polling_station")
 
-        context[
-            "advance_voting_station"
-        ] = self.get_advance_voting_station_info(context["polling_station"])
+        context["advance_voting_station"] = (
+            self.get_advance_voting_station_info(context["polling_station"])
+        )
 
         context["ballots_today"] = self.get_todays_ballots()
-        context[
-            "multiple_city_of_london_elections_today"
-        ] = self.multiple_city_of_london_elections_today()
+        context["multiple_city_of_london_elections_today"] = (
+            self.multiple_city_of_london_elections_today()
+        )
         context["referendums"] = list(self.get_referendums())
         context["parish_council_election"] = self.get_parish_council_election()
         context["num_ballots"] = self.num_ballots()
         context["requires_voter_id"] = self.get_voter_id_status()
 
         return context
+
+    def check_any_future_dates(self, postelections):
+        """
+        Check if there are any future dates in the list of postelections
+        """
+        return any(not postelection.past_date for postelection in postelections)
 
     def get_todays_ballots(self):
         """


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/WhoCanIVoteFor/issues/1858

This change adds to the context the ability to identify whether any postelections in a list are in the future, and in that case, shows the 'get ready to vote' anchors and details below. 
<img width="753" alt="Screenshot 2024-05-13 at 11 18 14 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/c53303a0-9e2f-4e5a-99e2-74d07bf4b01d">
<img width="930" alt="Screenshot 2024-05-13 at 11 18 20 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/40e81dec-0fe8-419b-9546-8e548064d905">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207297516776629