### PR TITLE
list current but past elections

### DIFF
--- a/wcivf/apps/people/templates/people/includes/_person_intro_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_intro_card.html
@@ -11,22 +11,10 @@
         Past elections will appear in the table below. 
         {% endcomment %}
         {% if object.future_candidacies.all.count > 1 %}
-            <h5>{{ object.name }}
-                {% blocktrans trimmed with party_name=object.future_candidacies.0.party_name a_or_an=object.future_candidacies.0.party.is_independent|yesno:_("an,a") party_link=object.future_candidacies.0.party.get_absolute_url %}
-                    is {{ a_or_an }} <a href="{{ party_link }}">{{ party_name }}</a> candidate in the following elections:
-                {% endblocktrans %}
-            </h5>
-
-            {% for candidacy in object.future_candidacies %}
-                <ul>
-                    <li>
-                        {% blocktrans trimmed with election=candidacy.election.name %}{{ election }} for{% endblocktrans %}
-                        <a href="{{ candidacy.post_election.get_absolute_url }}">
-                            {{ candidacy.post_election.friendly_name }}
-                        </a>
-                    </li>
-                </ul>
-            {% endfor %}
+            {% include "people/includes/_person_multiple_current_candidacies.html" with candidacies=object.future_candidacies person_name=object.name verb=object.get_verb %}
+            {% comment %} If there are no future elections, but > 1 current but past elections, list those {% endcomment %}
+        {% elif object.current_but_past_candidacies.all.count > 1 and not object.future_candidacies %}
+            {% include "people/includes/_person_multiple_current_candidacies.html" with candidacies=object.current_but_past_candidacies person_name=object.name verb=object.get_verb %}
             {% comment %} Otherwise, display the featured candidacy, whether it is current or not. {% endcomment %}
         {% else %}
             <p>

--- a/wcivf/apps/people/templates/people/includes/_person_multiple_current_candidacies.html
+++ b/wcivf/apps/people/templates/people/includes/_person_multiple_current_candidacies.html
@@ -1,0 +1,20 @@
+{% load i18n static %}
+
+<h5>{{ person_name }}
+    {% with party=candidacies.0.party %}
+        {% blocktrans trimmed with party_name=party.party_name party_link=party.get_absolute_url a_or_an=party.is_independent|yesno:_("an,a") %}
+            {{ verb }} {{ a_or_an }} <a href="{{ party_link }}">{{ party_name }}</a> candidate in the following elections:
+        {% endblocktrans %}
+    {% endwith %}
+</h5>
+
+{% for candidacy in candidacies %}
+    <ul>
+        <li>
+            {% blocktrans trimmed with election=candidacy.election.name %}{{ election }} for{% endblocktrans %}
+            <a href="{{ candidacy.post_election.get_absolute_url }}">
+                {{ candidacy.post_election.friendly_name }}
+            </a>
+        </li>
+    </ul>
+{% endfor %}


### PR DESCRIPTION
Now if a candidate has has no future candidacies, and multiple current but past candidacies, we will list them in their intro card.

Before we'd only show one of the elections, (e.g. the below candidate stood in both parl and local elections but we only show the local one in the intro card).
![image](https://github.com/user-attachments/assets/d693771b-1c83-4ae3-8fd4-f3bd5391f44a)

Now we'll show both in a list:
![image](https://github.com/user-attachments/assets/4531da81-19d6-4006-8d05-6941afbf77fc)



closes  #2029 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210003516031209