### PR TITLE
Send election event to goatcounter on postcode page

### DIFF
--- a/wcivf/apps/elections/templates/elections/postcode_view.html
+++ b/wcivf/apps/elections/templates/elections/postcode_view.html
@@ -102,6 +102,29 @@
 {% endblock content %}
 
 {% block in_page_javascript %}
+    {{ postelections | length |  json_script:"postElectionsCount" }}
+    <script>
+        const postElectionsCount = JSON.parse(document.getElementById('postElectionsCount').textContent);
+
+        function trackElectionsShownEvent(postElectionsCount) {
+            const hasElections = postElectionsCount > 0;
+            const eventData = hasElections ? {
+                path: 'ELECTION_SHOWN',
+                title: 'Election feedback form displayed',
+                event: true,
+            } : {
+                path: 'NO_ELECTION_SHOWN',
+                title: 'No election feedback form displayed',
+                event: true,
+            };
+
+            window.goatcounter.count(eventData);
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            trackElectionsShownEvent(postElectionsCount);
+        });
+    </script>
     <script>
         fallback.ready(['jQuery'], function () {
             /*! http://mths.be/details v0.1.0 by @mathias | includes http://mths.be/noselect v1.0.3 */


### PR DESCRIPTION
I think this does what we want, but I'm not 100%. In particular I don't know how it will look on the dashboard. 
Not sure the best way to test as local and dev sites don't post to goat counter.

We should be able to test how it appears on the dashboard, by [posting an event with curl](https://www.goatcounter.com/help/backend)