### PR TITLE
adds status message to past elections detail view

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -15,6 +15,18 @@
             {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
         {% else %}
 
+            {% if not postelection.cancelled and postelection.election.in_past%}
+                {% url "home_view" as home_view_url%}
+                {% blocktrans trimmed with time_since=postelection.election.election_date|timesince %}
+                    <div class="ds-status-message" >
+                        This election happened {{ time_since }} ago.
+                        <a href="{{ home_view_url }}">Enter your postcode</a>
+                        to find upcoming elections in your area.
+                    </div>
+                {% endblocktrans %}
+            {% endif %}
+
+
             {% if not postelection.is_pcc and not postelection.is_mayoral %}
                 <h3>{% if postelection.is_london_assembly_additional %}{% trans "Additional members" %}{% else %}{{ postelection.friendly_name }}{% endif %}</h3>
             {% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -15,8 +15,8 @@
             {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
         {% else %}
 
-            {% if not postelection.cancelled and postelection.election.in_past%}
-                {% url "home_view" as home_view_url%}
+            {% if not postelection.cancelled and postelection.election.in_past %}
+                {% url "home_view" as home_view_url %}
                 {% blocktrans trimmed with time_since=postelection.election.election_date|timesince %}
                     <div class="ds-status-message" >
                         This election happened {{ time_since }} ago.


### PR DESCRIPTION
This PR adds a new status message to detail views for ballots in the past, in order to better distinguish them from future elections.
Before:
![image](https://github.com/user-attachments/assets/fff96b70-83c1-444c-8721-1d661dbfdac6)
After:
![image](https://github.com/user-attachments/assets/2873095c-a359-48e1-88c6-ff9eb3c5dad6)

Closes #2238 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210003516031211