### PR TITLE
Don't save in get method

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -448,6 +448,10 @@ class YNRBallotImporter:
                             continue
                         person_post.previous_party_affiliations.add(party)
 
+            # Calculate ranks for all candidates if this ballot has results
+            if ballot_dict.get("results") and ballot.has_results:
+                ballot.update_candidate_ranks()
+
             if created:
                 self.stdout.write(
                     "Added new ballot: {0}".format(ballot.ballot_paper_id)

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -558,13 +558,11 @@ class PostElection(TimeStampedModel):
                 expression=DenseRank(), order_by=F("votes_cast").desc()
             )
         ).order_by("new_rank")
-
         # Set the rank on each candidate
         for candidate in candidates:
-            candidate.rank = candidate.new_rank
-
-        # Update all ranks
-        self.personpost_set.bulk_update(candidates, ["rank"])
+            if candidate.rank != candidate.new_rank:
+                candidate.rank = candidate.new_rank
+                candidate.save()
 
     @property
     def expected_sopn_date(self):

--- a/wcivf/apps/people/tests/factories.py
+++ b/wcivf/apps/people/tests/factories.py
@@ -11,6 +11,7 @@ from people.models import Person, PersonPost
 class PersonFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Person
+        django_get_or_create = ("ynr_id",)
 
     ynr_id = factory.Sequence(lambda n: n)
     name = factory.Sequence(lambda n: "Candidate %d" % n)

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -2,7 +2,9 @@ from django.test import TestCase
 from people.tests.factories import PersonFactory
 from people.tests.helpers import create_person
 
-from wcivf.apps.elections.tests.factories import ElectionFactory
+from wcivf.apps.elections.tests.factories import (
+    PostElectionFactory,
+)
 from wcivf.apps.people.tests.factories import PersonPostFactory
 
 
@@ -158,38 +160,46 @@ class TestPersonModel(TestCase):
         """Test that the get_results_rank method returns the correct rank
         given vote count is available."""
 
-        election = ElectionFactory()
-        candidate1 = PersonPostFactory(election=election)
-        candidate2 = PersonPostFactory(election=election)
-        candidate3 = PersonPostFactory(election=election)
-        candidate1.votes_cast = 100
-        candidate1.rank = 3
-        candidate2.votes_cast = 200
-        candidate2.rank = 2
-        candidate3.votes_cast = 300
-        candidate3.rank = 1
+        ballot = PostElectionFactory(spoilt_ballots=10)
+        PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=100
+        )
+        PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=200
+        )
+        candidate3 = PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=300
+        )
+
+        ballot.update_candidate_ranks()
+        candidate3.refresh_from_db()
         results_rank_str = candidate3.get_results_rank
-        self.assertTrue(results_rank_str, "1st / 3 candidates")
+        self.assertEqual(results_rank_str, "1st / 3 candidates")
 
     def test_get_results_rank_tied_candidates(self):
         """Test that the get_results_rank method returns the correct rank
         given vote count is available and there is a tie for a non-elected
         candidate."""
 
-        election = ElectionFactory()
-        candidate1 = PersonPostFactory(election=election)
-        candidate2 = PersonPostFactory(election=election)
-        candidate3 = PersonPostFactory(election=election)
-        candidate4 = PersonPostFactory(election=election)
-        candidate1.votes_cast = 100
-        candidate1.rank = 3
-        candidate2.votes_cast = 200
-        candidate2.rank = 2
-        candidate3.votes_cast = 300
-        candidate3.rank = 1
-        candidate4.votes_cast = 300
-        candidate4.rank = 1
+        ballot = PostElectionFactory(spoilt_ballots=10)
+        PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=100
+        )
+        candidate2 = PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=300
+        )
+        candidate3 = PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=300
+        )
+        PersonPostFactory(
+            election=ballot.election, post_election=ballot, votes_cast=400
+        )
+        ballot.update_candidate_ranks()
+
+        candidate2.refresh_from_db()
+        candidate3.refresh_from_db()
+
         results_rank_str_2 = candidate2.get_results_rank
         results_rank_str_3 = candidate3.get_results_rank
-        self.assertTrue(results_rank_str_2, "Joint 2nd / 4 candidates")
-        self.assertTrue(results_rank_str_3, "Joint 2nd / 4 candidates")
+        self.assertEqual(results_rank_str_2, "Joint 2nd / 4 candidates")
+        self.assertEqual(results_rank_str_3, "Joint 2nd / 4 candidates")

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -163,10 +163,12 @@ class TestPersonModel(TestCase):
         candidate2 = PersonPostFactory(election=election)
         candidate3 = PersonPostFactory(election=election)
         candidate1.votes_cast = 100
+        candidate1.rank = 3
         candidate2.votes_cast = 200
+        candidate2.rank = 2
         candidate3.votes_cast = 300
+        candidate3.rank = 1
         results_rank_str = candidate3.get_results_rank
-        candidate3.refresh_from_db()
         self.assertTrue(results_rank_str, "1st / 3 candidates")
 
     def test_get_results_rank_tied_candidates(self):
@@ -180,12 +182,14 @@ class TestPersonModel(TestCase):
         candidate3 = PersonPostFactory(election=election)
         candidate4 = PersonPostFactory(election=election)
         candidate1.votes_cast = 100
+        candidate1.rank = 3
         candidate2.votes_cast = 200
-        candidate3.votes_cast = 200
+        candidate2.rank = 2
+        candidate3.votes_cast = 300
+        candidate3.rank = 1
         candidate4.votes_cast = 300
+        candidate4.rank = 1
         results_rank_str_2 = candidate2.get_results_rank
         results_rank_str_3 = candidate3.get_results_rank
-        candidate2.refresh_from_db()
-        candidate3.refresh_from_db()
         self.assertTrue(results_rank_str_2, "Joint 2nd / 4 candidates")
         self.assertTrue(results_rank_str_3, "Joint 2nd / 4 candidates")

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -353,6 +353,7 @@ class PersonViewTests(TestCase):
             election=past_election,
             party=party,
             votes_cast=1000,
+            rank=1,
         )
         response = self.client.get(self.person_url, follow=True)
         self.assertTemplateUsed(


### PR DESCRIPTION
This is a bit of a refactor of the way we set and ranks. 

Previously we were calling `save()` _every time_ we got a candidate's rank. Now we use the stored rank field and ensure we set this when we import or update ballots.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211300441380986