### PR TITLE
Use node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@
 #
 version: 2.1
 orbs:
+  node: circleci/node@7.2.1
   slack: circleci/slack@4.13.3
   aws-cli: circleci/aws-cli@5.1.1
 
@@ -25,9 +26,16 @@ jobs:
     steps:
       - checkout
       # Download and cache dependencies
+      - node/install:
+          node-version: '18'
+
       - restore_cache:
           keys:
-          - v8-dependencies-{{ checksum "uv.lock" }}
+          - v8-dependencies-{{ checksum "uv.lock" }}-{{ checksum "package-lock.json" }}
+
+      - node/install-packages:
+          cache-path: ~/repo/node_modules
+
       - run:
           name: Install UV
           command: deploy/files/scripts/install-uv.sh
@@ -85,8 +93,9 @@ jobs:
           command: uv cache prune --ci
       - save_cache:
           paths:
+            - ./node_modules
             - $HOME/.cache/uv
-          key: v8-dependencies-{{ checksum "uv.lock" }}
+          key: v8-dependencies-{{ checksum "uv.lock" }}-{{ checksum "package-lock.json" }}
 
 
   sam_build:
@@ -130,7 +139,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v8-dependencies-{{ checksum "uv.lock" }}
+          - v8-dependencies-{{ checksum "uv.lock" }}-{{ checksum "package-lock.json" }}
       - attach_workspace:
           at: ~/repo/
       - run: echo <<parameters.instance-type>>
@@ -172,7 +181,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v8-dependencies-{{ checksum "uv.lock" }}
+            - v8-dependencies-{{ checksum "uv.lock" }}-{{ checksum "package-lock.json" }}
       - attach_workspace:
           at: ~/repo/
       - run:
@@ -212,7 +221,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - v8-dependencies-{{ checksum "uv.lock" }}
+          - v8-dependencies-{{ checksum "uv.lock" }}-{{ checksum "package-lock.json" }}
       - attach_workspace:
           at: ~/repo/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,24 +7,8 @@ orbs:
   slack: circleci/slack@4.13.3
   aws-cli: circleci/aws-cli@5.1.1
 
-executors:
-  py312:
-    docker:
-      - image: cimg/python:3.12
-        environment:
-          CIRCLECI: true
-          PGHOST: 127.0.0.1
-      - image: cimg/postgres:16.3
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: test
-
-
 jobs:
   build_and_test:
-    parameters:
-      python_version:
-        type: executor
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
@@ -38,7 +22,6 @@ jobs:
           POSTGRES_DB: wcivf
       - image: cimg/redis:7.0.5
     working_directory: ~/repo
-    executor: py312
     steps:
       - checkout
       # Download and cache dependencies
@@ -110,7 +93,6 @@ jobs:
     docker:
       - image: public.ecr.aws/sam/build-python3.12:latest
     working_directory: ~/repo
-    executor: py312
     steps:
       - checkout
       - run:
@@ -263,10 +245,7 @@ jobs:
 workflows:
   test_build_deploy:
     jobs:
-      - build_and_test:
-          matrix:
-            parameters:
-              python_version: [ py312 ]
+      - build_and_test
       - sam_build:
           requires:
           - build_and_test

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ wcivf/static/
 
 # PyCharm
 .idea/
+
+# node
+node_modules/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,17 @@ source .venv/bin/activate
 
 Or by `uv run` will automatically use the correct environment.
 
+## JavaScript packages
+
+JavaScript packages and environments are managed using
+`npm`.
+
+To install:
+
+```shell
+npm install
+```
+
 # Running tests
 
 Check that your env has correctly installed and project is working by running

--- a/appspec.yml
+++ b/appspec.yml
@@ -52,6 +52,9 @@ hooks:
     - location: deploy/after_install/install_python_deps.sh
       timeout: 300
       runas: wcivf
+    - location: deploy/after_install/install_npm_deps.sh
+      timeout: 300
+      runas: wcivf
     - location: deploy/after_install/write_envfile.py
       timeout: 300
       runas: wcivf

--- a/deploy/after_install/install_npm_deps.sh
+++ b/deploy/after_install/install_npm_deps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -xeEo pipefail
+
+cd /var/www/wcivf/code/
+npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,313 @@
+{
+  "name": "whocanivotefor",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "whocanivotefor",
+      "version": "1.0.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "maplibre-gl": "5.7.3",
+        "pmtiles": "4.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.3.tgz",
+      "integrity": "sha512-T6XsjwcSfOr0vtAt4GTzx4m/vD6nrbR0+61MgMzZ9REQwILSEnhqwNpFuFbDedX6LC3ZWjZWnxN7fN/I66WoDQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.1.1",
+        "@maplibre/vt-pbf": "^4.0.3",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "3.2.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.2",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/pmtiles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.3.0.tgz",
+      "integrity": "sha512-wnzQeSiYT/MyO63o7AVxwt7+uKqU0QUy2lHrivM7GvecNy0m1A4voVyGey7bujnEW5Hn+ZzLdvHPoFaqrOzbPA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "whocanivotefor",
+  "version": "1.0.0",
+  "description": "",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DemocracyClub/WhoCanIVoteFor.git"
+  },
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/DemocracyClub/WhoCanIVoteFor/issues"
+  },
+  "homepage": "https://github.com/DemocracyClub/WhoCanIVoteFor#readme",
+  "dependencies": {
+    "maplibre-gl": "5.7.3",
+    "pmtiles": "4.3.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ extend-exclude = ["wcivf/settings/local.py"]
 
 [tool.pytest.ini_options]
 norecursedirs =[
+    "node_modules",
     "src",
     "wcivf/static_root",
     ".aws-sam",

--- a/wcivf/apps/elections/templates/elections/boundary_reviews_view.html
+++ b/wcivf/apps/elections/templates/elections/boundary_reviews_view.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load pipeline %}
+{% load static %}
 
 {% block page_title %}{% trans "Boundary Reviews"%}{% endblock page_title %}
 {% block page_meta %}
@@ -8,6 +10,7 @@
 
 {% block extra_site_css%}
     {{ block.super }}
+    {% stylesheet 'maplibre-gl' %}
     <style>
         div[class$="-map-legend"] {
             display: none;
@@ -158,13 +161,13 @@
 {% endblock content %}
 {% block extra_javascript %}
     {{ block.super }}
+
     {{ boundary_reviews|json_script:"boundaryReviewsData" }}
     {{ postcode_location|json_script:"postcodeLocation" }}
     {{ nation|json_script:"nation" }}
 
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.7.3/maplibre-gl.css" integrity="sha512-IylZQnfgxyZ4rs0/u4TjuOthOSWKwh47nrCPuscGnyidnt1mrhKdja/uUxfvkLaMusDAWV3DgKHHpfzNdTdGhw==" crossorigin=""/>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/maplibre-gl/5.7.3/maplibre-gl.js" integrity="sha512-4qLefPK7TDle+A82wrHOa/B75+B8HH0w6Zwu6YaoXxwBrLl8tQ7UmoyS0PCWOobcq3fFe51G+AN+jVZpwN5qOw==" crossorigin=""></script>
-    <script src="//unpkg.com/pmtiles@4.4.0/dist/pmtiles.js" integrity="sha256-SqjwRpVddxFvwcm7cbxJ0XRlQ0KvjxKEqjTGJccf1nY=" crossorigin=""></script>
+    <script src="{% static 'maplibre-gl/dist/maplibre-gl.js' %}"></script>
+    {% javascript 'pmtiles' %}
 
 
     <script>

--- a/wcivf/assets/js/custom.js
+++ b/wcivf/assets/js/custom.js
@@ -1,0 +1,4 @@
+/* hoist pmtiles into the global scope
+   this allows us to minify it safely */
+
+window.pmtiles = pmtiles;

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -240,7 +240,7 @@ SHOW_BOUNDARY_CHANGES = os.environ.get("SHOW_BOUNDARY_CHANGES", "").lower() in (
 
 STATIC_URL = "/static/"
 
-STATICFILES_DIRS = (root("assets"),)
+STATICFILES_DIRS = (root("assets"), root("../node_modules"))
 STATIC_ROOT = root("static")
 
 PIPELINE = get_pipeline_settings(
@@ -250,6 +250,28 @@ PIPELINE = get_pipeline_settings(
 
 PIPELINE["SASS_ARGUMENTS"] += (
     " -I " + dc_design_system.DC_SYSTEM_PATH + "/system"
+)
+PIPELINE["STYLESHEETS"].update(
+    {
+        "maplibre-gl": {
+            "source_filenames": [
+                "maplibre-gl/dist/maplibre-gl.css",
+            ],
+            "output_filename": "css/maplibre.css",
+        },
+    }
+)
+
+PIPELINE["JAVASCRIPT"].update(
+    {
+        "pmtiles": {
+            "source_filenames": [
+                "pmtiles/dist/pmtiles.js",
+                "js/custom.js",
+            ],
+            "output_filename": "js/pmtiles.js",
+        },
+    }
 )
 
 CACHES = {


### PR DESCRIPTION
This PR moves the JS packages used for boundary change maps to be managed by npm rather than imported from a CDN. I've tested by deploying to [dev.wcivf.club](https://dev.wcivf.club/) and everything seems to be working.

I also did a small clean up of the CI config in https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2357/commits/46e3a5276d2e9eba50b0e4f9ab5e4af316d8c679 by removing the py312 execution env. I think we used to do some steps in a matrix with multiple python versions, but we no longer do and the execution env is redundant.

One thing I think will need a close inspection is [65b20ab](https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2357/commits/65b20abe2a52098964821028635547a613a6ca1a) where I add node to CI. I'm not sure I've put it in all the places it needs to be.


Follow up:

We are still importing leaflet from a CDN here: 
https://github.com/DemocracyClub/WhoCanIVoteFor/blob/aba09d6ae19ea8cecbcc8ef9965ca85190f81f8f/wcivf/apps/elections/templates/elections/includes/_polling_place.html#L166-L167

We could move to just using maplibre rather than depending on two mapping libraries, but I decided against including this in the PR. I will make a follow up card to return to this after May.