### PR TITLE
Refactor/always import current metadata

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -188,7 +188,6 @@ class YNRBallotImporter:
         current_only=False,
         exclude_candidacies=False,
         force_metadata=False,
-        force_current_metadata=False,
         recently_updated=False,
         base_url=None,
         api_key=None,
@@ -203,7 +202,6 @@ class YNRBallotImporter:
         self.current_only = current_only
         self.exclude_candidacies = exclude_candidacies
         self.force_metadata = force_metadata
-        self.force_current_metadata = force_current_metadata
         self.recently_updated = recently_updated
         self.base_url = base_url or settings.YNR_BASE
         self.api_key = api_key or settings.YNR_API_KEY
@@ -493,12 +491,6 @@ class YNRBallotImporter:
             ballot.save()
 
     def set_metadata(self, ballot):
-        if (
-            not self.force_current_metadata
-            and not self.force_update
-            and ballot.metadata
-        ):
-            return
         ee_data = self.ee_helper.get_data(ballot.ballot_paper_id)
         if ee_data:
             ballot.metadata = ee_data["metadata"]

--- a/wcivf/apps/elections/management/commands/import_ballots.py
+++ b/wcivf/apps/elections/management/commands/import_ballots.py
@@ -31,13 +31,6 @@ class Command(BaseCommand):
             help="Imports all metadata from EE for all elections",
         )
         parser.add_argument(
-            "--force-current-metadata",
-            action="store_true",
-            dest="force_current_metadata",
-            default=False,
-            help="Imports all metadata from EE for current elections",
-        )
-        parser.add_argument(
             "--recently-updated",
             action="store_true",
             dest="recently_updated",
@@ -90,7 +83,6 @@ class Command(BaseCommand):
             stdout=self.stdout,
             current_only=options["current"],
             force_metadata=options["force_metadata"],
-            force_current_metadata=options["force_current_metadata"],
             recently_updated=options["recently_updated"],
             exclude_candidacies=options["exclude_candidacies"],
         )


### PR DESCRIPTION
This PR addresses an issue we were having where updating metadata objects on EE wasn't propagating to WCIVF.

 The problem was that we wouldn't update metadata objects if a ballot on WCIVF already had one. However, this PR goes further so that now we always import metadata objects for current ballots. 



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209387104787681