### PR TITLE
Show different registration info for City of London Council ballots

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-06 12:21+0100\n"
+"POT-Creation-Date: 2024-10-28 14:52+0000\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -29,19 +29,19 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich côd post"
 
-#: wcivf/apps/elections/models.py:756
+#: wcivf/apps/elections/models.py:765
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
-#: wcivf/apps/elections/models.py:758
+#: wcivf/apps/elections/models.py:767
 msgid "Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
 
-#: wcivf/apps/elections/models.py:760
+#: wcivf/apps/elections/models.py:769
 msgid "Supplementary Vote"
 msgstr "Pleidlais Atodol"
 
-#: wcivf/apps/elections/models.py:762
+#: wcivf/apps/elections/models.py:771
 msgid "Single Transferable Vote"
 msgstr "Pleidlais Sengl Drosglwyddadwy"
 
@@ -295,6 +295,39 @@ msgstr "Bydd yn awr yn digwydd ar"
 msgid "Read more"
 msgstr "Darllenwch ragor"
 
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:8
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:10
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:139
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:90
+msgid "Register to vote"
+msgstr "Cofrestru i bleidleisio"
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:12
+msgid ""
+"City of London council elections do not use the same electoral register as "
+"other elections."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:17
+msgid ""
+"Both residents and city workers are eligible to vote. There is one register "
+"published annually, and the deadline to apply is 30 November each year. The "
+"new register comes into force on 16 February each year, and cannot be "
+"modified after that date. For more information, visit the <a href=\"https://"
+"www.speakforthecity.com/\">Speak for the City</a> website or contact City of "
+"London electoral services."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:28
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:30
+msgid ""
+"For questions about your poll card, polling place, or about returning your "
+"postal voting ballot, contact your council."
+msgstr ""
+"Ar gyfer cwestiynau ynghylch eich cerdyn pleidleisio, eich gorsaf "
+"bleidleisio, neu ynghylch dychwelyd eich pleidlais drwy'r post, cysylltwch "
+"â'ch cyngor."
+
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:3
 #: wcivf/apps/parties/templates/parties/parties_view.html:9
 msgid "You are here"
@@ -428,7 +461,7 @@ msgid "Photo of %(person_name)s"
 msgstr "Llun o %(person_name)s"
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:9
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:124
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:131
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:82
 msgid "Where to vote"
 msgstr "Ble i bleidleisio"
@@ -471,37 +504,27 @@ msgid "Vote on polling day"
 msgstr "Pleidleisiwch ar y diwrnod pleidleisio"
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:51
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:103
 msgid "Your polling station is"
 msgstr "Eich gorsaf bleidleisio yw"
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:53
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:105
 #, python-format
 msgid "<address>%(polling_station_address)s</address>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:58
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
-#, fuzzy
-#| msgid "It will be open from <strong>7am to 10pm</strong>."
-msgid "It will be open from <strong>8am to 8pm</strong>."
-msgstr "Bydd ar agor o <strong>7am tan 10pm</strong>."
-
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:60
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:112
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:57
 msgid "It will be open from <strong>7am to 10pm</strong>."
 msgstr "Bydd ar agor o <strong>7am tan 10pm</strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:67
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:63
 msgid "and"
 msgstr "a"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:76
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:72
 msgid "You don't need to take your poll card with you."
 msgstr "Nid oes angen i chi ddod â'ch cerdyn pleidleisio gyda chi."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:83
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:79
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
 "election day up to 10pm. When handing in postal votes, you will need to "
@@ -514,7 +537,7 @@ msgstr ""
 "faint o bleidleisiau post yr ydych yn eucyflwyno, a pham yr ydych yn "
 "cyflwyno'r pleidleisiau post hynny."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:93
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:89
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
 "election day up to 10pm."
@@ -522,18 +545,18 @@ msgstr ""
 "Os oes gennych bleidlais bost, gallwch ei chyflwyno yn yr orsaf bleidleisio "
 "hondiwrnod etholiad hyd at 10pm"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:93
 msgid ""
 "Postal votes cannot be accepted at polling stations in Northern Ireland."
 msgstr ""
 "Ni ellir derbyn pleidleisiau post mewn gorsafoedd pleidleisio yng Ngogledd "
 "Iwerddon."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:99
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:95
 msgid "Learn more about voting by post"
 msgstr "Dysgwch fwy am bleidleisio drwy'r post"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:118
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:98
 #, python-format
 msgid ""
 "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
@@ -542,7 +565,7 @@ msgstr ""
 "<p>Gallwch ddod o hyd i'ch gorsaf bleidleisio drwy <a "
 "href=\"%(custom_finder)s\"> ddilyn y ddolen hon</a>.</p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:126
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:106
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
@@ -551,7 +574,7 @@ msgstr ""
 "<strong>Bydd gorsafoedd pleidleisio ar agor o %(open_time)s tan "
 "%(close_time)s heddiw.</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:131
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:111
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -562,14 +585,14 @@ msgstr ""
 "<a href=\"https://wheredoivote.co.uk/postcode/%(postcode)s/\">Gwiriwch yr "
 "orsaf bleidleisio gywir ar gyfer eich cyfeiriad&raquo;</a></p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:135
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 "Dylech dderbyn \"cerdyn pleidleisio\" drwy'r post yn dweud ble y dylech chi "
 "bleidleisio."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:138
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:118
 #, python-format
 msgid ""
 "If you haven't got one, or for questions about your poll card, polling "
@@ -581,7 +604,7 @@ msgstr ""
 "ffonio'r Swyddfa Cofrestru Etholiadol <a href=\"tel:"
 "%(council_phone)s\">%(council_phone)s</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:163
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:128
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
@@ -590,7 +613,7 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "%(council_name)s ar <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:187
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:138
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council."
@@ -598,25 +621,25 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "eich cyngor lleol."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:195
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:146
 msgid "You will need photographic identification."
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:201
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:152
 msgid "Read more about how to vote in Northern Ireland"
 msgstr "Darllenwch fwy am sut i bleidleisio yng Ngogledd Iwerddon"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:205
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:156
 msgid "Read more about how to vote"
 msgstr "Darllenwch fwy am sut i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:214
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:165
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions"
 msgstr "Cael cyfarwyddiadau cerdded o"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:218
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:169
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions from"
@@ -669,7 +692,7 @@ msgstr ""
 "bleidleisio"
 
 #: wcivf/apps/elections/templates/elections/includes/_postcode_search_form.html:11
-#: wcivf/templates/home.html:33
+#: wcivf/templates/home.html:25
 msgid "Find your candidates"
 msgstr "Dod o hyd i'ch ymgeiswyr"
 
@@ -685,12 +708,6 @@ msgstr[0] ""
 "Mae %(person_name)s wedi datgan eu cysylltiad â'r blaid ganlynol yn y 12 mis "
 "diwethaf:"
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:10
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:132
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:90
-msgid "Register to vote"
-msgstr "Cofrestru i bleidleisio"
-
 #: wcivf/apps/elections/templates/elections/includes/_registration_details.html:15
 msgid ""
 "You need to be registered in order to vote. If you aren't registered to vote "
@@ -701,7 +718,7 @@ msgstr ""
 "cofrestru i bleidleisio, ewch i <a href=\"https://www.gov.uk/register-to-"
 "vote\"> https://www.gov.uk/register-to-vote </a>"
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:25
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:24
 #, python-format
 msgid ""
 "Register before midnight on %(registration_deadline)s to vote on "
@@ -709,15 +726,6 @@ msgid ""
 msgstr ""
 "Cofrestrwch cyn hanner nos ar %(registration_deadline)s i bleidleisio ar "
 "%(election_date)s."
-
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:32
-msgid ""
-"For questions about your poll card, polling place, or about returning your "
-"postal voting ballot, contact your council."
-msgstr ""
-"Ar gyfer cwestiynau ynghylch eich cerdyn pleidleisio, eich gorsaf "
-"bleidleisio, neu ynghylch dychwelyd eich pleidlais drwy'r post, cysylltwch "
-"â'ch cyngor."
 
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:19
 msgid "Additional members"
@@ -738,17 +746,17 @@ msgid "This election will be held <strong>%(election_date)s</strong>."
 msgstr ""
 "Bydd yr etholiad hwn yn cael ei gynnal <strong>%(election_date)s</strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:55
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:57
 msgid "About this position"
 msgstr "Ynglŷn â'r rôl hon"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:59
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:61
 #, fuzzy, python-format
 #| msgid " %(description)s"
 msgid " %(description)s"
 msgstr " %(description)s "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:66
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:73
 #, python-format
 msgid ""
 "<strong>%(num_candidates)s candidate%(plural)s</strong> stood in the "
@@ -757,19 +765,19 @@ msgstr ""
 "Ymgeisiodd <strong>%(num_candidates)s ymgeisydd%(plural)s</strong> yn "
 "%(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:71
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:78
 msgid ""
 "We don't know of any candidates standing yet. You can help improve this page:"
 msgstr ""
 "Ni wyddwn am unrhyw ymgeiswyr sy'n sefyll eto. Gallwch helpu i wella'r "
 "dudalen hon:"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:72
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:83
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:79
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:90
 msgid "add information about candidates to our database"
 msgstr "ychwanegwch wybodaeth am ymgeiswyr i'n cronfa ddata"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:77
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:84
 #, python-format
 msgid ""
 "We don't know of any candidates standing yet. The official candidate list "
@@ -780,7 +788,7 @@ msgstr ""
 "sefyll eto. Bydd y rhestr swyddogol o ymgeiswyr yn cael ei chyhoeddi ar ôl "
 "%(expected_sopn_date)s, pan fydd y dudalen hon yn cael ei diweddaru."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:89
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:96
 msgid ""
 "You will have one vote, and can vote for a single party list or independent "
 "candidate."
@@ -788,7 +796,7 @@ msgstr ""
 "Bydd gennych un bleidlais, a gallwch bleidleisio dros un blaid neu ymgeisydd "
 "annibynnol."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:92
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:99
 #, python-format
 msgid ""
 "You will have <strong>%(winner_count)s vote%(plural)s</strong>, and can "
@@ -799,7 +807,7 @@ msgstr ""
 "gallwch ddewis o <strong>%(num_candidates)s ymgeisydd%(plural_candidates)s</"
 "strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:105
 #, fuzzy, python-format
 msgid ""
 "You will have <strong>one vote</strong>, and can choose from "
@@ -808,7 +816,7 @@ msgstr ""
 "Bydd gennych ddwy bleidlais, a gallwch ddewis o <strong>%(num_ballots)s</"
 "strong> yn yr %(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:103
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:110
 #, fuzzy, python-format
 msgid ""
 "You will have <strong>two votes</strong>, and can choose from "
@@ -817,7 +825,7 @@ msgstr ""
 "Bydd gennych ddwy bleidlais, a gallwch ddewis o <strong>%(num_ballots)s</"
 "strong> yn yr %(postelection)s."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:110
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:117
 #, python-format
 msgid ""
 "There is <strong>one seat</strong>  up for election, and you can choose from "
@@ -826,7 +834,7 @@ msgstr ""
 "Mae yna <strong>un sedd</strong>  ar gael yn yr etholiad, a gallwch ddewis o "
 "<strong>%(num_ballots)s ymgeisydd</strong>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:114
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:121
 #, python-format
 msgid ""
 "There are <strong>%(winner_count)s seats</strong>  up for election, and you "
@@ -835,17 +843,17 @@ msgstr ""
 "Mae yna %(winner_count)s seddi sedd ar gael yn yr etholiad, a gallwch ddewis "
 "o %(num_ballots)s ymgeisydd."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:121
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:128
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:79
 msgid "Get ready to vote"
 msgstr "Ble i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:128
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:135
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:86
 msgid "Voter ID requirements"
 msgstr "Gofynion ID Pleidleisiwr"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:140
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:147
 #, python-format
 msgid ""
 "We are currently aware of %(num_candidates)s candidate%(plural_candidates)s "
@@ -855,7 +863,7 @@ msgstr ""
 "ymgeisydd%(plural_candidates)s ar gyfer y swydd hon."
 
 # python-format
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:144
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:151
 #, fuzzy, python-format
 #| msgid ""
 #| "The official candidate list will be published after "
@@ -873,47 +881,47 @@ msgstr ""
 "helpu i wella'r dudalen hon: <a href=\"%(ynr_link)s\"> ychwanegu gwybodaeth "
 "ymgeisydd i'n cronfa ddata</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:160
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:167
 msgid "Read the official candidate booklet for this election."
 msgstr "Darllenwch y llyfryn ymgeiswyr swyddogol ar gyfer yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:170
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:177
 msgid "Electorate"
 msgstr "Nifer etholwyr"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:177
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:184
 msgid "Ballot Papers Issued"
 msgstr "Bapurau pleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:184
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:191
 msgid "Spoilt Ballots"
 msgstr "Nifer y bleidleisiau a ddifethwyd"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:191
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:198
 msgid "Turnout"
 msgstr "Cyfrif pleidleisiau"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:214
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:221
 #, fuzzy
 #| msgid "The official candidate list should have been published on"
 msgid "The official candidate list should have been published after"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr fod wedi'i chyhoeddi ar "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:216
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:223
 #, fuzzy
 #| msgid "The official candidate list should be published on"
 msgid "The official candidate list should be published after"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr gael ei chyhoeddi ar"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:227
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:234
 msgid "Can you vote in this election?"
 msgstr "A allwch chi bleidleisio yn yr etholiad hwn?"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:228
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:235
 msgid "Age"
 msgstr "Oedran"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:230
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:237
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
@@ -922,16 +930,16 @@ msgstr ""
 "Mae angen i chi fod dros %(voter_age)s ar %(voter_age_date)s "
 "%(election_date)s i bleidleisio yn yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:235
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:242
 msgid "Citizenship"
 msgstr "Dinasyddiaeth"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:254
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:261
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:7
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:256
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:263
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Read more on Wikipedia"
 msgstr "Darllenwch fwy ar Wikipedia"
@@ -2676,11 +2684,11 @@ msgstr "GitHub"
 msgid "Who Can I Vote For?"
 msgstr "Pwy alla i bleidleisio ar gyfer?"
 
-#: wcivf/templates/home.html:18
+#: wcivf/templates/home.html:12
 msgid "Find out about candidates in your area"
 msgstr "Cael gwybod am ymgeiswyr yn eich ardal chi"
 
-#: wcivf/templates/home.html:28
+#: wcivf/templates/home.html:20
 #, python-format
 msgid ""
 "Sorry, we don't know the postcode %(postcode)s. Is there another one you can "
@@ -2689,46 +2697,51 @@ msgstr ""
 "Mae'n flin gennym, ond nid ydym yn gwybod y côd post %(postcode)s . A oes un "
 "arall y gallwch chi ei ddefnyddio?"
 
-#: wcivf/templates/home.html:78
+#: wcivf/templates/home.html:32
 #, fuzzy
 #| msgid "You will need photographic identification."
 msgid "Photographic identification"
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/templates/home.html:80
+#: wcivf/templates/home.html:34
 msgid ""
 "Photographic identification will be required to vote in English local "
 "elections, and parliamentary elections across the UK, on and after 4 May "
 "2023."
 msgstr ""
 
-#: wcivf/templates/home.html:82
+#: wcivf/templates/home.html:36
 msgid ""
 "Learn more about photographic identification for voters on the website of "
 "the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:82
+#: wcivf/templates/home.html:36
 msgid "Learn more on the website of the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:85
+#: wcivf/templates/home.html:39
 msgid ""
 "You can apply for a free 'Voter Authority Certificate' if you do not already "
 "possess a valid ID."
 msgstr ""
 
-#: wcivf/templates/home.html:87
+#: wcivf/templates/home.html:41
 msgid "Apply for free voter ID."
 msgstr ""
 
-#: wcivf/templates/home.html:89
+#: wcivf/templates/home.html:43
 msgid "You do not need photo ID to vote by post."
 msgstr ""
 
-#: wcivf/templates/home.html:93
+#: wcivf/templates/home.html:47
 msgid "Upcoming Elections"
 msgstr "Etholiadau i ddod"
+
+#, fuzzy
+#~| msgid "It will be open from <strong>7am to 10pm</strong>."
+#~ msgid "It will be open from <strong>8am to 8pm</strong>."
+#~ msgstr "Bydd ar agor o <strong>7am tan 10pm</strong>."
 
 #~ msgid ""
 #~ "A parliamentary general election has been called for 4 July. Enter your "

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,7 +23,7 @@ djangorestframework-jsonp==1.0.2
 feedparser==6.0.10
 
 sentry-sdk==1.27.1
-uk-election-timetables==3.0.0
+uk-election-timetables==4.0.0
 uk-election-ids==0.8.0
 django-dotenv==1.4.2
 akismet==24.5.1

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -457,30 +457,39 @@ class PostElection(TimeStampedModel):
             return get_election_timetable(
                 self.ballot_paper_id, self.post.territory
             ).sopn_publish_date
-
         except AttributeError:
             return None
 
     @property
     def registration_deadline(self):
-        date = get_election_timetable(
-            self.ballot_paper_id, self.post.territory
-        ).registration_deadline
+        try:
+            date = get_election_timetable(
+                self.ballot_paper_id, self.post.territory
+            ).registration_deadline
+        except AttributeError:
+            return None
 
         return date.strftime("%d %B %Y")
 
     @property
     def past_registration_deadline(self):
-        registration_deadline = get_election_timetable(
-            self.ballot_paper_id, self.post.territory
-        ).registration_deadline
+        try:
+            registration_deadline = get_election_timetable(
+                self.ballot_paper_id, self.post.territory
+            ).registration_deadline
+        except AttributeError:
+            return None
+
         return registration_deadline < datetime.date.today()
 
     @property
     def postal_vote_application_deadline(self):
-        return get_election_timetable(
-            self.ballot_paper_id, self.post.territory
-        ).postal_vote_application_deadline
+        try:
+            return get_election_timetable(
+                self.ballot_paper_id, self.post.territory
+            ).postal_vote_application_deadline
+        except AttributeError:
+            return None
 
     @property
     def postal_vote_requires_form(self):

--- a/wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html
@@ -1,0 +1,40 @@
+{% load i18n %}
+
+<li>
+    <details open>
+        <summary>
+            <h2>
+                <span aria-hidden="true"></span>
+                {% blocktrans trimmed %}Register to vote{% endblocktrans %}
+            </h2>
+        </summary>
+        <p>
+            {% blocktrans trimmed %}
+                City of London council elections do not use the same electoral register as other elections.
+            {% endblocktrans %}
+        </p>
+        <p>
+            {% blocktrans trimmed %}
+                Both residents and city workers are eligible to vote. There is one register
+                published annually, and the deadline to apply is 30 November each year.
+                The new register comes into force on 16 February each year,
+                and cannot be modified after that date. For more information, visit the
+                <a href="https://www.speakforthecity.com/">Speak for the City</a>
+                website or contact City of London electoral services.
+            {% endblocktrans %}
+        </p>
+        {% if council.council_id %}
+            <p>
+                {% blocktrans trimmed %}
+                    For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council.
+                {% endblocktrans %}
+            </p>
+            {% if registration %}
+                {% include "elections/includes/_council_contact_details.html" with contact_details=registration %}
+            {% endif %}
+            {% if council %}
+                {% include "elections/includes/_council_contact_details.html" with contact_details=council %}
+            {% endif %}
+        {% endif %}
+    </details>
+</li>

--- a/wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html
@@ -1,40 +1,38 @@
 {% load i18n %}
 
-<li>
-    <details open>
-        <summary>
-            <h2>
-                <span aria-hidden="true"></span>
-                {% blocktrans trimmed %}Register to vote{% endblocktrans %}
-            </h2>
-        </summary>
+<details open>
+    <summary>
+        <h2>
+            <span aria-hidden="true"></span>
+            {% blocktrans trimmed %}Register to vote{% endblocktrans %}
+        </h2>
+    </summary>
+    <p>
+        {% blocktrans trimmed %}
+            City of London council elections do not use the same electoral register as other elections.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+            Both residents and city workers are eligible to vote. There is one register
+            published annually, and the deadline to apply is 30 November each year.
+            The new register comes into force on 16 February each year,
+            and cannot be modified after that date. For more information, visit the
+            <a href="https://www.speakforthecity.com/">Speak for the City</a>
+            website or contact City of London electoral services.
+        {% endblocktrans %}
+    </p>
+    {% if council.council_id %}
         <p>
             {% blocktrans trimmed %}
-                City of London council elections do not use the same electoral register as other elections.
+                For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council.
             {% endblocktrans %}
         </p>
-        <p>
-            {% blocktrans trimmed %}
-                Both residents and city workers are eligible to vote. There is one register
-                published annually, and the deadline to apply is 30 November each year.
-                The new register comes into force on 16 February each year,
-                and cannot be modified after that date. For more information, visit the
-                <a href="https://www.speakforthecity.com/">Speak for the City</a>
-                website or contact City of London electoral services.
-            {% endblocktrans %}
-        </p>
-        {% if council.council_id %}
-            <p>
-                {% blocktrans trimmed %}
-                    For questions about your poll card, polling place, or about returning your postal voting ballot, contact your council.
-                {% endblocktrans %}
-            </p>
-            {% if registration %}
-                {% include "elections/includes/_council_contact_details.html" with contact_details=registration %}
-            {% endif %}
-            {% if council %}
-                {% include "elections/includes/_council_contact_details.html" with contact_details=council %}
-            {% endif %}
+        {% if registration %}
+            {% include "elections/includes/_council_contact_details.html" with contact_details=registration %}
         {% endif %}
-    </details>
-</li>
+        {% if council %}
+            {% include "elections/includes/_council_contact_details.html" with contact_details=council %}
+        {% endif %}
+    {% endif %}
+</details>

--- a/wcivf/apps/elections/templates/elections/includes/_registration_details.html
+++ b/wcivf/apps/elections/templates/elections/includes/_registration_details.html
@@ -20,13 +20,11 @@
                 </a>
             {% endblocktrans %}
         </p>
-        {% if postelection %}
-            <p>
-                {% blocktrans trimmed with registration_deadline=postelection.registration_deadline|naturalday:"j F Y" election_date=postelection.election.election_date|naturalday:"j F Y" %}
-                    Register before midnight on {{ registration_deadline }} to vote on {{ election_date }}.
-                {% endblocktrans %}
-            </p>
-        {% endif %}
+        <p>
+            {% blocktrans trimmed with registration_deadline=card.registration_deadline|naturalday:"j F Y" election_date=card.election_date|naturalday:"j F Y" %}
+                Register before midnight on {{ registration_deadline }} to vote on {{ election_date }}.
+            {% endblocktrans %}
+        </p>
         {% if council.council_id %}
             <p>
                 {% blocktrans trimmed %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -64,7 +64,9 @@
                 {% endif %}
 
                 {% if postelection.election.is_city_of_london_local_election and not postelection.past_registration_deadline and not postelection.cancelled %}
-                    {% include "elections/includes/_city_of_london_registration_details.html" %}
+                    <li>
+                        {% include "elections/includes/_city_of_london_registration_details.html" %}
+                    </li>
                 {% endif %}
             </ul>
 

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -47,19 +47,26 @@
             {% if object.election.slug == "europarl.2019-05-23"%}
                 {% include "elections/includes/eu_results.html" with card=0 %}
             {% endif %}
-            {% if postelection.election.description %}
-                <div class="ds-details">
-                    <details>
-                        <summary>
-                            <h2>
-                                <span aria-hidden="true">{% trans "About this position" %}
-                                </span>
-                            </h2>
-                        </summary>
-                        <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
-                    </details>
-                </div>
-            {% endif %}
+
+            <ul class="ds-details">
+                {% if postelection.election.description %}
+                    <li>
+                        <details>
+                            <summary>
+                                <h2>
+                                    <span aria-hidden="true">{% trans "About this position" %}
+                                    </span>
+                                </h2>
+                            </summary>
+                            <p>{% blocktrans with description=postelection.election.description|markdown %} {{ description }}{% endblocktrans%}</p>
+                        </details>
+                    </li>
+                {% endif %}
+
+                {% if postelection.election.is_city_of_london_local_election and not postelection.past_registration_deadline %}
+                    {% include "elections/includes/_city_of_london_registration_details.html" %}
+                {% endif %}
+            </ul>
 
             <p>
                 {% if postelection.election.in_past %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -128,7 +128,7 @@
                                             <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
                                         {% endif %}
 
-                                        {% if show_global_registration_card %}
+                                        {% if global_registration_card.show %}
                                             <li><a href="#register">{% trans "Register to vote" %}</a></li>
                                         {% endif %}
                                     </ul>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -63,7 +63,7 @@
                     </li>
                 {% endif %}
 
-                {% if postelection.election.is_city_of_london_local_election and not postelection.past_registration_deadline %}
+                {% if postelection.election.is_city_of_london_local_election and not postelection.past_registration_deadline and not postelection.cancelled %}
                     {% include "elections/includes/_city_of_london_registration_details.html" %}
                 {% endif %}
             </ul>

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -128,7 +128,7 @@
                                             <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
                                         {% endif %}
 
-                                        {% if is_before_registration_deadline %}
+                                        {% if show_global_registration_card %}
                                             <li><a href="#register">{% trans "Register to vote" %}</a></li>
                                         {% endif %}
                                     </ul>

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -86,7 +86,7 @@
                             <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
                         {% endif %}
 
-                        {% if is_before_registration_deadline %}
+                        {% if show_global_registration_card %}
                             <li><a href="#register">{% trans "Register to vote" %}</a></li>
                         {% endif %}
                     </ul>

--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -86,7 +86,7 @@
                             <li><a href="#requirements">{% trans "Voter ID requirements" %}</a></li>
                         {% endif %}
 
-                        {% if show_global_registration_card %}
+                        {% if global_registration_card.show %}
                             <li><a href="#register">{% trans "Register to vote" %}</a></li>
                         {% endif %}
                     </ul>

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -75,7 +75,7 @@
                         {% include "elections/includes/_voter_id.html" %}
                     {% endif %}
 
-                    {% if is_before_registration_deadline %}
+                    {% if show_global_registration_card %}
                         {% include "elections/includes/_registration_details.html" with postelection=postelections.0 council=council %}
                     {% endif %}
 

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -75,8 +75,8 @@
                         {% include "elections/includes/_voter_id.html" %}
                     {% endif %}
 
-                    {% if show_global_registration_card %}
-                        {% include "elections/includes/_registration_details.html" with postelection=postelections.0 council=council %}
+                    {% if global_registration_card.show %}
+                        {% include "elections/includes/_registration_details.html" with card=global_registration_card council=council %}
                     {% endif %}
 
                     {% if not messages %}

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -254,8 +254,6 @@ class TestPostcodeViewPolls:
             election__election_date="2024-05-06",
             election__name="Cities of London and Westminster by-election",
         )
-        parl_london.is_before_registration_deadline = True
-        local_london.is_before_registration_deadline = True
 
         mock_response.json.return_value["dates"].extend(
             [
@@ -374,8 +372,6 @@ class TestPostcodeViewPolls:
             post__territory="ENG",
         )
 
-        local.is_before_registration_deadline = True
-
         mock_response.json.return_value["dates"].extend(
             [
                 {
@@ -426,8 +422,6 @@ class TestPostcodeViewPolls:
             election__election_date="2021-05-06",
             post__territory="ENG",
         )
-
-        local.is_before_registration_deadline = True
 
         mock_response.json.return_value["dates"].extend(
             [
@@ -618,7 +612,7 @@ class TestPostcodeViewMethods:
 
     @freeze_time("2020-01-01")
     @pytest.mark.django_db
-    def test_is_before_registration_deadline(self, view_obj):
+    def test_show_global_registration_card(self, view_obj):
         post_elections = [
             PostElectionFactory(
                 election__slug="local.croydon.2020-05-06",
@@ -634,7 +628,7 @@ class TestPostcodeViewMethods:
             ),
         ]
         assert (
-            view_obj.is_before_registration_deadline(
+            view_obj.show_global_registration_card(
                 post_elections=post_elections
             )
             is True

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -621,13 +621,13 @@ class TestPostcodeViewMethods:
     def test_is_before_registration_deadline(self, view_obj):
         post_elections = [
             PostElectionFactory(
-                election__slug="local.city-of-london.2020-05-06",
+                election__slug="local.croydon.2020-05-06",
                 election__election_date="2020-05-06",
                 contested=True,
                 cancelled=False,
             ),
             PostElectionFactory(
-                election__slug="local.city-of-london.2020-05-06",
+                election__slug="local.croydon.2020-05-06",
                 election__election_date="2020-05-06",
                 contested=False,
                 cancelled=True,

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -612,27 +612,31 @@ class TestPostcodeViewMethods:
 
     @freeze_time("2020-01-01")
     @pytest.mark.django_db
-    def test_show_global_registration_card(self, view_obj):
+    def test_global_registration_card(self, view_obj):
         post_elections = [
             PostElectionFactory(
+                ballot_paper_id="local.croydon.wardname1.2020-05-06",
                 election__slug="local.croydon.2020-05-06",
                 election__election_date="2020-05-06",
                 contested=True,
                 cancelled=False,
+                post__territory="ENG",
             ),
             PostElectionFactory(
+                ballot_paper_id="local.croydon.wardname2.2020-05-06",
                 election__slug="local.croydon.2020-05-06",
                 election__election_date="2020-05-06",
                 contested=False,
                 cancelled=True,
+                post__territory="ENG",
             ),
         ]
-        assert (
-            view_obj.show_global_registration_card(
-                post_elections=post_elections
-            )
-            is True
+        card = view_obj.get_global_registration_card(
+            post_elections=post_elections
         )
+        assert card["show"] is True
+        assert card["registration_deadline"] == "20 April 2020"
+        assert card["election_date"] == "2020-05-06"
 
     def test_num_ballots_no_parish_election(self, view_obj, mocker):
         future_post_election = mocker.MagicMock(spec=PostElection, past_date=0)

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -177,7 +177,7 @@ class PollingStationInfoMixin(object):
         advance_voting_station["open_in_future"] = open_in_future
         return advance_voting_station
 
-    def show_global_registration_card(self, post_elections):
+    def get_global_registration_card(self, post_elections):
         # City of London local elections have different
         # registration rules to every other election
         non_city_of_london_ballots = [
@@ -188,8 +188,9 @@ class PollingStationInfoMixin(object):
 
         if not non_city_of_london_ballots:
             return False
-        election = non_city_of_london_ballots[0].election
-        country = non_city_of_london_ballots[0].post.territory
+        next_ballot = non_city_of_london_ballots[0]
+        election = next_ballot.election
+        country = next_ballot.post.territory
 
         if not country:
             country = Country.ENGLAND
@@ -202,7 +203,11 @@ class PollingStationInfoMixin(object):
             }.get(country)
         election = from_election_id(election_id=election.slug, country=country)
         event = TimetableEvent.REGISTRATION_DEADLINE
-        return election.is_before(event)
+        return {
+            "show": election.is_before(event),
+            "registration_deadline": next_ballot.registration_deadline,
+            "election_date": next_ballot.election.election_date,
+        }
 
 
 class LogLookUpMixin(object):

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -178,10 +178,18 @@ class PollingStationInfoMixin(object):
         return advance_voting_station
 
     def show_global_registration_card(self, post_elections):
-        if not post_elections:
+        # City of London local elections have different
+        # registration rules to every other election
+        non_city_of_london_ballots = [
+            ballot
+            for ballot in post_elections
+            if not ballot.election.is_city_of_london_local_election
+        ]
+
+        if not non_city_of_london_ballots:
             return False
-        election = post_elections[0].election
-        country = post_elections[0].post.territory
+        election = non_city_of_london_ballots[0].election
+        country = non_city_of_london_ballots[0].post.territory
 
         if not country:
             country = Country.ENGLAND

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -177,7 +177,7 @@ class PollingStationInfoMixin(object):
         advance_voting_station["open_in_future"] = open_in_future
         return advance_voting_station
 
-    def is_before_registration_deadline(self, post_elections):
+    def show_global_registration_card(self, post_elections):
         if not post_elections:
             return False
         election = post_elections[0].election

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -184,6 +184,7 @@ class PollingStationInfoMixin(object):
             ballot
             for ballot in post_elections
             if not ballot.election.is_city_of_london_local_election
+            and not ballot.cancelled
         ]
 
         if not non_city_of_london_ballots:

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -99,9 +99,9 @@ class PostcodeView(
         context["show_polling_card"] = self.show_polling_card(
             context["postelections"]
         )
-        context[
-            "show_global_registration_card"
-        ] = self.show_global_registration_card(context["postelections"])
+        context["global_registration_card"] = self.get_global_registration_card(
+            context["postelections"]
+        )
         context["people_for_post"] = {}
         for postelection in context["postelections"]:
             postelection.people = self.people_for_ballot(postelection)
@@ -406,8 +406,8 @@ class DummyPostcodeView(PostcodeView):
         context["show_polling_card"] = True
         context["polling_station"] = self.get_polling_station()
         context[
-            "show_global_registration_card"
-        ] = PostcodeView().show_global_registration_card(
+            "global_registration_card"
+        ] = PostcodeView().get_global_registration_card(
             context["postelections"]
         )
         context["registration"] = self.get_registration()

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -100,8 +100,8 @@ class PostcodeView(
             context["postelections"]
         )
         context[
-            "is_before_registration_deadline"
-        ] = self.is_before_registration_deadline(context["postelections"])
+            "show_global_registration_card"
+        ] = self.show_global_registration_card(context["postelections"])
         context["people_for_post"] = {}
         for postelection in context["postelections"]:
             postelection.people = self.people_for_ballot(postelection)
@@ -406,8 +406,8 @@ class DummyPostcodeView(PostcodeView):
         context["show_polling_card"] = True
         context["polling_station"] = self.get_polling_station()
         context[
-            "is_before_registration_deadline"
-        ] = PostcodeView().is_before_registration_deadline(
+            "show_global_registration_card"
+        ] = PostcodeView().show_global_registration_card(
             context["postelections"]
         )
         context["registration"] = self.get_registration()


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208540419887296/f

City of London has different registration rules to everywhere else in the country.
The point of this PR is to show people the correct "register to vote" information.
Before we started, "register to vote" was what I'm going to call "global" information: It is shown at the page level, not the ballot level.

The tradeoff I have decided to make here is to move it onto the ballot level for City of London Council elections.

In most cases (user is not in City Of London), we'll continue to just show one "global" gov.uk/register-to-vote card

If you're inside the City of London:
- If you have one City of London council election upcoming and nothing else, you'll see registration information on the ballot, but no global card
- If you have two City of London council elections upcoming, you'll see the same registration information duplicated on both ballots. This is sub-optimal, but sufficiently rare I think we can deal with it. You'd have to either have Common Councilman and Alderman elections both upcoming and before the registration deadline, or you'd have to have a by-election and scheduled election for the same ward both upcoming.
- If you have a City of London council election upcoming and also another ballot (e.g: Parliamentary or GLA election) you'll see City of London council registration information on the ballot and also the global gov.uk/register-to-vote card further down

I think this is probably a reasonable approach.

Out of scope for this PR is fixing the polling station opening times for City of London. Lets make that a second follow-up PR.

Screenshot (City of London):

![Screenshot 2024-10-28 at 16-05-14 City of London local election candidates in EC2Y 8BT](https://github.com/user-attachments/assets/931bb719-b987-43b3-9859-34efddac8bb6)

Screenshot (Everywhere else):

![Screenshot 2024-10-28 at 16-05-19 Somerset local election candidates in BA8 0DS](https://github.com/user-attachments/assets/1d164da1-29fa-4ff1-96c0-eca45a9c2c02)

I wasn't able to easily make an example with multiple City of London Council elections or a mix of City + GLA/Parl