### PR TITLE
pass object to cancelled election template

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
+++ b/wcivf/apps/elections/templates/elections/includes/_single_ballot.html
@@ -13,9 +13,9 @@
 
         {% if postelection.cancelled %}
             {% if postelection.election.in_past %}
-                {% include "elections/includes/_past_election.html" with past_election=True%}
+                {% include "elections/includes/_past_election.html" %}
             {% endif %}
-            {% include "elections/includes/_cancelled_election.html" %}
+            {% include "elections/includes/_cancelled_election.html" with object=postelection only %}
         {% else %}
 
             {% if postelection.election.in_past %}


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2316
https://github.com/DemocracyClub/WhoCanIVoteFor/commit/df0fb3f6802d6018f32c64f76a783e6fbc7a3c77 deleted the wrong line