### PR TITLE
Show the national party even if a local party exists

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -54,11 +54,11 @@
 
 
         {% comment %} TODO: Hide until GE parties sheet is populated {% endcomment %}
-        {% comment %} {% if object.current_or_future_candidacies and object.local_party and not object.national_party %}
+        {% comment %} {% if object.current_or_future_candidacies and object.local_party %}
             {% include "people/includes/_person_local_party_card.html" with person=object.featured_candidacy.person party=object.local_party.name %}
         {% endif %} {% endcomment %}
 
-        {% if object.current_or_future_candidacies and object.national_party and not object.local_party %}
+        {% if object.current_or_future_candidacies and object.national_party %}
             {% include "people/includes/_person_national_party_card.html" with person=object.featured_candidacy.person party=object.national_party.name %}
         {% endif %}
 

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -42,9 +42,9 @@
 
         {% include "people/includes/_person_policy_card.html" %}
 
-        {% if object.current_or_future_candidacies %}
+        {% comment %} {% if object.current_or_future_candidacies %}
             {% include "people/includes/_person_manifesto_card.html" with party=object.featured_candidacy.party party_name=object.featured_candidacy.party.name %}
-        {% endif %}
+        {% endif %} {% endcomment %}
 
         {% include "people/includes/_person_contact_card.html" %}
 


### PR DESCRIPTION
Follow up to https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1903

I had assumed that a candidate would either have a local or a national party, and we should show each card based on that logic. However, it's possible that a candidate has both, but at the moment, we only want to show the national party card. 

This change also hides manifestos. 
<img width="978" alt="Screenshot 2024-06-05 at 3 39 49 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/9790d81b-a4a6-4902-a88c-bce32b567d68">
