### PR TITLE
Post to Slack daily

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -162,7 +162,7 @@ Resources:
         BatchFeedbackToSlack:
           Type: Schedule
           Properties:
-            Schedule: cron(0 9 ? * FRI *) # using the ? as you cannot use * wildcard for both day-of-month and day-of-week field. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions
+            Schedule: cron(0 9 ? * * *) # using the ? as you cannot use * wildcard for both day-of-month and day-of-week field. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions
             Name: batch-feedback-to-slack
             Description: Send feedback entries for the last week to slack
             Input: '{"command": "batch_feedback_to_slack", "args": ["--hours=24"]}'


### PR DESCRIPTION
Post to Slack daily. 

I noticed when I was there that we never incensed the `--hours=24` arg to the command, so we've only been posting feedback on a Friday for the previous 24 hours. 

This is what we want now, but we need to make sure we bump the hours up when we go back to Friday posting after the elections.