### PR TITLE
Show local party manifestos

### DIFF
--- a/wcivf/apps/people/templates/people/person_detail.html
+++ b/wcivf/apps/people/templates/people/person_detail.html
@@ -42,7 +42,7 @@
 
         {% include "people/includes/_person_policy_card.html" %}
 
-        {% if object.show_national_manifesto and not object.deselected %}
+        {% if object.current_or_future_candidacies and not object.deselected %}
             {% include "people/includes/_person_manifesto_card.html" with party=object.national_party party_name=object.national_party.name %}
         {% endif %}
 


### PR DESCRIPTION
This change was made for the general election. 

We need to figure this logic out better at some point, but I'm not going to open that can of worms today. For now, this just shows the manifesto if we have one. 