### PR TITLE
Replaced elections on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ edited in `sam-template.yaml` for this change to take effect.
 PDF booklets can be manually added here wcivf/assets/booklets following the same naming convention as the other booklets. The file name should be the same as the election slug.
 Then, add the slug and corresponding booklet file name to the list here /wcivf/apps/elections/models.py#L187.
 
+## Disable upcoming elections
+
+The home page shows a list of upcoming elections. We don't want this for 
+scheduled elections, so we need to set `SHOW_UPCOMING_ELECTIONS = False` in 
+settings.  
+
 # New WCIVF Google Sheets imports (Hustings, local parties)
 
 Peter will have set up some Google sheets in a known format. The CSV version of these sheets are imported in to WCIVF from time to time.
@@ -125,6 +131,10 @@ If you want to show the GB voter ID messaging, set `SHOW_GB_ID_MESSAGING = True`
 
 When we've got some results to show, you'll want to update `SHOW_RESULTS_CHART = True` in `settings/base.py`.
 You'll also need to grab the Flourish chart info and replace it in `/templates/home.html`. It should live inside the `{% if show_results_chart %}` block.
+
+## Enable upcoming elections
+
+Set `SHOW_UPCOMING_ELECTIONS = True` in settings. 
 
 ## Deployments
 

--- a/wcivf/apps/core/tests/test_frontend.py
+++ b/wcivf/apps/core/tests/test_frontend.py
@@ -150,3 +150,23 @@ class TestHomePageView(TestCase):
         self.assertContains(req, "local.foo.bar.by.date")
         self.assertContains(req, "local.baz.replaced.date")
         self.assertContains(req, "Upcoming Elections")
+
+    def test_ref_in_upcoming_elections(self):
+        """
+        Ensure that referendums show up in the home page list
+
+
+        """
+        referendum_election = ElectionFactory(
+            election_date=today(),
+            current=True,
+            # This will get marked as True by the importer
+            any_non_by_elections=True,
+            slug="ref.date",
+        )
+        PostElectionFactory.create(
+            election=referendum_election,
+            ballot_paper_id="ref.foo.date",
+        )
+        req = self.client.get("/")
+        self.assertContains(req, "ref.foo.date")

--- a/wcivf/apps/core/tests/test_frontend.py
+++ b/wcivf/apps/core/tests/test_frontend.py
@@ -99,6 +99,7 @@ class TestBaseTemplate(TestCase):
             assert "dc_base_naked.html" in (t.name for t in req.templates)
 
 
+@override_settings(SHOW_UPCOMING_ELECTIONS=True)
 class TestHomePageView(TestCase):
     def test_home_page_smoke_test(self):
         req = self.client.get("/")

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -83,7 +83,8 @@ class HomePageView(PostcodeFormView):
             )
             .filter(
                 Q(election__any_non_by_elections=False)
-                | Q(replaces__isnull=False),
+                | Q(replaces__isnull=False)
+                | Q(ballot_paper_id__startswith="ref.")
             )
             # .exclude(election__election_date=may_election_day_this_year())
             .select_related("election", "post")

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -3,6 +3,7 @@ import os
 
 from django import http
 from django.conf import settings
+from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.views.generic import FormView, TemplateView, View
@@ -79,8 +80,10 @@ class HomePageView(PostcodeFormView):
             PostElection.objects.filter(
                 election__election_date__gte=today,
                 election__election_date__lte=cut_off_date,
-                # Temporarily removed following May elections #
-                election__any_non_by_elections=False,
+            )
+            .filter(
+                Q(election__any_non_by_elections=False)
+                | Q(replaces__isnull=False),
             )
             # .exclude(election__election_date=may_election_day_this_year())
             .select_related("election", "post")

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -68,7 +68,10 @@ class HomePageView(PostcodeFormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["upcoming_elections"] = PostElection.objects.home_page_upcoming_ballots()
+        if getattr(settings, "SHOW_UPCOMING_ELECTIONS", True):
+            context[
+                "upcoming_elections"
+            ] = PostElection.objects.home_page_upcoming_ballots()
         polls_open = timezone.make_aware(
             datetime.datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
         )

--- a/wcivf/apps/core/views.py
+++ b/wcivf/apps/core/views.py
@@ -3,7 +3,6 @@ import os
 
 from django import http
 from django.conf import settings
-from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.views.generic import FormView, TemplateView, View
@@ -69,27 +68,7 @@ class HomePageView(PostcodeFormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        # Comment in this code to hide upcoming elections on the homepage
-        # context["upcoming_elections"] = None
-
-        # # Comment in this code to show upcoming elections on the homepage
-        today = datetime.datetime.today()
-        delta = datetime.timedelta(weeks=4)
-        cut_off_date = today + delta
-        context["upcoming_elections"] = (
-            PostElection.objects.filter(
-                election__election_date__gte=today,
-                election__election_date__lte=cut_off_date,
-            )
-            .filter(
-                Q(election__any_non_by_elections=False)
-                | Q(replaces__isnull=False)
-                | Q(ballot_paper_id__startswith="ref.")
-            )
-            # .exclude(election__election_date=may_election_day_this_year())
-            .select_related("election", "post")
-            .order_by("election__election_date")
-        )
+        context["upcoming_elections"] = PostElection.objects.home_page_upcoming_ballots()
         polls_open = timezone.make_aware(
             datetime.datetime.strptime("2019-12-12 7", "%Y-%m-%d %H")
         )

--- a/wcivf/settings/local.example.py
+++ b/wcivf/settings/local.example.py
@@ -36,3 +36,5 @@ EMAIL_SIGNUP_BACKEND = "local_db"
 # GDAL_LIBRARY_PATH = "/opt/homebrew/Cellar/gdal/3.5.1_3/lib/libgdal.dylib"
 
 # GEOS_LIBRARY_PATH= '/opt/homebrew/Cellar/geos/3.11.0/lib/libgeos_c.1.17.0.dylib'
+
+SHOW_UPCOMING_ELECTIONS = True


### PR DESCRIPTION
A few commits to clean up the upcoming elections block on the home page:

1. Include any ballot that replaces a ballot. This catches polls that have been countermanded from scheduled elections
2. Include referendums
3. Move the code to a manager
4. Feature flag the code for easier disabling around scheduled elections. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210519443877124