### PR TITLE
render whitespace in cancelled election details

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_cancelled_election.html
@@ -47,7 +47,7 @@
 {% else %}
     {% if object.metadata.cancelled_election %}
         <h4>{{ object.metadata.cancelled_election.title }}</h4>
-        <p>{{ object.metadata.cancelled_election.detail }}</p>
+        {{ object.metadata.cancelled_election.detail | linebreaks }}
     {% else %}
         <h4>{% trans "Cancelled Election" %}</h4>
         <p>{% trans "This election was cancelled." %}</p>


### PR DESCRIPTION
Refs https://app.asana.com/0/1209332771640377/1209290265508276/f
Refs https://app.asana.com/0/1209332771640377/1209332771640386/f

I've already edited the descriptions in EE to already include line breaks in the right places.

Just a small change here as the handling of cancelled elections is already pretty good.