### PR TITLE
Fix/change candidate edit details

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -243,6 +243,23 @@ class Person(models.Model):
         return any(getattr(self, vt, False) for vt in VALUE_TYPES_TO_IMPORT)
 
     @property
+    def has_social_media_account(self):
+        """
+        Do we have any social media accounts for this person?
+        """
+        social_media = [
+            "twitter_username",
+            "facebook_username",
+            "instagram_username",
+            "linkedin_username",
+            "mastodon_username",
+            "tiktok_url",
+            "threads_url",
+            "blue_sky_url",
+        ]
+        return any(getattr(self, sm, False) for sm in social_media)
+
+    @property
     def get_max_facebook_ad_spend(self):
         return round(
             sum(

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -243,17 +243,6 @@ class Person(models.Model):
         return any(getattr(self, vt, False) for vt in VALUE_TYPES_TO_IMPORT)
 
     @property
-    def cta_example_details(self):
-        attrs = (
-            ("cv", "CV"),
-            ("statement_to_voters", "statement to voters"),
-            ("email", "email"),
-            ("homepage_url", "homepage"),
-            ("twitter_username", "twitter account"),
-        )
-        return [a[1] for a in attrs if not getattr(self, a[0], False)]
-
-    @property
     def get_max_facebook_ad_spend(self):
         return round(
             sum(

--- a/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
@@ -8,7 +8,9 @@
   </p>
   <p>
     {% trans 'If you can add information to this page' %}
-    {% blocktrans trimmed with person=object.name %}- such as {{ person }}'s policy statement or contact information -{% endblocktrans %}
+    {% blocktrans trimmed with person=object.name%} - such as {{ person }}'s {% endblocktrans %}
+    {% if not object.has_social_media_accounts %} {% trans "social media accounts," %}{% endif %}
+    {% trans "policy statement or contact information -"%}
     {% trans 'please use our crowdsourcing website.' %}
   </p>
   <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">{% trans 'Add or edit details &raquo;' %}</a>

--- a/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
@@ -2,24 +2,20 @@
 {% load i18n %}
 
 {% if object.current_or_future_candidacies %}
-    <h2 class="ds-h3">{% trans "That's all we know! Will you help us find more about this candidate?" %}</h2>
-    <p>{% trans "Our volunteers have been working hard to add information on as many candidates as possible, but they need help." %}</p>
-    <p>
-        {% trans "If you can add information that should be on this page" %}
+  <h2 class="ds-h3">{% trans "That's all we know! Will you help us find more about this candidate?" %}</h2>
+  <p>
+    {% trans 'Our volunteers have been working hard to add information on as many candidates as possible, but they need help.' %}
+  </p>
+  <p>
+    {% trans 'If you can add information that should be on this page' %}
+    {% blocktrans trimmed with person=object.name %}- such as {{ person }}'s policy statement or contact information -{% endblocktrans %}
+    {% trans 'please use our crowdsourcing website to add it.' %}
+  </p>
+  <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">{% trans 'Add or edit details &raquo;' %}</a>
 
-        {% if object.cta_example_details %}
-            {% blocktrans trimmed with person=object.name cta=object.cta_example_details|join:", "%}- such as {{ person }}'s
-                {{ cta }} - {% endblocktrans %}
-        {% endif %}
-        {% trans "please use our crowdsourcing website to add it." %}
-    </p>
-    <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">
-        {% trans "Add or edit details &raquo;" %}
-    </a>
-
-    {#    <h4>Upload your leaflets</h4>#}
-    {#    <p>If you've received election leaflets from {{ object.name }}, please take a photo#}
-    {#      of them and upload them to ElectionLeaflets.org</p>#}
-    {#    <p><a class="ds-button ds-cta ds-cta-blue" type="button" href="https://electionleaflets.org/">Add leaflets</a>#}
-    {#    </p>#}
+  {# <h4>Upload your leaflets</h4> #}
+  {# <p>If you've received election leaflets from {{ object.name }}, please take a photo #}
+  {# of them and upload them to ElectionLeaflets.org</p> #}
+  {# <p><a class="ds-button ds-cta ds-cta-blue" type="button" href="https://electionleaflets.org/">Add leaflets</a> #}
+  {# </p> #}
 {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
@@ -7,9 +7,9 @@
     {% trans 'Our volunteers have been working hard to add information on as many candidates as possible, but they need help.' %}
   </p>
   <p>
-    {% trans 'If you can add information that should be on this page' %}
+    {% trans 'If you can add information to this page' %}
     {% blocktrans trimmed with person=object.name %}- such as {{ person }}'s policy statement or contact information -{% endblocktrans %}
-    {% trans 'please use our crowdsourcing website to add it.' %}
+    {% trans 'please use our crowdsourcing website.' %}
   </p>
   <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">{% trans 'Add or edit details &raquo;' %}</a>
 

--- a/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_edit_details_card.html
@@ -15,9 +15,10 @@
   </p>
   <a href="{{ object.get_ynr_url }}update/" class="ds-cta ds-cta-blue">{% trans 'Add or edit details &raquo;' %}</a>
 
-  {# <h4>Upload your leaflets</h4> #}
-  {# <p>If you've received election leaflets from {{ object.name }}, please take a photo #}
-  {# of them and upload them to ElectionLeaflets.org</p> #}
-  {# <p><a class="ds-button ds-cta ds-cta-blue" type="button" href="https://electionleaflets.org/">Add leaflets</a> #}
-  {# </p> #}
+  <h3 class="ds-h4">{% trans 'Upload your leaflets' %}</h3>
+  <p>
+    {% blocktrans trimmed with person=object.name%} If you've received election leaflets from {{ person }}, please take a photo
+      of them and upload them to ElectionLeaflets.org {% endblocktrans %}
+  </p>
+  <a href="https://electionleaflets.org/" class="ds-cta ds-cta-blue">{% trans 'Add leaflets &raquo;' %}</a>
 {% endif %}


### PR DESCRIPTION
If we don't have a social media account yet the message will appear as:
![image](https://github.com/user-attachments/assets/5d69d896-29f7-4d92-92ba-c1d4f0392a6f)

If we do have a social media account:
![image](https://github.com/user-attachments/assets/0f1476b6-1973-4977-81de-29cc0ef6b8ac)


Social media values that we're checking for :
- twitter_username
- facebook_username
- instagram_username
- linkedin_username
- mastodon_username
- tiktok_url
- threads_url
- blue_sky_url

