### PR TITLE
Only show national manifestos even if local ones exist

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -43,7 +43,7 @@
         {% include "people/includes/_person_policy_card.html" %}
 
         {% if object.show_national_manifesto %}
-            {% include "people/includes/_person_manifesto_card.html" with party=object.national_party party_name=object.national_party.name %}
+            {% include "people/includes/_person_manifesto_card.html" with person=object.featured_candidacy.person %}
         {% endif %}
 
         {% include "people/includes/_person_contact_card.html" %}


### PR DESCRIPTION
Issue: Manifestos are currently showing on WCIVF with a combo of Local Party data with reference to National Parties. For example: https://whocanivotefor.co.uk/person/12398/lisa-banes

In cases where a national party manifesto has been published, we do see the card working as expected: https://whocanivotefor.co.uk/person/117663/richard-baker-howard

This change aims to make the logic for showing manifestos stricter and passes the national party context to the manifesto.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207520352598607