### PR TITLE
dc_django_utils==6.0.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ icalendar==5.0.7
 dealer==2.1.0
 
 git+https://github.com/DemocracyClub/design-system.git@0.5.0
-git+https://github.com/DemocracyClub/dc_django_utils.git@6.0.0
+git+https://github.com/DemocracyClub/dc_django_utils.git@6.0.1
 https://github.com/DemocracyClub/dc_logging/archive/refs/tags/1.0.1.tar.gz
 
 djangorestframework-jsonp==1.0.2


### PR DESCRIPTION
WIth version 6.0.1, the logo is sourced from an s3 url and footers are more stable with designated language files. 

![Screenshot 2024-05-22 at 10 48 25 AM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/7cf588ca-c4c0-4490-9c43-4d5690152f76)
![Screenshot 2024-05-22 at 10 47 58 AM](https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/022fb2de-eff4-489d-ad0c-1d3a8662edf4)
