### PR TITLE
Add missing translation tag

### DIFF
--- a/wcivf/apps/hustings/templates/hustings/husting_form.html
+++ b/wcivf/apps/hustings/templates/hustings/husting_form.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load dc_forms %}
+{% load i18n %}
 
 {% block content %}
     <h1>


### PR DESCRIPTION
This is a fix for https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1971 which was missing a translation tag in the template. 