### PR TITLE
webcal: Don't double-convert election time zone 

### DIFF
--- a/wcivf/apps/elections/dummy_models.py
+++ b/wcivf/apps/elections/dummy_models.py
@@ -83,3 +83,28 @@ class DummyPostElection(PostElection):
                 party_name="Independent",
             ),
         ]
+
+
+dummy_polling_station = {
+    "polling_station_known": True,
+    "custom_finder": False,
+    "report_problem_url": "http://wheredoivote.co.uk/report_problem/?source=testing&source_url=testing",
+    "station": {
+        "id": "w06000015.QK",
+        "type": "Feature",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-3.119229, 51.510885],
+        },
+        "properties": {
+            "address": "1 Made Up Street\nMade Up Town\nMade Up County",
+            "postcode": "MA1 1AA",
+        },
+    },
+    "geometry": {
+        "coordinates": [-0.127758, 51.507351],
+    },
+    "properties": {
+        "address": "1 Made Up Street\nMade Up Town\nMade Up County",
+    },
+}

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -37,10 +37,6 @@ class ElectionCancellationReason(models.TextChoices):
     CANDIDATE_DEATH = "CANDIDATE_DEATH", "Death of a candidate"
 
 
-def utc_to_local(utc_dt):
-    return utc_dt.replace(tzinfo=pytz.utc).astimezone(LOCAL_TZ)
-
-
 class Election(models.Model):
     slug = models.CharField(max_length=128, unique=True)
     election_date = models.DateField()
@@ -187,12 +183,12 @@ class Election(models.Model):
     @property
     def start_time(self):
         election_datetime = self._election_datetime_tz()
-        return utc_to_local(election_datetime.replace(hour=7))
+        return election_datetime.replace(hour=7)
 
     @property
     def end_time(self):
         election_datetime = self._election_datetime_tz()
-        return utc_to_local(election_datetime.replace(hour=22))
+        return election_datetime.replace(hour=22)
 
     def get_absolute_url(self):
         return reverse(

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -789,13 +789,14 @@ class TestPostcodeiCalView:
             "postcode_to_ballots",
             side_effect=InvalidPostcodeError,
         )
-        url = reverse("postcode_ical_view", kwargs={"postcode": "TE1 1ST"})
+        # TE1 1ST is a known (fake) postcode, TE1 2ST is not.
+        url = reverse("postcode_ical_view", kwargs={"postcode": "TE1 2ST"})
         response = client.get(url)
 
         assert response.status_code == 302
-        assert response.url == "/?invalid_postcode=1&postcode=TE1%201ST"
+        assert response.url == "/?invalid_postcode=1&postcode=TE1%202ST"
 
-    def test_ical_with_no_polling_station(self, mocker, client):
+    def test_ical_with_election(self, mocker, client):
         mocker.patch.object(
             PostcodeToPostsMixin,
             "postcode_to_ballots",
@@ -804,5 +805,23 @@ class TestPostcodeiCalView:
         url = reverse("postcode_ical_view", kwargs={"postcode": "TE1 1ST"})
         response = client.get(url)
 
-        assert response.status_code == 302
-        assert response.url == "/?invalid_postcode=1&postcode=TE1%201ST"
+        assert response.status_code == 200
+        content_without_ephemeral_datestamp = "\n".join(line for line in response.content.decode("utf-8").replace("\r\n", "\n").split("\n") if "DTSTAMP" not in line)
+        assert content_without_ephemeral_datestamp == """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Elections in TE1 1ST//mxm.dk//
+SUMMARY:Elections in TE1 1ST
+X-WR-CALNAME:Elections in TE1 1ST
+X-WR-TIMEZONE:Europe/London
+BEGIN:VEVENT
+SUMMARY:Llantalbot local election - Made-Up-Ward
+DTSTART;TZID=Europe/London:20240704T070000
+DTEND;TZID=Europe/London:20240704T220000
+UID:-local.faketown.2024-07-04
+DESCRIPTION:Find out more at https://whocanivotefor.co.uk/elections/TE11ST
+ /
+GEO:-3.119229\;51.510885
+LOCATION:1 Made Up Street\\, Made Up Town\\, Made Up County\\, MA1 1AA
+END:VEVENT
+END:VCALENDAR
+"""

--- a/wcivf/apps/elections/urls.py
+++ b/wcivf/apps/elections/urls.py
@@ -1,6 +1,9 @@
 from core.views import TranslatedTemplateView
 from django.urls import re_path
-from elections.views.postcode_view import DummyPostcodeView
+from elections.views.postcode_view import (
+    DummyPostcodeiCalView,
+    DummyPostcodeView,
+)
 
 from .helpers import ElectionIDSwitcher
 from .views import (
@@ -72,6 +75,11 @@ urlpatterns = [
             extra_context={"voting_sytem": "Single Transferable Vote"},
         ),
         name="stv_voting_system_view",
+    ),
+    re_path(
+        r"^TE1 1ST.ics$",
+        DummyPostcodeiCalView.as_view(),
+        name="dummy_postcode_ical_view",
     ),
     re_path(
         r"^(?P<postcode>[^/]+)/(?P<uprn>[^/]+)/$",

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.views.generic import TemplateView, View
-from elections.dummy_models import DummyPostElection
+from elections.dummy_models import DummyPostElection, dummy_polling_station
 from elections.models import InvalidPostcodeError
 from icalendar import Calendar, Event, vText
 from parishes.models import ParishCouncilElection
@@ -363,6 +363,18 @@ class PostcodeiCalView(
         return HttpResponse(cal.to_ical(), content_type="text/calendar")
 
 
+class DummyPostcodeiCalView(PostcodeiCalView):
+    def get(self, request, *args, **kwargs):
+        kwargs["postcode"] = "TE1 1ST"
+        return super().get(request, *args, **kwargs)
+
+    def postcode_to_ballots(self, postcode, uprn=None, compact=False):
+        return {
+            "ballots": [DummyPostElection()],
+            "polling_station": dummy_polling_station,
+        }
+
+
 class DummyPostcodeView(PostcodeView):
     postcode = None
     uprn = None
@@ -421,26 +433,4 @@ class DummyPostcodeView(PostcodeView):
         }
 
     def get_polling_station(self):
-        return {
-            "polling_station_known": True,
-            "custom_finder": False,
-            "report_problem_url": "http://wheredoivote.co.uk/report_problem/?source=testing&source_url=testing",
-            "station": {
-                "id": "w06000015.QK",
-                "type": "Feature",
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [-3.119229, 51.510885],
-                },
-                "properties": {
-                    "address": "1 Made Up Street\nMade Up Town\nMade Up County",
-                    "postcode": "MA1 1AA",
-                },
-            },
-            "geometry": {
-                "coordinates": [-0.127758, 51.507351],
-            },
-            "properties": {
-                "address": "1 Made Up Street\nMade Up Town\nMade Up County",
-            },
-        }
+        return dummy_polling_station

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.views.generic import TemplateView, View
 from elections.dummy_models import DummyPostElection, dummy_polling_station
-from elections.models import InvalidPostcodeError, LOCAL_TZ
+from elections.models import LOCAL_TZ, InvalidPostcodeError
 from icalendar import Calendar, Event, vText
 from parishes.models import ParishCouncilElection
 

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.views.generic import TemplateView, View
 from elections.dummy_models import DummyPostElection, dummy_polling_station
-from elections.models import InvalidPostcodeError
+from elections.models import InvalidPostcodeError, LOCAL_TZ
 from icalendar import Calendar, Event, vText
 from parishes.models import ParishCouncilElection
 
@@ -284,7 +284,7 @@ class PostcodeiCalView(
         cal = Calendar()
         cal["summary"] = "Elections in {}".format(postcode)
         cal["X-WR-CALNAME"] = "Elections in {}".format(postcode)
-        cal["X-WR-TIMEZONE"] = "Europe/London"
+        cal["X-WR-TIMEZONE"] = LOCAL_TZ.zone
 
         cal.add("version", "2.0")
         cal.add("prodid", "-//Elections in {}//mxm.dk//".format(postcode))
@@ -298,8 +298,8 @@ class PostcodeiCalView(
             event["uid"] = f"{postcode}-address-picker"
             event["summary"] = "You may have upcoming elections"
             event.add("dtstamp", timezone.now())
-            event.add("dtstart", timezone.now().date())
-            event.add("dtend", timezone.now().date())
+            PostcodeiCalView.add_local_timestamp(event, "dtstart", timezone.now().date())
+            PostcodeiCalView.add_local_timestamp(event, "dtend", timezone.now().date())
             event.add(
                 "DESCRIPTION",
                 (
@@ -323,8 +323,8 @@ class PostcodeiCalView(
                 post_election.election.name, post_election.post.label
             )
             event.add("dtstamp", timezone.now())
-            event.add("dtstart", post_election.election.start_time)
-            event.add("dtend", post_election.election.end_time)
+            PostcodeiCalView.add_local_timestamp(event, "dtstart", post_election.election.start_time)
+            PostcodeiCalView.add_local_timestamp(event, "dtend", post_election.election.end_time)
             event.add(
                 "DESCRIPTION",
                 "Find out more at {}/elections/{}/".format(
@@ -354,13 +354,17 @@ class PostcodeiCalView(
                 event["uid"] = husting.uuid
                 event["summary"] = husting.title
                 event.add("dtstamp", timezone.now())
-                event.add("dtstart", husting.starts)
+                PostcodeiCalView.add_local_timestamp(event, "dtstart", husting.starts)
                 if husting.ends:
-                    event.add("dtend", husting.ends)
+                    PostcodeiCalView.add_local_timestamp(event, "dtend", husting.ends)
                 event.add("DESCRIPTION", f"Find out more at {husting.url}")
                 cal.add_component(event)
 
         return HttpResponse(cal.to_ical(), content_type="text/calendar")
+
+    @staticmethod
+    def add_local_timestamp(event, name, value):
+        event.add(name, value, {"TZID": LOCAL_TZ.zone})
 
 
 class DummyPostcodeiCalView(PostcodeiCalView):


### PR DESCRIPTION
Also, set up a dummy ics route for the test election so these can be manually verified.

See individual commits for details, but tl;dr: We were double-converting election times from UTC to Local, and this now means we're only doing it once.

We're still showing husting times offset by an hour, but I think that's due to using the wrong timezone in the database, rather than because of double-converting in code.

Fixes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/801

```[tasklist]
### PR Checklist
- [ ] Update changelog (ie https://keepachangelog.com/en/1.0.0/)
- [x] References a specific issue or if not, describes the bug or feature in detail
- [ ] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [ ] Screenshot of the feature/bug fix (if applicable)
- [ ] If any new text is added, it's internationalized
- [ ] Any new elements have aria labels
- [x] No unintentional console.logs left behind after debugging
- [x] Did I use the clear and concise names for variables and functions?
- [ ] Did I explain all possible solutions and why I chose the one I did?
- [ ] Added any comments to make new functions clearer
- [ ] Did I added or updated any new dependencies? Explain why.
- [ ] Did I update the package.json and/or Pipfile.lock version if relevant?
- [x] Have I rebased with the latest version of master?
- [ ] Added PR labels
- [ ] Update any history/changelog file
- [ ] Update any documentation
- [ ] Update dev handbook
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207643917899041