### PR TITLE
remove empty results table from ballot pages

### DIFF
--- a/wcivf/apps/elections/import_helpers.py
+++ b/wcivf/apps/elections/import_helpers.py
@@ -449,7 +449,9 @@ class YNRBallotImporter:
                         person_post.previous_party_affiliations.add(party)
 
             # Calculate ranks for all candidates if this ballot has results
-            if ballot_dict.get("results") and ballot.has_results:
+            if ballot_dict.get("results") and (
+                ballot.has_results_summary or ballot.has_winner
+            ):
                 ballot.update_candidate_ranks()
 
             if created:

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -532,24 +532,30 @@ class PostElection(TimeStampedModel):
         return self.ballot_paper_id
 
     @property
-    def has_results(self):
+    def has_results_summary(self):
         """
-        Returns a boolean for if the election has results
+        Returns a boolean for if the election has any results summary data
         """
         return bool(
             self.spoilt_ballots
             or self.ballot_papers_issued
             or self.turnout
             or self.electorate
-            or self.personpost_set.filter(elected=True)
         )
+
+    @property
+    def has_winner(self):
+        """
+        Returns a boolean for if the election has a winner
+        """
+        return self.personpost_set.filter(elected=True).exists()
 
     def update_candidate_ranks(self):
         """
         Calculate ranks for all candidates on this ballot.
         This should be called when results are imported or updated.
         """
-        if not self.has_results:
+        if not self.has_results_summary:
             return
 
         # Get all candidates with calculated ranks

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -181,7 +181,7 @@
             </b></p>
         {% endif %}
 
-        {% if postelection.election.in_past and postelection.has_results %}
+        {% if postelection.election.in_past and postelection.has_results_summary %}
             <section class="ds-card ds-width-half-text">
                 <div class="ds-table">
                     <table id="results-table">

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -714,7 +714,7 @@ class TestPostElectionView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        self.assertTrue(self.post_election.has_results)
+        self.assertTrue(self.post_election.has_results_summary)
         self.assertContains(response, "Electorate")
         self.assertNotContains(response, "Turnout")
         self.assertContains(response, "Spoilt Ballots")


### PR DESCRIPTION
This PR fixes the empty results table appearing on the WCIVF ballot pages with no results.

An empty table was showing because the `PostElection.has_results` property was checking for both results summary info (AKA a `ResultSet` on YNR) and an election winner. All elections have winners, but not all have results summary data, because we don't currently collect `ResultSet` data  on YNR for all voting systems . This PR separates `PostElection.has_results`  into `PostElection.has_results_summary` and `PostElection.has_winner` to address the issue.


Old:
<img width="635" height="634" alt="image" src="https://github.com/user-attachments/assets/6236760c-73c4-4104-a339-1fa957693379" />

New:
<img width="1196" height="494" alt="image" src="https://github.com/user-attachments/assets/368510fc-6c03-4630-ba79-5ada761deea3" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211659141646618