### PR TITLE
remove get_voter_id_requirements property

### DIFF
--- a/wcivf/apps/api/views.py
+++ b/wcivf/apps/api/views.py
@@ -96,7 +96,7 @@ class BaseCandidatesAndElectionsViewSet(
                 "voting_system": VotingSystemSerializer(
                     postelection.voting_system
                 ).data,
-                "requires_voter_id": postelection.get_voter_id_requirements,
+                "requires_voter_id": postelection.requires_voter_id,
                 "postal_voting_requirements": postelection.get_postal_voting_requirements,
                 "seats_contested": postelection.winner_count,
                 "organisation_type": postelection.post.organization_type,

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -16,7 +16,6 @@ from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from uk_election_ids.metadata_tools import (
-    IDRequirementsMatcher,
     PostalVotingRequirementsMatcher,
 )
 
@@ -711,16 +710,6 @@ class PostElection(TimeStampedModel):
         if self.cancellation_reason in ["CANDIDATE_DEATH"]:
             return False
         return True
-
-    @property
-    def get_voter_id_requirements(self):
-        try:
-            matcher = IDRequirementsMatcher(
-                self.ballot_paper_id, nation=self.post.territory
-            )
-            return matcher.get_id_requirements()
-        except Exception:
-            return None
 
     @property
     def get_postal_voting_requirements(self):

--- a/wcivf/apps/elections/tests/test_models.py
+++ b/wcivf/apps/elections/tests/test_models.py
@@ -456,10 +456,8 @@ class TestPostElectionModel:
 
     def test_metadata_tools(self, db):
         old_ballot = PostElectionFactory()
-        assert old_ballot.get_voter_id_requirements is None
         assert old_ballot.get_postal_voting_requirements == "RPA2000"
 
         newer_ballot = PostElectionFactory()
         newer_ballot.ballot_paper_id = "parl.place.2025-01-01"
-        assert newer_ballot.get_voter_id_requirements == "EA-2022"
         assert newer_ballot.get_postal_voting_requirements == "EA-2022"


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208687275764621/f

These two places in WCIVF where we are showing ID requirements are not doing the same thing
In the frontend, we are looking at the `PostElection.requires_voter_id` property
https://github.com/DemocracyClub/WhoCanIVoteFor/blob/afcd3c6a366d1a2a380088858643caa26e151759/wcivf/apps/elections/models.py#L420
This is a database field
In the API endpoint, we are looking at the `PostElection.get_voter_id_requirements` property
https://github.com/DemocracyClub/WhoCanIVoteFor/blob/afcd3c6a366d1a2a380088858643caa26e151759/wcivf/apps/elections/models.py#L715-L723
This function basically answers the same question, but it works it out from first principles using the election type and territory code.

In this PR I have removed `get_voter_id_requirements`. Everywhere now looks at `requires_voter_id`.