### PR TITLE
Remove feedback DB and related settings

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -68,20 +68,6 @@ Parameters:
     Description: "API key used to import data from YNR"
     Type: String
 
-  AppFeedbackDbEnabled:
-    Default: FEEDBACK_DB_ENABLED
-    Description: "Is the feedback DB enabled?"
-    Type: AWS::SSM::Parameter::Value<String>
-  AppFeedbackDbPassword:
-    Default: FEEDBACK_DB_PASSWORD
-    Description: "Webhook url used to send feeback entries to Slack"
-    Type: AWS::SSM::Parameter::Value<String>
-
-  AppFeedbackDbHost:
-    Default: FEEDBACK_DB_HOST
-    Description: "Webhook url used to send feeback entries to Slack"
-    Type: AWS::SSM::Parameter::Value<String>
-
 Resources:
   WCIVFControllerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -106,9 +92,6 @@ Resources:
           DC_ENVIRONMENT: !Ref AppDcEnvironment
           SLACK_FEEDBACK_WEBHOOK_URL: !Ref AppSlackFeedbackWebhookUrl
           YNR_API_KEY: !Ref AppYnrApiKey
-          FEEDBACK_DB_ENABLED: !Ref AppFeedbackDbEnabled
-          FEEDBACK_DB_PASSWORD: !Ref AppFeedbackDbPassword
-          FEEDBACK_DB_HOST: !Ref AppFeedbackDbHost
       Tags:
         dc-environment: !Ref AppDcEnvironment
         dc-product: wcivf

--- a/wcivf/apps/core/db_routers.py
+++ b/wcivf/apps/core/db_routers.py
@@ -1,23 +1,6 @@
 from django_middleware_global_request import get_request
 
 
-class FeedbackRouter(object):
-    apps_that_use_feedback_router = ["feedback"]
-
-    def db_for_read(self, model, **hints):
-        if model._meta.app_label in self.apps_that_use_feedback_router:
-            return "feedback"
-        return None
-
-    def db_for_write(self, model, **hints):
-        if model._meta.app_label in self.apps_that_use_feedback_router:
-            return "feedback"
-        return None
-
-    def allow_migrate(self, db, app_label, model_name=None, **hints):
-        return True
-
-
 class PrincipalRDSRouter:
     def db_for_read(self, model, **hints):
         request = get_request()

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -183,18 +183,6 @@ DATABASES = {
     }
 }
 DATABASE_ROUTERS = []
-if int(os.environ.get("FEEDBACK_DB_ENABLED", "0")):
-    DATABASES["feedback"] = {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("FEEDBACK_DB_NAME", "wcivf_feedback_production"),
-        "USER": "postgres",
-        "PASSWORD": os.environ.get("FEEDBACK_DB_PASSWORD"),
-        "HOST": os.environ.get("FEEDBACK_DB_HOST"),
-        "PORT": "",
-    }
-
-    if os.environ.get("DC_ENVIRONMENT") in ["production"]:
-        DATABASE_ROUTERS.append("core.db_routers.FeedbackRouter")
 
 if not os.environ.get("IGNORE_ROUTERS") and os.environ.get(
     "RDS_DB_NAME", False


### PR DESCRIPTION
I've done the work of importing the old data into the principal. Once this is merged and deployed new feedback will write to the principal and we can clean up the feedback DB. 