### PR TITLE
don't try and render a list of posts if election has zero posts

### DIFF
--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -256,11 +256,15 @@ class Election(models.Model):
         Returns a string for the pluralised divison name for the posts in the
         election
         """
+        first_post = self.post_set.first()
+        if not first_post:
+            return "posts"
+
         pluralise = {
             "parish": "parishes",
             "constituency": "constituencies",
         }
-        suffix = self.post_set.first().division_suffix
+        suffix = first_post.division_suffix
 
         if not suffix:
             return "posts"

--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -69,17 +69,19 @@
                     {% endif %}
                 {% endif %}
 
-                <h3>{% blocktrans trimmed with title=object.pluralized_division_name|title %} {{ title }}{% endblocktrans %}</h3>
-                <ul>
-                    {% for postelection in object.postelection_set.all %}
-                        <li>
-                            {% blocktrans trimmed with postelection_url=postelection.get_absolute_url post_label=postelection.post.label cancelled_message=postelection.short_cancelled_message_html %}
-                                <a href="{{ postelection_url }}">{{ post_label }}</a>
-                                {{ cancelled_message }}
-                            {% endblocktrans %}
-                        </li>
-                    {% endfor %}
-                </ul>
+                {% if object.postelection_set.exists %}
+                    <h3>{% blocktrans trimmed with title=object.pluralized_division_name|title %} {{ title }}{% endblocktrans %}</h3>
+                    <ul>
+                        {% for postelection in object.postelection_set.all %}
+                            <li>
+                                {% blocktrans trimmed with postelection_url=postelection.get_absolute_url post_label=postelection.post.label cancelled_message=postelection.short_cancelled_message_html %}
+                                    <a href="{{ postelection_url }}">{{ post_label }}</a>
+                                    {{ cancelled_message }}
+                                {% endblocktrans %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             {% endif %}
             <script type="application/ld+json">
                 {


### PR DESCRIPTION
Refs https://democracy-club-gp.sentry.io/issues/3801672829

We've seen a lot of this error popping up in Sentry. Mainly on the following URLs:

- https://whocanivotefor.co.uk/elections/local.haringey.2025-05-01/
- http://whocanivotefor.co.uk/elections/pcc.2016-05-05/

This whole thing is a bit odd and really points to problems in our data. Fundamentally, there shouldn't be elections in our data with 0 posts attached to them. That said, this probably isn't the way we should find out about this. So in this PR, I am making the decision that if we have an election with zero posts then lets not try and render a list of posts for it. That gets us to a place where these pages render a page. Not a very useful page, but a page nonetheless.

Then the next question is: How have we ended up with elections that have zero posts?

I've now soft-deleted `local.haringey.2025-05-01`. This one happened because we made a ballot, soft-deleted the ballot but not the group and ended up with an empty group. Hopefully this should just sync through and magically fix itself.

`pcc.2016-05-05` is an odd one, because it does actually have posts in EE and YNR https://elections.democracyclub.org.uk/elections/pcc.2016-05-05/ but has zero posts attached to it in WCIVF.

Then there's some others like

https://whocanivotefor.co.uk/elections/parl.2010-11-05/
and
https://whocanivotefor.co.uk/elections/local.city-of-london.2017-09-11/
that do exist in WCIVF but don't exist at all in EE or YNR

I made https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210098227316290?focus=true to look at the data in more detail, but lets consider this PR to fix the application code separately.