### PR TITLE
improve search engine indexing/snippets

### DIFF
--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block page_title %}{{ object.name }}{% endblock page_title %}
-{% block og_title_content  %}{{ object.name }}{% endblock og_title_content  %}
+{% block og_title_content %}{{ object.name }}{% endblock og_title_content %}
 {% block og_description_content %}
     {% if object.in_past %}
         {% blocktrans trimmed with election=object.name date=object.election_date|date:"j M Y"  %}The {{ election }} was held on {{ date }}.{% endblocktrans %}
@@ -12,7 +12,7 @@
     {% endif %}
 {% endblock og_description_content %}
 
-{% block twitter_title_content %}{{ object.name }}{% endblock twitter_title_content %}>
+{% block twitter_title_content %}{{ object.name }}{% endblock twitter_title_content %}
 
 {% block twitter_description_content %}
     {% if object.in_past %}
@@ -20,7 +20,7 @@
     {% else %}
         {% blocktrans trimmed with election=object.name date=object.election_date|date:"j M Y" %}The {{ election }} will be held on {{ date }}.{% endblocktrans %}
     {% endif %}
-{% endblock twitter_description_content %}/>
+{% endblock twitter_description_content %}
 
 
 {% block content %}

--- a/wcivf/apps/elections/templates/elections/election_view.html
+++ b/wcivf/apps/elections/templates/elections/election_view.html
@@ -31,21 +31,23 @@
         <div class="ds-card-body">
             <h3>{{ object.nice_election_name }}</h3>
 
-            <p>
-                {% if object.is_election_day %}
-                    {% blocktrans trimmed with election=object.nice_election_name %}The {{ election }}
-                        <strong>is being held today</strong>. Polls are open from{% endblocktrans %} {{ object.polls_open|time:"ga" }} {% trans "till" %} {{ object.polls_close|time:"ga" }}
-                {% elif object.in_past %}
-                    {% comment %} TO DO: Change text when the election is "tomorrow" {% endcomment %}
-                    {% blocktrans trimmed with election_date=object.election_date|naturalday:"\o\n l j F Y" %}
-                        This election was held <strong>{{ election_date }}</strong>.
-                    {% endblocktrans %}
-                {% else %}
-                    {% blocktrans trimmed with election_date=object.election_date|naturalday:"\o\n l j F Y" %}
-                        This election will be held on <strong>{{ election_date }}</strong>.
-                    {% endblocktrans %}
-                {% endif %}
-            </p>
+            <div data-nosnippet>
+                <p>
+                    {% if object.is_election_day %}
+                        {% blocktrans trimmed with election=object.nice_election_name %}The {{ election }}
+                            <strong>is being held today</strong>. Polls are open from{% endblocktrans %} {{ object.polls_open|time:"ga" }} {% trans "till" %} {{ object.polls_close|time:"ga" }}
+                    {% elif object.in_past %}
+                      {% comment %} TO DO: Change text when the election is "tomorrow" {% endcomment %}
+                        {% blocktrans trimmed with election_date=object.election_date|naturalday:"\o\n l j F Y" %}
+                            This election was held <strong>{{ election_date }}</strong>.
+                        {% endblocktrans %}
+                    {% else %}
+                        {% blocktrans trimmed with election_date=object.election_date|naturalday:"\o\n l j F Y" %}
+                            This election will be held on <strong>{{ election_date }}</strong>.
+                        {% endblocktrans %}
+                    {% endif %}
+                </p>
+            </div>
             {% if object.election_type != "ref" %}
                 {% if election.person_set.count %}
                     <p>

--- a/wcivf/apps/elections/templates/elections/elections_view.html
+++ b/wcivf/apps/elections/templates/elections/elections_view.html
@@ -6,8 +6,8 @@
 {% block page_title %}{% trans "UK Elections" %}{% endblock page_title %}
 {% block og_title_content  %}{% trans "UK Elections" %}{% endblock og_title_content  %}
 {% block og_description_content %}{% trans "All Elections in the UK" %}{% endblock og_description_content %}
-{% block twitter_title_content %}{% trans "UK Elections" %}{% endblock twitter_title_content %}>
-{% block twitter_description_content %}{% trans "All Elections in the UK" %}{% endblock twitter_description_content %}/>
+{% block twitter_title_content %}{% trans "UK Elections" %}{% endblock twitter_title_content %}
+{% block twitter_description_content %}{% trans "All Elections in the UK" %}{% endblock twitter_description_content %}
 
 {% block content %}
 

--- a/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
+++ b/wcivf/apps/elections/templates/elections/includes/_post_meta_description.html
@@ -7,7 +7,7 @@
         {% blocktrans trimmed with election_name=object.election.name num_candidates=postelection.people|length election_date=object.election.election_date|date:"j M Y" %}
             See all {{ num_candidates }} candidates in the {{ election_name }} on {{ election_date }}:{% endblocktrans %}
         {% for pp in postelection.people %}
-            {{ pp.person.name|safe }} ({{ pp.party_name }})
+            {{ pp.person.name }} ({{ pp.party_name }})
         {% endfor %}
     {% endautoescape %}
 {% else %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -38,22 +38,24 @@
             {% endif %}
 
             <p>
-                {% if postelection.election.is_election_day %}
-                    {% blocktrans trimmed with open_time=postelection.election.polls_open|time:"ga" close_time=postelection.election.polls_close|time:"ga" %}
-                        This election <strong>is being held today</strong>. Polls are open from {{ open_time }} till {{ close_time }}
-                    {% endblocktrans %}
+                <div data-nosnippet>
+                    {% if postelection.election.is_election_day %}
+                        {% blocktrans trimmed with open_time=postelection.election.polls_open|time:"ga" close_time=postelection.election.polls_close|time:"ga" %}
+                            This election <strong>is being held today</strong>. Polls are open from {{ open_time }} till {{ close_time }}
+                        {% endblocktrans %}
 
-                {% else %}
-                    {% if postelection.election.in_past %}
-                        {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
-                            This election was held <strong>{{ election_date }}</strong>.
-                        {% endblocktrans %}
                     {% else %}
-                        {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
-                            This election will be held <strong>{{ election_date }}</strong>.
-                        {% endblocktrans %}
+                        {% if postelection.election.in_past %}
+                            {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
+                                This election was held <strong>{{ election_date }}</strong>.
+                            {% endblocktrans %}
+                        {% else %}
+                            {% blocktrans trimmed with election_date=postelection.election.election_date|naturalday:"\o\n l j F Y" %}
+                                This election will be held <strong>{{ election_date }}</strong>.
+                            {% endblocktrans %}
+                        {% endif %}
                     {% endif %}
-                {% endif %}
+                </div>
             </p>
 
             {% if object.election.slug == "europarl.2019-05-23"%}

--- a/wcivf/apps/elections/templates/elections/post_view.html
+++ b/wcivf/apps/elections/templates/elections/post_view.html
@@ -6,8 +6,8 @@
 {% block page_description %}{% include "elections/includes/_post_meta_description.html" %}{% endblock page_description %}
 {% block og_title_content %}{% include "elections/includes/_post_meta_title.html" %}{% endblock og_title_content %}
 {% block og_description_content %}{% include "elections/includes/_post_meta_description.html" %}{% endblock og_description_content %}
-{% block twitter_title_content %}{% include "elections/includes/_post_meta_title.html" %}{% endblock twitter_title_content %}>
-{% block twitter_description_content %}{% include "elections/includes/_post_meta_description.html" %}{% endblock twitter_description_content %}/>
+{% block twitter_title_content %}{% include "elections/includes/_post_meta_title.html" %}{% endblock twitter_title_content %}
+{% block twitter_description_content %}{% include "elections/includes/_post_meta_description.html" %}{% endblock twitter_description_content %}
 {% block page_meta %}
     {% if postelection.people.contains_delisted_person %}
         <meta name="robots" content="noindex">

--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -15,6 +15,9 @@
     {% include "elections/includes/_postcode_meta_title.html" %}{% endblock twitter_title_content %}
 {% block twitter_description_content %}
     {% include "elections/includes/_postcode_meta_title.html" %}{% endblock twitter_description_content %}
+{% block page_meta %}
+    <meta name="robots" content="noindex">
+{% endblock %}
 
 {% block content %}
     <style>


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210134603328600?focus=true
Refs https://github.com/DemocracyClub/dc_django_utils/pull/94

This PR is a bit of a grab bag of things
The main thrust is to improve how we appear in search results, but I noticed a couple of other bits while I was nosing around here

I think the other thing we could consider is setting a

```html
<meta name="description" content="stuff here">
```

Currently none of our pages set this. We set `<meta property="og:description">` and `<meta name="twitter:description">`, but not `<meta name="description">`. I did consider re-using the existing og/twitter description, but having had a look at it, I don't think it is actually that great - it can get quite long and unwieldy for elections with more than a few candidates. Obviously I'm picking a particularly comical example here
https://unfurl-preview.vercel.app/?url=https%3A%2F%2Fwhocanivotefor.co.uk%2Felections%2Fsp.r.central-scotland.2021-05-06%2Fcentral-scotland%2F
but you get the point. A lot of the higher profile elections we have coming up in 2026 are going to be for seats with quite long candidate lists.
I think if we are going to set a `<meta name="description">` we should re-think what goes in it taking into account Google's guidance on how to write good meta descriptions https://developers.google.com/search/docs/appearance/snippet#meta-descriptions
In the meantime, what Google is cobbling together from the page content is probably better.

I reckon as a first step, lets make the changes I propose here and see what Google makes of it
Then maybe we come back to meta description another day