### PR TITLE
Mayoral booklets 20260421

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ edited in `sam-template.yaml` for this change to take effect.
 
 ## Mayoral Booklets
 
-PDF booklets can be manually added here wcivf/assets/booklets following the same naming convention as the other booklets. The file name should be the same as the election slug.
-Then, add the slug and corresponding booklet file name to the list here /wcivf/apps/elections/models.py#L187.
+PDF booklets can be uploaded to the s3 bucket: `https://wcivf-mayoral-booklets.s3.eu-west-2.amazonaws.com/booklets`. The file name should be the same as the election slug.
+Then, add the slug and corresponding booklet file name to the `election_to_booklet` dict lookup in `Election.election_booklet` in `/wcivf/apps/elections/models.py`.
 
 ## Disable upcoming elections
 

--- a/wcivf/apps/elections/models.py
+++ b/wcivf/apps/elections/models.py
@@ -290,6 +290,10 @@ class Election(models.Model):
             "mayor.greater-lincolnshire-cca.2025-05-01": f"{s3_bucket}/2025-05-01/mayoral/mayor.greater-lincolnshire-cca.2025-05-01.pdf",
             "mayor.doncaster.2025-05-01": f"{s3_bucket}/2025-05-01/mayoral/mayor.doncaster.2025-05-01.pdf",
             "mayor.north-tyneside.2025-05-01": f"{s3_bucket}/2025-05-01/mayoral/mayor.north-tyneside.2025-05-01.pdf",
+            "mayor.tower-hamlets.2026-05-07": f"{s3_bucket}/2025-05-01/mayoral/mayor.tower-hamlets.2026-05-07.pdf",
+            "mayor.newham.2026-05-07": f"{s3_bucket}/2025-05-01/mayoral/mayor.newham.2026-05-07.pdf",
+            "mayor.hackney.2026-05-07": f"{s3_bucket}/2025-05-01/mayoral/mayor.hackney.2026-05-07.pdf",
+            "mayor.lewisham.2026-05-07": f"{s3_bucket}/2025-05-01/mayoral/mayor.lewisham.2026-05-07.pdf",
         }
 
         return election_to_booklet.get(self.slug)


### PR DESCRIPTION
This PR adds mayoral booklets for the 2026 mayoral elections (4 out of 6). It also updates the README for the process. The booklets have already been uploaded to S3.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214134850090685