### PR TITLE
Restrict additional manifestos to specific parties

### DIFF
--- a/wcivf/apps/parties/templates/parties/regional_manifesto.html
+++ b/wcivf/apps/parties/templates/parties/regional_manifesto.html
@@ -1,44 +1,43 @@
 {% load i18n %}
 
-{% if party_name == "Labour Party" or "Labour and Co-operative Party" %}
+{% if object.featured_candidacy.party_name == "Labour Party" or object.featured_candidacy.party_name == "Labour and Co-operative Party" %}
     {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://labour.org.uk/change/scotland/">manifesto for Scotland</a>.
             {% endblocktrans %}
         </li>
     {% endif %}
-
     {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://labour.org.uk/change/wales/">manifesto for Wales</a>.
             {% endblocktrans %}
         </li>
     {% endif %}
 {% endif %}
 
-{% if party_name == "Conservative and Unionist Party" or "Conservative Party" %}
+{% if object.featured_candidacy.party_name == "Conservative and Unionist Party" or object.featured_candidacy.party_name == "Conservative Party" %}
     {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://www.scottishconservatives.com/manifestos/2024-general-election-manifesto/">manifesto for Scotland</a>.
             {% endblocktrans %}
         </li>
     {% endif %}
-    {% comment %} {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
+    {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
         <li>
             {% blocktrans trimmed with party_name=party_name %}
-                The {{ party_name }} have also released a <a href="">manifesto for Wales</a>.
+                The {{ party_name }} have also released a <a href="https://www.conservatives.wales/manifesto24">manifesto for Wales</a>.
             {% endblocktrans %}
         </li>
-    {% endif %} {% endcomment %}
+    {% endif %}
 {% endif %}
 
 {% if object.featured_candidacy.party_name == "Liberal Democrats" %}
     {% if object.featured_candidacy.post_election.post.nice_territory == "Scotland" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://www.scotlibdems.org.uk/fairdeal">manifesto for Scotland</a>.
             {% endblocktrans %}
         </li>
@@ -46,7 +45,7 @@
 
     {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://www.libdems.wales/fairdeal">manifesto for Wales</a>.
             {% endblocktrans %}
         </li>
@@ -55,7 +54,7 @@
 {% if object.featured_candidacy.party_name == "Green Party" %}
     {% if object.featured_candidacy.post_election.post.nice_territory == "Wales" %}
         <li>
-            {% blocktrans trimmed with party_name=party_name %}
+            {% blocktrans trimmed with party_name=object.featured_candidacy.party_name %}
                 The {{ party_name }} have also released a <a href="https://wales.greenparty.org.uk/manifesto-2024-2/">manifesto for Wales</a>.
             {% endblocktrans %}
         </li>

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -478,7 +478,7 @@ class Person(models.Model):
             return False
 
     @property
-    def has_additional_manifesto(self):
+    def has_regional_manifesto(self):
         file_path = (
             "wcivf/apps/parties/templates/parties/regional_manifesto_ids.txt"
         )
@@ -488,7 +488,13 @@ class Person(models.Model):
             if (
                 self.featured_candidacy.post_election.ballot_paper_id
                 in regional_manifesto_ids
-            ):
+            ) and self.featured_candidacy.party.party_id in [
+                "party:53",
+                "party:52",
+                "party:90",
+                "party:63",
+                "joint-party:53-119",
+            ]:
                 return True
         return False
 

--- a/wcivf/apps/people/templates/people/includes/_person_manifesto_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_manifesto_card.html
@@ -23,9 +23,9 @@
                     {% for manifesto in object.manifestos %}
                         {% include "parties/single_manifesto.html" %}
                     {% endfor %}
-                    {% comment %} {% if object.has_additional_manifesto %}
+                    {% if object.has_regional_manifesto %}
                         {% include "parties/regional_manifesto.html" with party_name=object.featured_candidacy.party_name %}
-                    {% endif %} {% endcomment %}
+                    {% endif %}
                 </ul>
             </div>
             {% if party.emblem_url %}


### PR DESCRIPTION
In https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1955 I failed to consider how not filtering on party would effect candidates within the list of eligible ballot ids. This led to an additional manifesto from another party to be shown on all candidates listed on these ballots. This fix adds a test that mimics this bug and limits additional manifestos to a list of party ids.
<img width="646" alt="Screenshot 2024-06-25 at 1 03 18 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/df07f886-c548-4cc0-8d3d-5333ea8ba663">
<img width="697" alt="Screenshot 2024-06-25 at 2 06 02 PM" src="https://github.com/DemocracyClub/WhoCanIVoteFor/assets/7017118/095300b3-e44e-40bb-9c26-0c039ca5b2c2">
