### PR TITLE
fix ruff CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           name: Ruff
           command: |
             . .venv/bin/activate
-            ruff format .
+            ruff format . --check
       - run:
           name: CurlyLint
           command: |

--- a/wcivf/apps/api/views.py
+++ b/wcivf/apps/api/views.py
@@ -106,9 +106,9 @@ class BaseCandidatesAndElectionsViewSet(
                 ),
             }
             if postelection.replaced_by:
-                election["replaced_by"] = (
-                    postelection.replaced_by.ballot_paper_id
-                )
+                election[
+                    "replaced_by"
+                ] = postelection.replaced_by.ballot_paper_id
             else:
                 election["replaced_by"] = None
 

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -99,9 +99,9 @@ class PostcodeView(
         context["show_polling_card"] = self.show_polling_card(
             context["postelections"]
         )
-        context["is_before_registration_deadline"] = (
-            self.is_before_registration_deadline(context["postelections"])
-        )
+        context[
+            "is_before_registration_deadline"
+        ] = self.is_before_registration_deadline(context["postelections"])
         context["people_for_post"] = {}
         for postelection in context["postelections"]:
             postelection.people = self.people_for_ballot(postelection)
@@ -115,14 +115,14 @@ class PostcodeView(
             "postcode_location", None
         )
 
-        context["advance_voting_station"] = (
-            self.get_advance_voting_station_info(context["polling_station"])
-        )
+        context[
+            "advance_voting_station"
+        ] = self.get_advance_voting_station_info(context["polling_station"])
 
         context["ballots_today"] = self.get_todays_ballots()
-        context["multiple_city_of_london_elections_today"] = (
-            self.multiple_city_of_london_elections_today()
-        )
+        context[
+            "multiple_city_of_london_elections_today"
+        ] = self.multiple_city_of_london_elections_today()
         context["referendums"] = list(self.get_referendums())
         context["parish_council_election"] = self.get_parish_council_election()
         context["num_ballots"] = self.num_ballots()
@@ -405,8 +405,10 @@ class DummyPostcodeView(PostcodeView):
         )
         context["show_polling_card"] = True
         context["polling_station"] = self.get_polling_station()
-        context["is_before_registration_deadline"] = (
-            PostcodeView().is_before_registration_deadline(context["postelections"])
+        context[
+            "is_before_registration_deadline"
+        ] = PostcodeView().is_before_registration_deadline(
+            context["postelections"]
         )
         context["registration"] = self.get_registration()
         context["council"] = self.get_electoral_services()

--- a/wcivf/apps/ppc_2024/management/commands/import_2024_ppcs.py
+++ b/wcivf/apps/ppc_2024/management/commands/import_2024_ppcs.py
@@ -17,7 +17,8 @@ from people.models import Person
 from ppc_2024.models import PPCPerson
 
 
-class BlankRowException(ValueError): ...
+class BlankRowException(ValueError):
+    ...
 
 
 def clean_party_id(party_id):


### PR DESCRIPTION
When I checked this out locally I was getting fails running pytest that didn't seem to reproduce in CI.

As written, the CI will never fail due to ruff formatting errors because we were running `ruff format .` (which exits with code 0 even if files were written) before running pytest.

This means if there were formatting errors we just fix them in CI before checking.

In this PR I have modified the build to run `ruff format --check .` (which doesn't write anything but exits with non-zero if files would have been written). Pushed it to prove the build fails. Then I have pushed another commit which fixes the errors to get the build passing.