### PR TITLE
Hotfix/biography in markdown

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -2561,7 +2561,7 @@ msgstr ""
 
 #: wcivf/templates/home.html:23
 msgid ""
-"A parliamentary general election has been called for 4 July.Enter your "
+"A parliamentary general election has been called for 4 July. Enter your "
 "postcode to find your constituency and candidates."
 msgstr ""
 "Mae etholiad cyffredinol seneddol wedi ei alw ar gyfer 4 Gorffennaf. Rhowch "

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -2171,7 +2171,7 @@ msgstr ""
 
 #: wcivf/templates/home.html:23
 msgid ""
-"A parliamentary general election has been called for 4 July.Enter your "
+"A parliamentary general election has been called for 4 July. Enter your "
 "postcode to find your constituency and candidates."
 msgstr ""
 

--- a/wcivf/apps/people/templates/people/includes/_person_policy_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_policy_card.html
@@ -19,7 +19,7 @@
                 </blockquote>
             </div>
         {% else %}
-            <blockquote>{{ object.statement_to_voters|linebreaks }}</blockquote>
+            <blockquote>{{ object.statement_to_voters|markdown }}</blockquote>
         {% endif %}
         {% if object.statement_to_voters_last_updated %}
             <p>{% blocktrans with date=object.statement_to_voters_last_updated|naturalday %}This statement was last updated on {{ date }}.{% endblocktrans %}</p>
@@ -44,7 +44,7 @@
                     {% if leaflet.thumb_url %}
                         <a href="https://electionleaflets.org/leaflets/{{ leaflet.leaflet_id }}">
                             <img src="{{ leaflet.thumb_url }}"
-                                alt="{% blocktrans with person_name=object.name %}Thumbnail of leaflet from {{ person_name }}{% endblocktrans %}"/>
+                                 alt="{% blocktrans with person_name=object.name %}Thumbnail of leaflet from {{ person_name }}{% endblocktrans %}"/>
                         </a>
                     {% endif %}
                     <p>

--- a/wcivf/templates/home.html
+++ b/wcivf/templates/home.html
@@ -20,7 +20,7 @@
                 </p>
             {% endif %}
             <button class="ds-button-pink" type="submit">{% trans "Find your candidates" %}</button>
-            <p>{% trans "A parliamentary general election has been called for 4 July.Enter your postcode to find your constituency and candidates." %}</p>
+            <p>{% trans "A parliamentary general election has been called for 4 July. Enter your postcode to find your constituency and candidates." %}</p>
             <p>{% trans "A new set of constituency boundaries will be used for the 2024 election. This means that your constituency may have changed since the last election." %}</p>
             <p>{% trans "You will need to show photo ID to vote at a polling station in these elections." %}</p>
 


### PR DESCRIPTION
This change 

- renders statement to voters in markdown where markdown has been used to create the statement
- Adds a space after . in a follow up to https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1902

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207430370250227