### PR TITLE
Fix local parties importer

### DIFF
--- a/wcivf/apps/core/db_routers.py
+++ b/wcivf/apps/core/db_routers.py
@@ -27,3 +27,9 @@ class PrincipalRDSRouter:
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         return True
+
+
+def get_principal_db_name():
+    if PRINCIPAL in settings.DATABASES:
+        return PRINCIPAL
+    return REPLICA

--- a/wcivf/apps/core/db_routers.py
+++ b/wcivf/apps/core/db_routers.py
@@ -1,4 +1,9 @@
+from django.conf import settings
+from django.db import DEFAULT_DB_ALIAS
 from django_middleware_global_request import get_request
+
+PRINCIPAL = settings.PRINCIPAL_DB_NAME
+REPLICA = DEFAULT_DB_ALIAS
 
 
 class PrincipalRDSRouter:
@@ -7,12 +12,12 @@ class PrincipalRDSRouter:
         if request and request.path.startswith("/admin"):
             # read from the replica in the admin
             # to prevent race conditions
-            return "principal"
+            return PRINCIPAL
 
-        return "default"
+        return REPLICA
 
     def db_for_write(self, model, **hints):
-        return "principal"
+        return PRINCIPAL
 
     def allow_relation(self, obj1, obj2, **hints):
         """

--- a/wcivf/apps/parties/management/commands/import_local_parties.py
+++ b/wcivf/apps/parties/management/commands/import_local_parties.py
@@ -1,7 +1,10 @@
+from core.db_routers import get_principal_db_name
 from dateutil.parser import parse
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from parties.importers import LocalElection, LocalPartyImporter
+
+DB_NAME = get_principal_db_name()
 
 
 class Command(BaseCommand):
@@ -101,7 +104,7 @@ class Command(BaseCommand):
         )
         importer.import_parties()
 
-    @transaction.atomic
+    @transaction.atomic(using=DB_NAME)
     def handle(self, **options):
         self.options = options
 

--- a/wcivf/settings/base.py
+++ b/wcivf/settings/base.py
@@ -184,6 +184,7 @@ WSGI_APPLICATION = "wcivf.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+PRINCIPAL_DB_NAME = "principal"
 
 DATABASES = {
     "default": {
@@ -199,7 +200,7 @@ if not os.environ.get("IGNORE_ROUTERS") and os.environ.get(
     "RDS_DB_NAME", False
 ):
     DATABASE_ROUTERS.append("core.db_routers.PrincipalRDSRouter")
-    DATABASES["principal"] = {
+    DATABASES[PRINCIPAL_DB_NAME] = {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": os.environ.get("RDS_DB_NAME"),
         "USER": "wcivf",


### PR DESCRIPTION
This transaction wasn't actually doing anything because it was using the default database but all the writing was being done on the principal. See:
https://github.com/DemocracyClub/UK-Polling-Stations/pull/8224
https://github.com/DemocracyClub/UK-Polling-Stations/pull/8605
[Chris's blog](https://chris48s.github.io/blogmarks/posts/2025/django-db-routers-1/#:~:text=expected%20DB%20connection.-,Transactions,-This%20one%20is)

That meant that when `LocalPartyImporter` deleted all the parties/manifestos, they would disappear from the site until they were re-imported.

We're going to have to do a big review of all the other transactions in WCIVF, but I that's for another PR.