### PR TITLE
Direct users to ppcs home instead of details page

### DIFF
--- a/wcivf/templates/base.html
+++ b/wcivf/templates/base.html
@@ -84,7 +84,7 @@
 {% block messages %}
     <aside class="ds-status" aria-label="Status">
         <ul class="ds-stack">
-            <li class="ds-status-message"><a href="{% url 'ppc_2024:details' %}" >{% trans "Browse the list of people and parties standing in the next general election" %}</a></li>
+            <li class="ds-status-message"><a href="{% url 'ppc_2024:home' %}" >{% trans "Browse the list of people and parties standing in the next general election" %}</a></li>
         </ul>
     </aside>
 {% endblock messages %}


### PR DESCRIPTION
At @pmk01 request...changes the CTA url in the banner


<img width="938" alt="Screenshot 2024-05-16 at 8 50 51 AM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/a5c2d1cb-7c3d-4e4e-a8b0-1660a464a1e4">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207297517017249