### PR TITLE
Hide local party card until national parties are imported:

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -52,10 +52,11 @@
             {% include "people/includes/_person_about_card.html" %}
         {% endif %}
 
-        {% if object.current_or_future_candidacies and object.local_party and not object.national_party %}
-            {% include "people/includes/_person_local_party_card.html" with person=object.featured_candidacy.person party=object.local_party.name %}
-        {% endif %}
 
+        {% comment %} TODO: Hide until GE parties sheet is populated {% endcomment %}
+        {% comment %} {% if object.current_or_future_candidacies and object.local_party and not object.national_party %}
+            {% include "people/includes/_person_local_party_card.html" with person=object.featured_candidacy.person party=object.local_party.name %}
+        {% endif %} {% endcomment %}
 
         {% if object.current_or_future_candidacies and object.national_party and not object.local_party %}
             {% include "people/includes/_person_national_party_card.html" with person=object.featured_candidacy.person party=object.national_party.name %}

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -13,7 +13,7 @@ from elections.tests.factories import (
 )
 from freezegun import freeze_time
 from parties.tests.factories import (
-    LocalPartyFactory,
+    # LocalPartyFactory,
     NationalPartyFactory,
     PartyFactory,
 )
@@ -713,33 +713,33 @@ class PersonViewTests(TestCase):
         self.assertEqual(response.template_name, ["people/person_detail.html"])
         self.assertContains(response, "other contact info")
 
-    def test_local_party_for_local_election(self):
-        party = PartyFactory(party_name="Labour Party", party_id="party:53")
-        local_party = LocalPartyFactory(
-            name="Derbyshire Labour", is_local=True, parent=party
-        )
-        PersonPostFactory(
-            person=self.person,
-            election=ElectionFactory(),
-            party=party,
-        )
-        response = self.client.get(self.person_url, follow=True)
-        expected = f"{self.person.name}'s local party is {local_party.label}."
-        self.assertContains(response, expected)
+    # def test_local_party_for_local_election(self):
+    #     party = PartyFactory(party_name="Labour Party", party_id="party:53")
+    #     local_party = LocalPartyFactory(
+    #         name="Derbyshire Labour", is_local=True, parent=party
+    #     )
+    #     PersonPostFactory(
+    #         person=self.person,
+    #         election=ElectionFactory(),
+    #         party=party,
+    #     )
+    #     response = self.client.get(self.person_url, follow=True)
+    #     expected = f"{self.person.name}'s local party is {local_party.label}."
+    #     self.assertContains(response, expected)
 
-    def test_local_party_for_non_local_election(self):
-        party = PartyFactory(party_name="Labour Party", party_id="party:53")
-        local_party = LocalPartyFactory(
-            name="Welsh Labour | Llafur Cymru", is_local=False, parent=party
-        )
-        PersonPostFactory(
-            person=self.person,
-            election=ElectionFactory(),
-            party=party,
-        )
-        response = self.client.get(self.person_url, follow=True)
-        expected = f"{self.person.name} is a {local_party.label} candidate."
-        self.assertContains(response, expected)
+    # def test_local_party_for_non_local_election(self):
+    #     party = PartyFactory(party_name="Labour Party", party_id="party:53")
+    #     local_party = LocalPartyFactory(
+    #         name="Welsh Labour | Llafur Cymru", is_local=False, parent=party
+    #     )
+    #     PersonPostFactory(
+    #         person=self.person,
+    #         election=ElectionFactory(),
+    #         party=party,
+    #     )
+    #     response = self.client.get(self.person_url, follow=True)
+    #     expected = f"{self.person.name} is a {local_party.label} candidate."
+    #     self.assertContains(response, expected)
 
     def test_national_party_for_general_election(self):
         party = PartyFactory(party_name="Labour Party", party_id="party:53")


### PR DESCRIPTION
With https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1903, I changed the logic so local party cards wouldn't show if national parties exist for a candidate. However, I overlooked the fact that we need a couple more days to populate the national parties sheet. This change temporarily hides that card until we have the data ready. 