### PR TITLE
list independents at bottom of list ballot pages

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
+++ b/wcivf/apps/elections/templates/elections/includes/_people_list_with_lists.html
@@ -1,8 +1,7 @@
 {% load static %}
 {% load i18n %}
 {% load humanize %}
-{% regroup people.by_party by party.party_name as people_by_party %}
-
+{% regroup people by party.party_name as people_by_party %}
 {% for person_post in people_by_party %}
     {% with party=person_post.list.0.party %}
         {% if party.is_independent %}

--- a/wcivf/apps/elections/views/mixins.py
+++ b/wcivf/apps/elections/views/mixins.py
@@ -137,8 +137,15 @@ class PostelectionsToPeopleMixin(object):
         people_for_post = people_for_post.annotate(
             name_for_ordering=Coalesce("person__sort_name", "last_name")
         )
+
         if postelection.election.uses_lists:
-            order_by = ["party__party_name", "list_position"]
+            # Put independent candidates at the end of the list for elections that use lists
+            list_party_sort = Case(
+                When(party__party_id="ynmp-party:2", then=1),
+                default=0,
+                output_field=IntegerField(),
+            )
+            order_by = [list_party_sort, "party__party_name", "list_position"]
 
             manifesto_qs = Manifesto.objects.filter(
                 election_id=postelection.election.pk


### PR DESCRIPTION
This PR changes the order of candidates for list ballots such that independents always appear at the bottom.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213798517395114