### PR TITLE
Handle absence of some fields in objects

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -368,7 +368,7 @@ class YNRBallotImporter:
             if self.recently_updated:
                 defaults["ynr_modified"] = ballot_dict["last_updated"]
 
-            if ballot_dict["results"]:
+            if ballot_dict.get("results"):
                 results_defaults = {
                     "ballot_papers_issued": ballot_dict["results"][
                         "num_turnout_reported"
@@ -423,8 +423,8 @@ class YNRBallotImporter:
                             "party_description_text"
                         ],
                         list_position=candidate["party_list_position"],
-                        deselected=candidate["deselected"],
-                        deselected_source=candidate["deselected_source"],
+                        deselected=candidate.get("deselected", False),
+                        deselected_source=candidate.get("deselected_source"),
                         elected=elected,
                         votes_cast=result.get("num_ballots", None),
                         post=ballot.post,

--- a/wcivf/apps/people/management/commands/import_people.py
+++ b/wcivf/apps/people/management/commands/import_people.py
@@ -252,7 +252,7 @@ class Command(BaseCommand):
         while url:
             req = requests.get(url)
             page = req.json()
-            for result in page["results"]:
+            for result in page.get("results", []):
                 merged_ids.append(result["old_person_id"])
                 PersonRedirect.objects.get_or_create(
                     old_person_id=result["old_person_id"],


### PR DESCRIPTION
Authored by [illicitonion](https://github.com/illicitonion) in https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1967, duplicated here for CI.

> When running python manage.py import_ballots for the first time on a fresh DB, I ran into exceptions because these fields weren't present for some of the fetched data.
> 
> This now treats these fields as optional, and falls back to reasonable default behaviours if they're absent.
> 
> This can be tested by following the database setup steps of the README without this change, observing errors, then trying again with these patches and observing success.