### PR TITLE
always display past election status text

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_past_election.html
+++ b/wcivf/apps/elections/templates/elections/includes/_past_election.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+{% url "home_view" as home_view_url %}
+{% if postelection.cancelled %}
+    {% blocktrans trimmed with time_since=postelection.election.election_date|timesince %}
+        <div class="ds-status-message" >
+            This election was scheduled to happen {{ time_since }} ago.
+            <a href="{{ home_view_url }}">Enter your postcode</a>
+            to find upcoming elections in your area.
+        </div>
+    {% endblocktrans %}
+{% else %}
+    {% blocktrans trimmed with time_since=postelection.election.election_date|timesince %}
+        <div class="ds-status-message" >
+            This election happened {{ time_since }} ago.
+            <a href="{{ home_view_url }}">Enter your postcode</a>
+            to find upcoming elections in your area.
+        </div>
+    {% endblocktrans %}
+{% endif %}

--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -12,20 +12,15 @@
         </h2>
 
         {% if postelection.cancelled %}
-            {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
+            {% if postelection.election.in_past %}
+                {% include "elections/includes/_past_election.html" with past_election=True%}
+            {% endif %}
+            {% include "elections/includes/_cancelled_election.html" %}
         {% else %}
 
-            {% if not postelection.cancelled and postelection.election.in_past %}
-                {% url "home_view" as home_view_url %}
-                {% blocktrans trimmed with time_since=postelection.election.election_date|timesince %}
-                    <div class="ds-status-message" >
-                        This election happened {{ time_since }} ago.
-                        <a href="{{ home_view_url }}">Enter your postcode</a>
-                        to find upcoming elections in your area.
-                    </div>
-                {% endblocktrans %}
+            {% if postelection.election.in_past %}
+                {% include "elections/includes/_past_election.html" %}
             {% endif %}
-
 
             {% if not postelection.is_pcc and not postelection.is_mayoral %}
                 <h3>{% if postelection.is_london_assembly_additional %}{% trans "Additional members" %}{% else %}{{ postelection.friendly_name }}{% endif %}</h3>


### PR DESCRIPTION
This PR adds a status message to postponed elections in the past:

<img width="813" height="207" alt="image" src="https://github.com/user-attachments/assets/0267fbdc-9538-4b92-b4a0-2bc5ea608de7" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212718419645311