### PR TITLE
Fix/remove parish messaging for ni and lnd

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
+++ b/wcivf/apps/elections/templates/elections/includes/inline_elections_nav_list.html
@@ -99,6 +99,8 @@
         {% if referendums %}
             {% include 'referendums/includes/_list.html' with referendums=referendums %}
         {% endif %}
-        <p>{% trans "There may also be parish, town or community council elections in some areas." %}</p>
+        {% if show_parish_text %}
+            <p>{% trans "There may also be parish, town or community council elections in some areas." %}</p>
+        {% endif %}
     {% endif %}
 </div>

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -864,6 +864,27 @@ class TestPostcodeViewMethods:
         }
         assert view_obj.get_voter_id_status() is None
 
+    def test_show_parish_text_true(self, view_obj):
+        view_obj.postcode = "s11 8qe"
+        council_context = {"identifiers": ["code"]}
+        assert view_obj.show_parish_text(council_context) is True
+
+    @pytest.mark.parametrize(
+        "ni_postcodes", ["BT1 1AA", "BT93 8AD", "BT60 4PU"]
+    )
+    def test_show_parish_text_false_for_NI_postcodes(
+        self, ni_postcodes, view_obj
+    ):
+        view_obj.postcode = ni_postcodes
+        council_context = {"identifiers": ["code"]}
+        assert view_obj.show_parish_text(council_context) is False
+
+    @pytest.mark.parametrize("lnd_gss", ["E09000011", "E09000012", "E09000013"])
+    def test_show_parish_text_false_for_lnd_boroughs(self, lnd_gss, view_obj):
+        view_obj.postcode = "postcode"
+        council_context = {"identifiers": [lnd_gss]}
+        assert view_obj.show_parish_text(council_context) is False
+
 
 class TestPostcodeiCalView:
     def test_invalid_postcode_redirects(self, mocker, client):

--- a/wcivf/apps/elections/tests/test_postcode_views.py
+++ b/wcivf/apps/elections/tests/test_postcode_views.py
@@ -154,7 +154,7 @@ class TestPostcodeViewPolls:
         response.json.return_value = {
             "address_picker": False,
             "dates": [],
-            "electoral_services": {},
+            "electoral_services": {"identifiers": ["code"]},
             "registration": {},
         }
         mocker.patch(

--- a/wcivf/apps/elections/views/postcode_view.py
+++ b/wcivf/apps/elections/views/postcode_view.py
@@ -127,6 +127,7 @@ class PostcodeView(
         context["parish_council_election"] = self.get_parish_council_election()
         context["num_ballots"] = self.num_ballots()
         context["requires_voter_id"] = self.get_voter_id_status()
+        context["show_parish_text"] = self.show_parish_text(context["council"])
 
         return context
 
@@ -279,6 +280,22 @@ class PostcodeView(
             if not ballot.cancelled and (voter_id := ballot.requires_voter_id):
                 return voter_id
         return None
+
+    def show_parish_text(self, council):
+        """
+        Returns True if the postcode isn't in London and Northern Ireland. We don't want
+        to show the parish council text in these areas because they don't have them.
+        """
+        # all NI postcodes start with BT
+        if self.postcode.startswith("BT"):
+            return False
+        # All London borough GSS codes start with E09
+        if any(
+            identifier.startswith("E09")
+            for identifier in council["identifiers"]
+        ):
+            return False
+        return True
 
 
 class PostcodeiCalView(


### PR DESCRIPTION
Makes text relating to parish councils not appear for users in NI or London.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209494648137473