### PR TITLE
Fix for empty list items on regional manifestos

### DIFF
--- a/wcivf/apps/parties/templates/parties/regional_manifesto.html
+++ b/wcivf/apps/parties/templates/parties/regional_manifesto.html
@@ -1,78 +1,93 @@
 {% load i18n %}
-<li>
-    {% if party_name == "Labour Party" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+
+{% if party_name == "Labour Party" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="https://labour.org.uk/change/scotland/">manifesto for Scotland</a>.
             {% endblocktrans %}
-        {% endif %}
+        </li>
+    {% endif %}
 
-        {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %} {% endcomment %}
-    {% endif %}
-
-    {% if party_name == "Conservative Party" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        </li>
+    {% endif %} {% endcomment %}
+{% endif %}
+{% if party_name == "Conservative Party" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Scotland</a>.
             {% endblocktrans %}
-        {% endif %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        </li>
+    {% endif %}
+    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %}
-    {% endif %}
-
-    {% if party_name == "Conservative and Unionist Party" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        </li>
+    {% endif %} {% endcomment %}
+{% endif %}
+{% if party_name == "Conservative and Unionist Party" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="https://www.scottishconservatives.com/manifestos/2024-general-election-manifesto/">manifesto for Scotland</a>.
             {% endblocktrans %}
-        {% endif %}
-        {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        </li>
+    {% endif %}
+    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %} {% endcomment %}
-    {% endif %}
-
-    {% if object.featured_candidacy.party_name == "Liberal Democrats" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        </li>
+    {% endif %} {% endcomment %}
+{% endif %}
+{% if object.featured_candidacy.party_name == "Liberal Democrats" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="https://www.scotlibdems.org.uk/fairdeal">manifesto for Scotland</a>.
             {% endblocktrans %}
-        {% endif %}
+        </li>
+    {% endif %}
 
-        {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %} {% endcomment %}
-    {% endif %}
-
-    {% if object.featured_candidacy.party_name == "Green Party" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        </li>
+    {% endif %} {% endcomment %}
+{% endif %}
+{% if object.featured_candidacy.party_name == "Green Party" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="https://wales.greenparty.org.uk/manifesto-2024-2/">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %}
+        </li>
     {% endif %}
-
-    {% if object.featured_candidacy.party_name == "Labour and Co-operative Party" %}
-        {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+{% endif %}
+{% if object.featured_candidacy.party_name == "Labour and Co-operative Party" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="https://labour.org.uk/change/scotland/">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %}
-        {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        </li>
+    {% endif %}
+    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+        <li>
             {% blocktrans trimmed with party_name=party_name %}
                 The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
             {% endblocktrans %}
-        {% endif %} {% endcomment %}
-    {% endif %}
-
-</li>
+        </li>
+    {% endif %} {% endcomment %}
+{% endif %}


### PR DESCRIPTION
Before
<img width="966" alt="Screenshot 2024-06-24 at 10 02 56 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/3c9bae75-f544-4b0d-9c31-8b87ab6ab9a1">
After
<img width="630" alt="Screenshot 2024-06-24 at 10 02 49 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/04667a93-cad7-4202-97c9-3b1b85adfad8">

