### PR TITLE
remove trailing slashes before extracting linkedin username

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -290,8 +290,7 @@ class Person(models.Model):
 
     @property
     def linkedin_username(self):
-        linkedin_url = self.linkedin_url
-        return urlparse(linkedin_url).path.split("/")[-2]
+        return urlparse(self.linkedin_url.rstrip("/")).path.split("/")[-1]
 
     @property
     def youtube_username(self):

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -52,8 +52,14 @@ class TestPersonModel(TestCase):
         assert self.person.instagram_username == "vickyfordmp"
 
     def test_linkedin_username(self):
+        # Trailing slash
         self.person.linkedin_url = "https://www.linkedin.com/in/vicky-ford/"
         assert self.person.linkedin_username == "vicky-ford"
+        # No trailing slash
+        self.person.linkedin_url = (
+            "https://uk.linkedin.com/in/marianne-overton-mbe-54b88917"
+        )
+        assert self.person.linkedin_username == "marianne-overton-mbe-54b88917"
 
     def test_youtube_username(self):
         self.person.youtube_profile = (


### PR DESCRIPTION
A quick fix for linkedin usernames that should mean we display the correct part of the url path regardless of whether there is a trailing slash or not.

Before we would get something like below if the linkedin_url had no trailing slash.:
![image](https://github.com/user-attachments/assets/c4047cf6-c886-4106-9026-42e2f57d5baf)
Now it should display properly.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209796823053715