### PR TITLE
Fix BlueSky embed images

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -430,6 +430,7 @@ Resources:
               - Authorization
               - Origin
               - Referer
+              - CloudFront-Forwarded-Proto
           ViewerProtocolPolicy: "redirect-to-https"
 
         CacheBehaviors:

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -77,6 +77,8 @@ CSRF_TRUSTED_ORIGINS = [
     f"https://{os.environ.get('FQDN')}",
 ]
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_CLOUDFRONT_FORWARDED_PROTO", "https")
+
 SITE_ID = 1
 
 # Application definition


### PR DESCRIPTION
Refs https://app.asana.com/0/1204880927741389/1208998713208653/f

OK, so this one is a real "..and the knee bone's connected to the leg bone" situation, but stick with me here.

The actual top-level problem we're trying to solve here is: BlueSky embedds are all blurry.

My _theory_ on this (unproven) is: The `og:image` and `twitter:image` tags are pointing to a http:// link instead of a https:// one (even if you are looking at https://whocanivotefor.co.uk/ ) and bluesky is choosing to ignore them, preferring an image which is served over https.

Here's an image showing this issue:

![Screenshot at 2025-01-15 15-19-56](https://github.com/user-attachments/assets/fe7c6552-2521-48ae-ac72-aab49cc73320)

So as a first step, lets see if we can fix that and then see if that fixes the embeds.

But first off.. why is that happening?
At first glance, it would seem that this should be doing the right thing:
https://github.com/DemocracyClub/WhoCanIVoteFor/blob/b3f590a31516dfc6a3cf8eb268505e20db973eb5/wcivf/apps/core/context_processors.py#L7-L8

Theory number 2: In production we're effectively sitting behind a proxy. The thing that actually performs the TLS termination is CloudFront. The CloudFront talks to the load balancer over straight HTTP. So from the server's perspective, in production this incoming request is HTTP.

Fortunately there's a way we can fix this, which is Django's `SECURE_PROXY_SSL_HEADER`. We can use this to tell Django's `HttpRequest.scheme` method to return `https` if a particular header is set.

https://github.com/django/django/blob/6cfe00ee438111af38f1e414bd01976e23b39715/django/http/request.py#L289-L303

We can tell CloudFront to set a `CloudFront-Forwarded-Proto` header, which the user can't spoof and use that.

..so then finally if we unwind all of that back to the original point: Hopefully that will make the image not blurry 🙃 😂

I've deployed this to staging (now reverted) and checked this makes all the links resolve to HTTPS, which wants fixing anyway. I've not confirmed what happens if we post a link to WCIVF and view the preview through the masto --> bluesky bridge though.

Then if it does work we need to individually do this on every application we host because all of them will have the same problem. Yay