### PR TITLE
Remove unneeded line on ballot page

### DIFF
--- a/locale/cy/LC_MESSAGES/django.po
+++ b/locale/cy/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-09 15:05+0000\n"
+"POT-Creation-Date: 2024-12-18 12:44+0000\n"
 "PO-Revision-Date: 2022-03-24 09:04+0000\n"
 "Last-Translator: Sym Roe <sym@talusdesign.co.uk>, 2022\n"
 "Language-Team: Welsh (https://www.transifex.com/democracy-club/teams/61326/"
@@ -29,19 +29,19 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr "Rhowch eich côd post"
 
-#: wcivf/apps/elections/models.py:765
+#: wcivf/apps/elections/models.py:757
 msgid "First-past-the-post"
 msgstr "Y Cyntaf i’r Felin"
 
-#: wcivf/apps/elections/models.py:767
+#: wcivf/apps/elections/models.py:759
 msgid "Additional Member System"
 msgstr "Y System Aelodau Ychwanegol"
 
-#: wcivf/apps/elections/models.py:769
+#: wcivf/apps/elections/models.py:761
 msgid "Supplementary Vote"
 msgstr "Pleidlais Atodol"
 
-#: wcivf/apps/elections/models.py:771
+#: wcivf/apps/elections/models.py:763
 msgid "Single Transferable Vote"
 msgstr "Pleidlais Sengl Drosglwyddadwy"
 
@@ -519,20 +519,20 @@ msgstr "Eich gorsaf bleidleisio yw"
 msgid "<address>%(polling_station_address)s</address>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:57
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:58
 #, python-format
 msgid "It will be open from <strong>%(open_time)s to %(close_time)s</strong>"
 msgstr "Bydd ar agor o <strong>%(open_time)s tan %(close_time)s</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:65
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:67
 msgid "and"
 msgstr "a"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:74
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:76
 msgid "You don't need to take your poll card with you."
 msgstr "Nid oes angen i chi ddod â'ch cerdyn pleidleisio gyda chi."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:81
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:83
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
 "election day up to 10pm. When handing in postal votes, you will need to "
@@ -545,7 +545,7 @@ msgstr ""
 "faint o bleidleisiau post yr ydych yn eucyflwyno, a pham yr ydych yn "
 "cyflwyno'r pleidleisiau post hynny."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:91
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:93
 msgid ""
 "If you have a postal vote, you can hand it in at this polling station on "
 "election day up to 10pm."
@@ -553,18 +553,18 @@ msgstr ""
 "Os oes gennych bleidlais bost, gallwch ei chyflwyno yn yr orsaf bleidleisio "
 "hondiwrnod etholiad hyd at 10pm"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:95
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
 msgid ""
 "Postal votes cannot be accepted at polling stations in Northern Ireland."
 msgstr ""
 "Ni ellir derbyn pleidleisiau post mewn gorsafoedd pleidleisio yng Ngogledd "
 "Iwerddon."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:97
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:99
 msgid "Learn more about voting by post"
 msgstr "Dysgwch fwy am bleidleisio drwy'r post"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:100
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
 #, python-format
 msgid ""
 "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
@@ -573,7 +573,7 @@ msgstr ""
 "<p>Gallwch ddod o hyd i'ch gorsaf bleidleisio drwy <a "
 "href=\"%(custom_finder)s\"> ddilyn y ddolen hon</a>.</p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:108
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
@@ -582,7 +582,7 @@ msgstr ""
 "<strong>Bydd gorsafoedd pleidleisio ar agor o %(open_time)s tan "
 "%(close_time)s heddiw.</strong>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:113
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -593,14 +593,14 @@ msgstr ""
 "<a href=\"https://wheredoivote.co.uk/postcode/%(postcode)s/\">Gwiriwch yr "
 "orsaf bleidleisio gywir ar gyfer eich cyfeiriad&raquo;</a></p>"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:117
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:119
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 "Dylech dderbyn \"cerdyn pleidleisio\" drwy'r post yn dweud ble y dylech chi "
 "bleidleisio."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:120
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:122
 #, python-format
 msgid ""
 "If you haven't got one, or for questions about your poll card, polling "
@@ -612,7 +612,7 @@ msgstr ""
 "ffonio'r Swyddfa Cofrestru Etholiadol <a href=\"tel:"
 "%(council_phone)s\">%(council_phone)s</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:127
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:129
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
@@ -621,7 +621,7 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "%(council_name)s ar <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:134
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:136
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council."
@@ -629,25 +629,25 @@ msgstr ""
 "Os nad oes gennych chi un, neu ddim yn siŵr ble i bleidleisio, dylech ffonio "
 "eich cyngor lleol."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:142
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:144
 msgid "You will need photographic identification."
 msgstr "Bydd angen dull adnabod ffotograffig arnoch."
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:148
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:150
 msgid "Read more about how to vote in Northern Ireland"
 msgstr "Darllenwch fwy am sut i bleidleisio yng Ngogledd Iwerddon"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:152
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:154
 msgid "Read more about how to vote"
 msgstr "Darllenwch fwy am sut i bleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:161
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:163
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions"
 msgstr "Cael cyfarwyddiadau cerdded o"
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:165
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:167
 #, fuzzy
 #| msgid "Get walking directions from"
 msgid "Get directions from"
@@ -799,9 +799,10 @@ msgid ""
 "will be published after %(expected_sopn_date)s, when this page will be "
 "updated. You can help improve this page:"
 msgstr ""
-"Gallwch helpu i wella'r dudalen hon:Ni wyddwn am unrhyw ymgeiswyr sy'n "
+"Ni wyddwn am unrhyw ymgeiswyr sy'n "
 "sefyll eto. Bydd y rhestr swyddogol o ymgeiswyr yn cael ei chyhoeddi ar ôl "
-"%(expected_sopn_date)s, pan fydd y dudalen hon yn cael ei diweddaru."
+"%(expected_sopn_date)s, pan fydd y dudalen hon yn cael ei diweddaru. "
+"Gallwch helpu i wella'r dudalen hon:"
 
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
 msgid ""
@@ -887,8 +888,7 @@ msgstr ""
 #| "candidates to our database</a>."
 msgid ""
 "The official candidate list will be published after %(expected_sopn_date)s, "
-"when this page will be updated. Once nomination papers are published, we "
-"will manually verify each candidate. You can help improve this page: <a "
+"when this page will be updated. You can help improve this page: <a "
 "href=\"%(ynr_link)s\"> add information about candidates to our database</a>."
 msgstr ""
 "Bydd y rhestr ymgeiswyr swyddogol yn cael ei chyhoeddi ar ôl "
@@ -896,47 +896,47 @@ msgstr ""
 "helpu i wella'r dudalen hon: <a href=\"%(ynr_link)s\"> ychwanegu gwybodaeth "
 "ymgeisydd i'n cronfa ddata</a>."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:169
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:168
 msgid "Read the official candidate booklet for this election."
 msgstr "Darllenwch y llyfryn ymgeiswyr swyddogol ar gyfer yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:179
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
 msgid "Electorate"
 msgstr "Nifer etholwyr"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:186
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:185
 msgid "Ballot Papers Issued"
 msgstr "Bapurau pleidleisio"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:193
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:192
 msgid "Spoilt Ballots"
 msgstr "Nifer y bleidleisiau a ddifethwyd"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:200
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:199
 msgid "Turnout"
 msgstr "Cyfrif pleidleisiau"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:223
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:222
 #, fuzzy
 #| msgid "The official candidate list should have been published on"
 msgid "The official candidate list should have been published after"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr fod wedi'i chyhoeddi ar "
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:225
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:224
 #, fuzzy
 #| msgid "The official candidate list should be published on"
 msgid "The official candidate list should be published after"
 msgstr "Dylai'r rhestr swyddogol o ymgeiswyr gael ei chyhoeddi ar"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:236
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:235
 msgid "Can you vote in this election?"
 msgstr "A allwch chi bleidleisio yn yr etholiad hwn?"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:237
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:236
 msgid "Age"
 msgstr "Oedran"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:239
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:238
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
@@ -945,16 +945,16 @@ msgstr ""
 "Mae angen i chi fod dros %(voter_age)s ar %(voter_age_date)s "
 "%(election_date)s i bleidleisio yn yr etholiad hwn."
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:244
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:243
 msgid "Citizenship"
 msgstr "Dinasyddiaeth"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:260
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:259
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:7
 msgid "Wikipedia"
 msgstr "Wikipedia"
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:262
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:261
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Read more on Wikipedia"
 msgstr "Darllenwch fwy ar Wikipedia"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -716,8 +716,7 @@ msgstr ""
 #, python-format
 msgid ""
 "The official candidate list will be published after %(expected_sopn_date)s, "
-"when this page will be updated. Once nomination papers are published, we "
-"will manually verify each candidate. You can help improve this page: <a "
+"when this page will be updated. You can help improve this page: <a "
 "href=\"%(ynr_link)s\"> add information about candidates to our database</a>."
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-08 10:36+0100\n"
+"POT-Creation-Date: 2024-12-18 12:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,19 +22,19 @@ msgstr ""
 msgid "Enter your postcode"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:756
+#: wcivf/apps/elections/models.py:757
 msgid "First-past-the-post"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:758
+#: wcivf/apps/elections/models.py:759
 msgid "Additional Member System"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:760
+#: wcivf/apps/elections/models.py:761
 msgid "Supplementary Vote"
 msgstr ""
 
-#: wcivf/apps/elections/models.py:762
+#: wcivf/apps/elections/models.py:763
 msgid "Single Transferable Vote"
 msgstr ""
 
@@ -237,6 +237,43 @@ msgstr ""
 msgid "Read more"
 msgstr ""
 
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:7
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:10
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:141
+#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:90
+msgid "Register to vote"
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:11
+msgid ""
+"City of London council elections do not use the same electoral register as "
+"other elections."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:16
+msgid ""
+"Both residents and city workers are eligible to vote. There is one register "
+"published annually, and the deadline to apply is 30 November each year. The "
+"new register comes into force on 16 February each year, and cannot be "
+"modified after that date. For more information, visit the <a href=\"https://"
+"www.speakforthecity.com/\">Speak for the City</a> website or contact City of "
+"London electoral services."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_city_of_london_registration_details.html:27
+msgid ""
+"For questions about your poll card, polling place, or about returning your "
+"postal voting ballot, contact your council."
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_contact_details_registration.html:5
+msgid "Electoral Registration"
+msgstr ""
+
+#: wcivf/apps/elections/templates/elections/includes/_contact_details_registration.html:7
+msgid "Your Local Council"
+msgstr ""
+
 #: wcivf/apps/elections/templates/elections/includes/_elections_breadcrumbs.html:3
 #: wcivf/apps/parties/templates/parties/parties_view.html:9
 msgid "You are here"
@@ -360,7 +397,7 @@ msgid "Photo of %(person_name)s"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:9
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:124
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:133
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:82
 msgid "Where to vote"
 msgstr ""
@@ -399,24 +436,17 @@ msgid "Vote on polling day"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:51
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:103
 msgid "Your polling station is"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:53
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:105
 #, python-format
 msgid "<address>%(polling_station_address)s</address>"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:58
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
-msgid "It will be open from <strong>8am to 8pm</strong>."
-msgstr ""
-
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:60
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:112
-msgid "It will be open from <strong>7am to 10pm</strong>."
+#, python-format
+msgid "It will be open from <strong>%(open_time)s to %(close_time)s</strong>"
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_polling_place.html:67
@@ -450,21 +480,21 @@ msgstr ""
 msgid "Learn more about voting by post"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:118
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:102
 #, python-format
 msgid ""
 "<p>You can find your polling station by <a href=\"%(custom_finder)s\"> "
 "following this link</a>. </p>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:126
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:110
 #, python-format
 msgid ""
 "<strong>Polling stations are open from %(open_time)s till %(close_time)s "
 "today.</strong>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:131
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:115
 #, python-format
 msgid ""
 "<p>Your polling station in %(postcode)s depends on your address. <a "
@@ -472,12 +502,12 @@ msgid ""
 "polling station for your address &raquo;</a></p>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:135
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:119
 msgid ""
 "You should get a \"poll card\" through the post telling you where to vote."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:138
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:122
 #, python-format
 msgid ""
 "If you haven't got one, or for questions about your poll card, polling "
@@ -486,36 +516,36 @@ msgid ""
 "%(council_phone)s\">%(council_phone)s</a>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:163
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:129
 #, python-format
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call "
 "%(council_name)s on <a href=\"tel:%(council_phone)s\">%(council_phone)s</a>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:187
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:136
 msgid ""
 "If you haven't got one, or aren't sure where to vote, you should call your "
 "local council."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:195
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:144
 msgid "You will need photographic identification."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:201
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:150
 msgid "Read more about how to vote in Northern Ireland"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:205
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:154
 msgid "Read more about how to vote"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:214
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:163
 msgid "Get directions"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:218
+#: wcivf/apps/elections/templates/elections/includes/_polling_place.html:167
 msgid "Get directions from"
 msgstr ""
 
@@ -562,7 +592,7 @@ msgid ""
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_postcode_search_form.html:11
-#: wcivf/templates/home.html:33
+#: wcivf/templates/home.html:25
 msgid "Find your candidates"
 msgstr ""
 
@@ -577,12 +607,6 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:10
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:132
-#: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:90
-msgid "Register to vote"
-msgstr ""
-
 #: wcivf/apps/elections/templates/elections/includes/_registration_details.html:15
 msgid ""
 "You need to be registered in order to vote. If you aren't registered to vote "
@@ -590,17 +614,18 @@ msgid ""
 "register-to-vote </a>"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:25
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:24
 #, python-format
 msgid ""
 "Register before midnight on %(registration_deadline)s to vote on "
 "%(election_date)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:32
+#: wcivf/apps/elections/templates/elections/includes/_registration_details.html:30
 msgid ""
-"For questions about your poll card, polling place, or about returning your "
-"postal voting ballot, contact your council."
+"Send your postal and proxy vote applications to your local electoral "
+"registration team. You can also contact them to find out if you’re on the "
+"electoral register, and if you already have a postal or proxy vote."
 msgstr ""
 
 #: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:19
@@ -619,33 +644,33 @@ msgstr ""
 msgid "This election will be held <strong>%(election_date)s</strong>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:55
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:57
 msgid "About this position"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:59
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:61
 #, python-format
 msgid " %(description)s"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:66
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:75
 #, python-format
 msgid ""
 "<strong>%(num_candidates)s candidate%(plural)s</strong> stood in the "
 "%(postelection)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:71
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:80
 msgid ""
 "We don't know of any candidates standing yet. You can help improve this page:"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:72
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:83
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:81
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:92
 msgid "add information about candidates to our database"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:77
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:86
 #, python-format
 msgid ""
 "We don't know of any candidates standing yet. The official candidate list "
@@ -653,13 +678,13 @@ msgid ""
 "updated. You can help improve this page:"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:89
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
 msgid ""
 "You will have one vote, and can vote for a single party list or independent "
 "candidate."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:92
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:101
 #, python-format
 msgid ""
 "You will have <strong>%(winner_count)s vote%(plural)s</strong>, and can "
@@ -667,52 +692,52 @@ msgid ""
 "strong>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:98
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:107
 #, python-format
 msgid ""
 "You will have <strong>one vote</strong>, and can choose from "
 "<strong>%(num_ballots)s</strong> in the %(postelection)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:103
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:112
 #, python-format
 msgid ""
 "You will have <strong>two votes</strong>, and can choose from "
 "<strong>%(num_ballots)s</strong> in the %(postelection)s."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:110
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:119
 #, python-format
 msgid ""
 "There is <strong>one seat</strong>  up for election, and you can choose from "
 "<strong>%(num_ballots)s</strong>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:114
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:123
 #, python-format
 msgid ""
 "There are <strong>%(winner_count)s seats</strong>  up for election, and you "
 "can choose from <strong>%(num_ballots)s</strong>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:121
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:130
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:79
 msgid "Get ready to vote"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:128
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:137
 #: wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html:86
 msgid "Voter ID requirements"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:140
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:149
 #, python-format
 msgid ""
 "We are currently aware of %(num_candidates)s candidate%(plural_candidates)s "
 "for this position."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:144
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:153
 #, python-format
 msgid ""
 "The official candidate list will be published after %(expected_sopn_date)s, "
@@ -720,59 +745,59 @@ msgid ""
 "href=\"%(ynr_link)s\"> add information about candidates to our database</a>."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:160
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:168
 msgid "Read the official candidate booklet for this election."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:170
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:178
 msgid "Electorate"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:177
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:185
 msgid "Ballot Papers Issued"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:184
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:192
 msgid "Spoilt Ballots"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:191
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:199
 msgid "Turnout"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:214
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:222
 msgid "The official candidate list should have been published after"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:216
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:224
 msgid "The official candidate list should be published after"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:227
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:235
 msgid "Can you vote in this election?"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:228
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:236
 msgid "Age"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:230
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:238
 #, python-format
 msgid ""
 "You need to be over %(voter_age)s on the %(voter_age_date)s of "
 "%(election_date)s in order to vote in this election."
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:235
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:243
 msgid "Citizenship"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:254
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:259
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:7
 msgid "Wikipedia"
 msgstr ""
 
-#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:256
+#: wcivf/apps/elections/templates/elections/includes/_single_ballot.html:261
 #: wcivf/apps/people/templates/people/includes/_person_about_card.html:9
 msgid "Read more on Wikipedia"
 msgstr ""
@@ -1045,35 +1070,35 @@ msgstr ""
 msgid "Submit event"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:6
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:7
 #: wcivf/apps/hustings/templates/hustings/includes/_person.html:4
 msgid "Election events"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:9
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:10
 msgid ""
 "You can meet candidates and question them at events (often known as "
 "'hustings'). Here are some events that are taking place:"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:12
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:13
 msgid "Events are reported by users, if you spot an error, please"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:13
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:14
 msgid "get in touch"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:17
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:18
 msgid "Do you know about any other events in the area? If so, please"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:18
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:26
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:19
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:27
 msgid "tell us about them"
 msgstr ""
 
-#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:24
+#: wcivf/apps/hustings/templates/hustings/includes/_ballot.html:25
 msgid "Do you know about any events (often known as 'hustings')? If so, please"
 msgstr ""
 
@@ -1697,7 +1722,7 @@ msgid ""
 "policies in the %(party_name)s manifesto."
 msgstr ""
 
-#: wcivf/apps/people/templates/people/includes/_person_manifesto_card.html:33
+#: wcivf/apps/people/templates/people/includes/_person_manifesto_card.html:30
 #, python-format
 msgid "'%(party_name)s' emblem"
 msgstr ""
@@ -2258,52 +2283,52 @@ msgstr ""
 msgid "Who Can I Vote For?"
 msgstr ""
 
-#: wcivf/templates/home.html:18
+#: wcivf/templates/home.html:12
 msgid "Find out about candidates in your area"
 msgstr ""
 
-#: wcivf/templates/home.html:28
+#: wcivf/templates/home.html:20
 #, python-format
 msgid ""
 "Sorry, we don't know the postcode %(postcode)s. Is there another one you can "
 "try?"
 msgstr ""
 
-#: wcivf/templates/home.html:78
+#: wcivf/templates/home.html:32
 msgid "Photographic identification"
 msgstr ""
 
-#: wcivf/templates/home.html:80
+#: wcivf/templates/home.html:34
 msgid ""
 "Photographic identification will be required to vote in English local "
 "elections, and parliamentary elections across the UK, on and after 4 May "
 "2023."
 msgstr ""
 
-#: wcivf/templates/home.html:82
+#: wcivf/templates/home.html:36
 msgid ""
 "Learn more about photographic identification for voters on the website of "
 "the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:82
+#: wcivf/templates/home.html:36
 msgid "Learn more on the website of the Electoral Commission."
 msgstr ""
 
-#: wcivf/templates/home.html:85
+#: wcivf/templates/home.html:39
 msgid ""
 "You can apply for a free 'Voter Authority Certificate' if you do not already "
 "possess a valid ID."
 msgstr ""
 
-#: wcivf/templates/home.html:87
+#: wcivf/templates/home.html:41
 msgid "Apply for free voter ID."
 msgstr ""
 
-#: wcivf/templates/home.html:89
+#: wcivf/templates/home.html:43
 msgid "You do not need photo ID to vote by post."
 msgstr ""
 
-#: wcivf/templates/home.html:93
+#: wcivf/templates/home.html:47
 msgid "Upcoming Elections"
 msgstr ""

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -152,7 +152,6 @@
 
                                 {% blocktrans trimmed with expected_sopn_date=postelection.expected_sopn_date|date:"j F Y" ynr_link=postelection.ynr_link %}
                                     The official candidate list will be published after {{expected_sopn_date}}, when this page will be updated.
-                                    Once nomination papers are published, we will manually verify each candidate.
                                     You can help improve this page: <a href="{{ ynr_link }}">
                                         add information about candidates to our database</a>.
                                 {% endblocktrans %}

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -203,10 +203,6 @@ class ElectionPostViewTests(TestCase):
         pre_sopn_text_2 = """The official candidate list will be published after 10 April 2024, when this page will be updated."""
         self.assertContains(response, pre_sopn_text_1)
         self.assertContains(response, pre_sopn_text_2)
-        self.assertContains(
-            response,
-            """Once nomination papers are published, we will manually verify each candidate.""",
-        )
 
     def test_zero_candidates(self):
         response = self.client.get(


### PR DESCRIPTION
I thought we had removed this, but clearly not. This sentence isn't needed as it essentially repeats the one preceding it.
