### PR TITLE
use correct words for Scotland: Council/Returning Officer

### DIFF
--- a/wcivf/apps/elections/templates/elections/includes/_contact_details_registration.html
+++ b/wcivf/apps/elections/templates/elections/includes/_contact_details_registration.html
@@ -4,7 +4,7 @@
 {% if council and registration and council.address != registration.address and not postcode|ni_postcode %}
     <h4>{% trans "Electoral Registration" %}</h4>
     {% include "elections/includes/_council_contact_details.html" with contact_details=registration with_address=True %}
-    <h4>{% trans "Your Local Council" %}</h4>
+    <h4>{% trans "Your Returning Officer" %}</h4>
     {% include "elections/includes/_council_contact_details.html" with contact_details=council with_address=True %}
 {% elif council %}
     {% include "elections/includes/_council_contact_details.html" with contact_details=council with_address=True %}


### PR DESCRIPTION
As with https://github.com/DemocracyClub/ec-postcode-lookup-pages/pull/218 we also mention "your local council" in the section on postal voting, but I I have another ticket this sprint which requires other Scotland-specific text changes to the postal votes section so I'm going to suggest we ignore it in this PR and I'll do it there. https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1213559459008744?focus=true