### PR TITLE
Refactor results text

### DIFF
--- a/wcivf/apps/elections/tests/factories.py
+++ b/wcivf/apps/elections/tests/factories.py
@@ -4,6 +4,15 @@ from django.utils.text import slugify
 from elections.models import Election, Post, PostElection
 
 
+class VotingSystemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = "elections.VotingSystem"
+        django_get_or_create = ("slug",)
+
+    slug = "FPTP"
+    name = "First Past the Post"
+
+
 class ElectionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Election
@@ -14,6 +23,7 @@ class ElectionFactory(factory.django.DjangoModelFactory):
     current = True
     name = "UK General Election 2015"
     any_non_by_elections = True
+    voting_system = factory.SubFactory(VotingSystemFactory)
 
 
 class ElectionFactoryLazySlug(ElectionFactory):

--- a/wcivf/apps/elections/tests/test_election_views.py
+++ b/wcivf/apps/elections/tests/test_election_views.py
@@ -397,7 +397,7 @@ class ElectionPostViewTests(TestCase):
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
         self.assertContains(response, "{}'s elections".format(self.person.name))
-        self.assertContains(response, "(election cancelled")
+        self.assertContains(response, "(Election cancelled")
 
     def test_previous_elections_elected_with_count(self):
         """Previous elections table with elected candidate and vote count"""
@@ -414,8 +414,9 @@ class ElectionPostViewTests(TestCase):
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
         self.assertContains(response, "{}'s elections".format(self.person.name))
+        self.assertContains(response, "Elected")
         self.assertContains(
-            response, "{} votes (elected)".format(self.person_post.votes_cast)
+            response, "({} votes)".format(self.person_post.votes_cast)
         )
 
     def test_previous_elections_not_elected_with_count(self):
@@ -431,9 +432,10 @@ class ElectionPostViewTests(TestCase):
         self.post_election.cancelled = False
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
+        self.assertContains(response, "Not elected")
         self.assertContains(
             response,
-            "{} votes (not elected)".format(self.person_post.votes_cast),
+            "({} votes)".format(self.person_post.votes_cast),
         )
 
     def test_previous_elections_elected_no_count(self):
@@ -451,7 +453,8 @@ class ElectionPostViewTests(TestCase):
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
         self.assertContains(response, "{}'s elections".format(self.person.name))
-        self.assertContains(response, "Elected (vote count not available")
+        self.assertContains(response, "Elected")
+        self.assertContains(response, "(vote count not available)")
 
     def test_previous_elections_not_elected_no_count(self):
         """Previous elections table with no wins and no vote count"""
@@ -468,7 +471,8 @@ class ElectionPostViewTests(TestCase):
         self.post_election.save()
         response = self.client.get(self.person.get_absolute_url(), follow=True)
         self.assertContains(response, "{}'s elections".format(self.person.name))
-        self.assertContains(response, "Not elected (vote count not available)")
+        self.assertContains(response, "Not elected")
+        self.assertContains(response, "(vote count not available)")
 
     def test_deselected_person(self):
         self.person = PersonFactory()

--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -63,11 +63,10 @@ class PersonPost(models.Model):
     @property
     def get_results_text(self) -> str:
         """
-        Text describing the outcome of the election, as relates to this person.
+        Returns text describing whether or not this person was elected.
+        For example, if they were elected, return:
 
-        For example, if they were elected and we have the vote count, return:
-
-            "Elected (12345 votes)"
+            "Elected"
         """
 
         # Cancelled ballot:
@@ -79,42 +78,30 @@ class PersonPost(models.Model):
         if self.post_election.cancelled:
             if self.elected:
                 return _("Elected unopposed")
-            return _("(election cancelled)")
+            return _("(Election cancelled)")
 
-        # If the election is in the past, we can't have results!
-        # NOTE: this needs to be after the cancelled checks, as an election
-        # is always cancelled before the election day(!)
-        if "election" in self._state.fields_cache:
-            election = self._state.fields_cache["election"]
-        else:
-            election = self.post_election.election
-
-        if election and not election.in_past:
-            return _("(Results due after %(date)s)") % {
-                "date": election.election_date.strftime("%d %B %Y")
-            }
-
-        # If this candidacy was marked as elected, we need to show that!
-        # But we might not always have votes case for them.
-        # This is either because no one has gone and entered them, or
-        # because it's not an election we don't support votes cast for
-        # (e.g. non-FPTP)
-        num_votes = intcomma(self.votes_cast)
         if self.elected:
-            if self.votes_cast:
-                return _("%(num_votes)s votes (elected)") % {
-                    "num_votes": num_votes
-                }
-            return _("Elected (vote count not available)")
+            return _("Elected")
+        return _("Not elected")
 
-        # If we have votes cast, but we've not marked the candidacy as elected
-        # then the person wasn't elected, but we should still show the votes
-        # they got.
-        if self.votes_cast:
-            return _("%(num_votes)s votes (not elected)") % {
-                "num_votes": num_votes
+    @property
+    def get_vote_count_text(self) -> str:
+        """
+        Returns text describing the vote count for this candidacy, formatted with commas.
+
+        For example, "12,345 votes".
+        """
+        if self.post_election.get_voting_system.slug != "FPTP":
+            return _(
+                "We do not collect voting data for %(voting_system)s elections"
+            ) % {"voting_system": self.post_election.get_voting_system.get_name}
+
+        if self.votes_cast is not None:
+            return _("%(vote_count)s votes") % {
+                "vote_count": intcomma(self.votes_cast)
             }
-        return _("Not elected (vote count not available)")
+
+        return _("vote count not available")
 
     @property
     def get_results_rank(self):

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -31,7 +31,10 @@
                                 (Results due after {{ date }})
                             {% endblocktrans %}
                         {% else %}
-                            <strong>{{ person_post.get_results_text }}</strong> <span class="ds-font-size-s1">({{ person_post.get_vote_count_text }})</span>
+                            <strong>{{ person_post.get_results_text }}</strong>
+                            {% if not person_post.post_election.cancelled %}
+                                <span class="ds-font-size-s1">({{ person_post.get_vote_count_text }})</span>
+                            {% endif %}
                         {% endif %}
                     </td>
                     {% if object.previous_party_count %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -26,12 +26,10 @@
                     </td>
                     <td>{{ person_post.party_name }}</td>
                     <td>
-                        {% if person_post.election.voting_system.slug == "sv" %}
-                            {% trans "We do not collect voting data for Supplementary Vote elections." %}
-                        {% elif person_post.election.voting_system.slug == "STV" %}
-                            {% trans "We do not collect voting data for Single Transferable Vote elections." %}
-                        {% else  %}
-                            {{ person_post.get_results_text }}
+                        {% if not person_post.election.in_past %}
+                            (Results due after {{ person_post.election.election_date|date:"d M Y" }})
+                        {% else %}
+                            <strong>{{ person_post.get_results_text }}</strong> <span class="ds-font-size-s1">({{ person_post.get_vote_count_text }})</span>
                         {% endif %}
                     </td>
                     {% if object.previous_party_count %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -27,7 +27,9 @@
                     <td>{{ person_post.party_name }}</td>
                     <td>
                         {% if not person_post.election.in_past and not person_post.post_election.cancelled %}
-                            (Results due after {{ person_post.election.election_date|date:"d M Y" }})
+                            {% blocktrans trimmed with date=person_post.election.election_date|date:"d M Y" %}
+                                (Results due after {{ date }})
+                            {% endblocktrans %}
                         {% else %}
                             <strong>{{ person_post.get_results_text }}</strong> <span class="ds-font-size-s1">({{ person_post.get_vote_count_text }})</span>
                         {% endif %}

--- a/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
+++ b/wcivf/apps/people/templates/people/includes/_person_previous_elections_card.html
@@ -26,7 +26,7 @@
                     </td>
                     <td>{{ person_post.party_name }}</td>
                     <td>
-                        {% if not person_post.election.in_past %}
+                        {% if not person_post.election.in_past and not person_post.post_election.cancelled %}
                             (Results due after {{ person_post.election.election_date|date:"d M Y" }})
                         {% else %}
                             <strong>{{ person_post.get_results_text }}</strong> <span class="ds-font-size-s1">({{ person_post.get_vote_count_text }})</span>

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -397,6 +397,75 @@ class PersonViewTests(TestCase):
         self.assertContains(response, "Not elected")
         self.assertContains(response, """1st / 1 candidate""")
 
+    def test_previous_elections_card_future_cancelled_election(self):
+        """Test that the postcode search results with the text
+        'Election cancelled'
+        """
+        election = ElectionFactory(
+            name="Welsh Assembly Election",
+            current=False,
+            election_date="2100-05-01",
+            slug="local.welsh.assembly.2100-05-01",
+        )
+        future_cancelled_post_election = PostElectionFactory(
+            election=election,
+            post=PostFactory(label="Welsh Assembly", territory="WLS"),
+            ballot_paper_id="local.welsh.assembly.2100-05-01",
+            voting_system=VotingSystem(slug="FPTP"),
+            cancelled=True,
+        )
+        party = PartyFactory(
+            party_name="Conservative and Unionist Party",
+            party_id="party:52",
+        )
+        PersonPostFactory(
+            person=self.person,
+            post_election=future_cancelled_post_election,
+            election=election,
+            party=party,
+        )
+        response = self.client.get(self.person_url, follow=True)
+        self.assertTemplateUsed(
+            "people/includes/_person_previous_elections_card.html"
+        )
+        self.assertContains(response, "2100")
+        self.assertContains(response, "Welsh Assembly: Welsh Assembly Election")
+        self.assertContains(response, "Election cancelled")
+
+    def test_previous_elections_card_future_election(self):
+        """Test that the postcode search results with the text
+        'Results due after [election date]'
+        """
+        election = ElectionFactory(
+            name="Welsh Assembly Election",
+            current=False,
+            election_date="2100-05-01",
+            slug="local.welsh.assembly.2100-05-01",
+        )
+        future_post_election = PostElectionFactory(
+            election=election,
+            post=PostFactory(label="Welsh Assembly", territory="WLS"),
+            ballot_paper_id="local.welsh.assembly.2100-05-01",
+            voting_system=VotingSystem(slug="FPTP"),
+        )
+        party = PartyFactory(
+            party_name="Conservative and Unionist Party",
+            party_id="party:52",
+        )
+        PersonPostFactory(
+            person=self.person,
+            post_election=future_post_election,
+            election=election,
+            party=party,
+        )
+        response = self.client.get(self.person_url, follow=True)
+        self.assertTemplateUsed(
+            "people/includes/_person_previous_elections_card.html"
+        )
+        self.assertContains(response, "2100")
+        self.assertContains(response, "Welsh Assembly: Welsh Assembly Election")
+        self.assertContains(response, "(Results due after 01 May 2100)")
+
     def test_previous_elections_card_for_STV(self):
         """Test that the postcode search results have a
         table of previous elections with the text:

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -397,6 +397,75 @@ class PersonViewTests(TestCase):
         self.assertContains(response, "Not elected")
         self.assertContains(response, """1st / 1 candidate""")
 
+    def test_previous_elections_card_cancelled_election(self):
+        """Test that the postcode search results with the text
+        'Election cancelled'
+        """
+        election = ElectionFactory(
+            name="Welsh Assembly Election",
+            current=False,
+            election_date="2021-05-01",
+            slug="local.welsh.assembly.2021-05-01",
+        )
+        cancelled_post_election = PostElectionFactory(
+            election=election,
+            post=PostFactory(label="Welsh Assembly", territory="WLS"),
+            ballot_paper_id="local.welsh.assembly.2021-05-01",
+            cancelled=True,
+        )
+        party = PartyFactory(
+            party_name="Conservative and Unionist Party",
+            party_id="party:52",
+        )
+        PersonPostFactory(
+            person=self.person,
+            post_election=cancelled_post_election,
+            election=election,
+            party=party,
+            votes_cast=0,
+        )
+        response = self.client.get(self.person_url, follow=True)
+        self.assertTemplateUsed(
+            "people/includes/_person_previous_elections_card.html"
+        )
+        self.assertNotContains(response, "0 votes")
+        self.assertContains(response, "Election cancelled")
+
+    def test_previous_elections_card_unopposed_election(self):
+        """Test that the postcode search results with the text:
+        'Elected unopposed'
+        """
+        election = ElectionFactory(
+            name="Welsh Assembly Election",
+            current=False,
+            election_date="2021-05-01",
+            slug="local.welsh.assembly.2021-05-01",
+        )
+        unopposed_post_election = PostElectionFactory(
+            election=election,
+            post=PostFactory(label="Welsh Assembly", territory="WLS"),
+            ballot_paper_id="local.welsh.assembly.2021-05-01",
+            cancelled=True,
+        )
+        party = PartyFactory(
+            party_name="Conservative and Unionist Party",
+            party_id="party:52",
+        )
+        PersonPostFactory(
+            person=self.person,
+            post_election=unopposed_post_election,
+            election=election,
+            party=party,
+            elected=True,
+            votes_cast=0,
+        )
+        response = self.client.get(self.person_url, follow=True)
+        self.assertTemplateUsed(
+            "people/includes/_person_previous_elections_card.html"
+        )
+        self.assertNotContains(response, "0 votes")
+        self.assertContains(response, "Elected unopposed")
+
     def test_previous_elections_card_future_cancelled_election(self):
         """Test that the postcode search results with the text
         'Election cancelled'

--- a/wcivf/apps/people/tests/test_person_views.py
+++ b/wcivf/apps/people/tests/test_person_views.py
@@ -393,7 +393,8 @@ class PersonViewTests(TestCase):
         )
         self.assertContains(response, "2021")
         self.assertContains(response, "Welsh Assembly: Welsh Assembly Election")
-        self.assertContains(response, "1,000 votes (not elected)")
+        self.assertContains(response, "(1,000 votes)")
+        self.assertContains(response, "Not elected")
         self.assertContains(response, """1st / 1 candidate""")
 
     def test_previous_elections_card_for_STV(self):
@@ -427,14 +428,14 @@ class PersonViewTests(TestCase):
         )
         self.assertContains(
             response,
-            """We do not collect voting data for Single Transferable Vote elections.""",
+            """(We do not collect voting data for Single Transferable Vote elections)""",
             html=True,
         )
 
     def test_previous_elections_card_for_sv(self):
         """Test that the postcode search results have a
         table of previous elections with the text:
-        "We do not collect voting data for Supplementary Vote elections."
+        "(We do not collect voting data for Supplementary Vote elections)"
         """
         past_election = ElectionFactory(
             name="Welsh Assembly Election",
@@ -461,7 +462,7 @@ class PersonViewTests(TestCase):
         )
         self.assertContains(
             response,
-            """We do not collect voting data for Supplementary Vote elections.""",
+            """(We do not collect voting data for Supplementary Vote elections)""",
             html=True,
         )
 


### PR DESCRIPTION
This PR refactors the text in the results column of the previous candidacies table. It:
- makes the text for non-FPTP elections consistent
- Makes the Elected/Not elected text bold and makes the vote count text smaller
- Elected/Not elected always appears before the vote count


To do this I've simplified `get_results_text` by moving the vote count text logic to a new property, `get_vote_count_text` and putting the logic for determining text when an election is in the past back into to the template.
Old:
<img width="921" height="719" alt="image" src="https://github.com/user-attachments/assets/4f92ba2f-7062-4d55-9afe-ce1dc2cf2eb8" />
New:
<img width="854" height="742" alt="image" src="https://github.com/user-attachments/assets/b1a67d43-b2b1-4234-ad9a-edccaebb4f81" />
Old:
<img width="911" height="470" alt="image" src="https://github.com/user-attachments/assets/0e1ac027-4f6c-49d0-9dc3-8138213287d1" />

New:
<img width="862" height="430" alt="image" src="https://github.com/user-attachments/assets/d22e898f-401f-4d8a-9796-acc7ad068025" />
 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214259695023894