### PR TITLE
Properly take territory_code from division or organisation

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -466,10 +466,8 @@ class YNRBallotImporter:
         if ballot.post.territory and not self.force_update:
             return
         ee_data = self.ee_helper.get_data(ballot.ballot_paper_id)
-        if ee_data and "organisation" in ee_data:
-            territory = ee_data["organisation"].get("territory_code", "-")
         if ee_data:
-            territory = ee_data.get("division", {}).get(
+            territory = (ee_data.get("division") or {}).get(
                 "territory_code",
                 ee_data["organisation"].get("territory_code", "-"),
             )


### PR DESCRIPTION
`ee_data.get("division")` can return `None`, so was failing for ballots with no division.

This change means we always default to an empty dict, and fall back to taking the territory_code from the organisation when there is no division.

Tested on the current set of elections that has ballots with no divisions.
