### PR TITLE
use filter widget from dc_utils

### DIFF
--- a/wcivf/apps/core/utils.py
+++ b/wcivf/apps/core/utils.py
@@ -1,9 +1,4 @@
-from urllib.parse import urlencode
-
-from django.db.models import BLANK_CHOICE_DASH, Transform
-from django.utils.encoding import force_str
-from django.utils.safestring import mark_safe
-from django_filters.widgets import LinkWidget
+from django.db.models import Transform
 
 
 class LastWord(Transform):
@@ -23,45 +18,3 @@ class LastWord(Transform):
 
     def as_postgresql(self, compiler, connection):
         return self.as_sql(compiler, connection)
-
-
-class DSLinkWidget(LinkWidget):
-    """
-    The LinkWidget doesn't allow iterating over choices in the template layer
-    to change the HTML wrapping the widget.
-
-    This breaks the way that Django *should* work, so we have to subclass
-    and alter the HTML in Python :/
-
-    https://github.com/carltongibson/django-filter/issues/880
-    """
-
-    def render(self, name, value, attrs=None, choices=(), renderer=None):
-        if not hasattr(self, "data"):
-            self.data = {}
-        if value is None:
-            value = ""
-        self.build_attrs(self.attrs, extra_attrs=attrs)
-        output = []
-        options = self.render_options(choices, [value], name)
-        if options:
-            output.append(options)
-        # output.append('</ul>')
-        return mark_safe("\n".join(output))
-
-    def render_option(self, name, selected_choices, option_value, option_label):
-        option_value = force_str(option_value)
-        if option_label == BLANK_CHOICE_DASH[0][1]:
-            option_label = "All"
-        data = self.data.copy()
-        data[name] = option_value
-        selected = data == self.data or option_value in selected_choices
-        try:
-            url = data.urlencode()
-        except AttributeError:
-            url = urlencode(data)
-        return self.option_string() % {
-            "attrs": selected and ' aria-current="true"' or "",
-            "query_string": url,
-            "label": force_str(option_label),
-        }

--- a/wcivf/apps/elections/filters.py
+++ b/wcivf/apps/elections/filters.py
@@ -1,5 +1,5 @@
 import django_filters
-from core.utils import DSLinkWidget
+from dc_utils.filter_widgets import DSLinkWidget
 from elections.models import Election
 
 

--- a/wcivf/apps/parties/filters.py
+++ b/wcivf/apps/parties/filters.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode
 
 import django_filters
-from core.utils import DSLinkWidget
+from dc_utils.filter_widgets import DSLinkWidget
 from parties.models import Party
 
 

--- a/wcivf/apps/ppc_2024/filters.py
+++ b/wcivf/apps/ppc_2024/filters.py
@@ -1,7 +1,5 @@
 import django_filters
-
-# TODO: refactor into core.utils
-from elections.filters import DSLinkWidget
+from dc_utils.filter_widgets import DSLinkWidget
 from ppc_2024.models import PPCPerson
 
 


### PR DESCRIPTION
We moved DSLinkWidget to dc_utils in[ 2.5.0](https://github.com/DemocracyClub/dc_django_utils/releases/tag/2.5.0) but never migrated over to using it.

