### PR TITLE
fix post caching during import

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -165,14 +165,16 @@ class YNRPostImporter:
         if not post_id:
             # if no id to use return None to indicate to skip this ballot
             return None
+        created_date = ballot_dict["post"]["created"]
+        post_cache_key = f"{post_id}-{created_date}"
 
-        if post_id not in self.post_cache:
+        if post_cache_key not in self.post_cache:
             post, _ = Post.objects.update_or_create(
                 ynr_id=post_id,
                 defaults={"label": ballot_dict["post"]["label"]},
             )
-            self.post_cache[post_id] = post
-        return self.post_cache[post_id]
+            self.post_cache[post_cache_key] = post
+        return self.post_cache[post_cache_key]
 
 
 class YNRBallotImporter:

--- a/wcivf/apps/elections/tests/test_helpers.py
+++ b/wcivf/apps/elections/tests/test_helpers.py
@@ -628,6 +628,7 @@ class TestYNRPostImporter:
                 "id": "foo",
                 "slug": "bar",
                 "label": "example",
+                "created": "2021-01-01T00:00:00+00:00",
             }
         }
         mock = mocker.Mock(return_value=(1, True))
@@ -645,6 +646,7 @@ class TestYNRPostImporter:
                 "id": None,
                 "slug": "bar",
                 "label": "example",
+                "created": "2021-01-01T00:00:00+00:00",
             }
         }
         mock = mocker.Mock(return_value=(1, True))
@@ -655,3 +657,55 @@ class TestYNRPostImporter:
         mock.assert_called_once_with(
             ynr_id="bar", defaults={"label": "example"}
         )
+
+    def test_post_cache_with_duplicate_ids(self, mocker):
+        ballot_dict_one = {
+            "post": {
+                "id": "foo",
+                "slug": "bar",
+                "label": "example",
+                "created": "date-one",
+            }
+        }
+        ballot_dict_two = {
+            "post": {
+                "id": "foo",
+                "slug": "bar",
+                "label": "example",
+                "created": "date-two",
+            }
+        }
+        mock = mocker.Mock(return_value=(1, True))
+        mocker.patch("elections.models.Post.objects.update_or_create", mock)
+        importer = YNRPostImporter()
+        importer.update_or_create_from_ballot_dict(ballot_dict=ballot_dict_one)
+        assert len(importer.post_cache) == 1
+
+        importer.update_or_create_from_ballot_dict(ballot_dict=ballot_dict_two)
+        assert len(importer.post_cache) == 2
+
+    def test_post_cache_with_duplicate_slugs(self, mocker):
+        ballot_dict_one = {
+            "post": {
+                "id": None,
+                "slug": "bar",
+                "label": "example",
+                "created": "date-one",
+            }
+        }
+        ballot_dict_two = {
+            "post": {
+                "id": None,
+                "slug": "bar",
+                "label": "example",
+                "created": "date-two",
+            }
+        }
+        mock = mocker.Mock(return_value=(1, True))
+        mocker.patch("elections.models.Post.objects.update_or_create", mock)
+        importer = YNRPostImporter()
+        importer.update_or_create_from_ballot_dict(ballot_dict=ballot_dict_one)
+        assert len(importer.post_cache) == 1
+
+        importer.update_or_create_from_ballot_dict(ballot_dict=ballot_dict_two)
+        assert len(importer.post_cache) == 2


### PR DESCRIPTION
Addresses the issue that caused: https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210995577125990?focus=true

Neither id or slug are unique on EE (and therefore YNR) so if two ballots with the same post identifier or slug are imported at the same time then only the the first one's post is saved to the cache. Appending the created date to the post or slug should make it so the the cache key is unique.