### PR TITLE
Only show manifesto if it's related to a NationalParty

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -456,6 +456,26 @@ class Person(models.Model):
         intro = intro.strip()
         return " ".join(intro.split())
 
+    @property
+    def show_national_manifesto(self):
+        """
+        Return the national party manifesto for the featured candidacy
+        """
+        try:
+            if (
+                self.current_or_future_candidacies
+                and self.featured_candidacy
+                and (
+                    self.featured_candidacy.party.party_name
+                    == self.national_party.name
+                )
+                and self.manifestos
+            ):
+                return True
+            return False
+        except AttributeError:
+            return False
+
 
 class PersonRedirect(models.Model):
     old_person_id = models.IntegerField()

--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -42,9 +42,9 @@
 
         {% include "people/includes/_person_policy_card.html" %}
 
-        {% comment %} {% if object.current_or_future_candidacies %}
+        {% if object.show_national_manifesto %}
             {% include "people/includes/_person_manifesto_card.html" with party=object.featured_candidacy.party party_name=object.featured_candidacy.party.name %}
-        {% endif %} {% endcomment %}
+        {% endif %}
 
         {% include "people/includes/_person_contact_card.html" %}
 
@@ -54,11 +54,11 @@
 
 
         {% comment %} TODO: Hide until GE parties sheet is populated {% endcomment %}
-        {% comment %} {% if object.current_or_future_candidacies and object.local_party %}
+        {% comment %} {% if object.current_or_future_candidacies and object.local_party and not object.national_party %}
             {% include "people/includes/_person_local_party_card.html" with person=object.featured_candidacy.person party=object.local_party.name %}
         {% endif %} {% endcomment %}
 
-        {% if object.current_or_future_candidacies and object.national_party %}
+        {% if object.current_or_future_candidacies and object.national_party and not object.local_party %}
             {% include "people/includes/_person_national_party_card.html" with person=object.featured_candidacy.person party=object.national_party.name %}
         {% endif %}
 


### PR DESCRIPTION
Currently, we have local party importing switched off and local party cards commented out during the pre-GE period. However, since the manifesto import is linked to the party importing, and manifesto cards are used to show both LocalParty and NationalParty data, I've made a change to ensure that if a manifesto exists, it's only showing for the NationalParty. I expect this is a temporary change and we can revert this work after the GE. 

A manifesto card does not show when a NationalParty doesn't exist and there are no manifestos 
<img width="771" alt="Screenshot 2024-06-05 at 6 45 12 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/4ba2ebce-30f8-4a53-816e-bd62c4a8e69f">

A NationalParty exists for this person, but there is no manifesto data
<img width="783" alt="Screenshot 2024-06-05 at 6 44 46 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/85bbe810-fa5d-4caa-a62d-932847403293">
The manifesto card shows if there is manifesto data and it's for a NationalParty

<img width="744" alt="Screenshot 2024-06-05 at 6 44 11 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/7d0039e0-4bdd-4014-bc67-8db35a91b0b4">
