### PR TITLE
Lambda db routing

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -92,6 +92,7 @@ Resources:
           DC_ENVIRONMENT: !Ref AppDcEnvironment
           SLACK_FEEDBACK_WEBHOOK_URL: !Ref AppSlackFeedbackWebhookUrl
           YNR_API_KEY: !Ref AppYnrApiKey
+          IGNORE_ROUTERS: "1"
       Tags:
         dc-environment: !Ref AppDcEnvironment
         dc-product: wcivf

--- a/wcivf/settings/lambda.py
+++ b/wcivf/settings/lambda.py
@@ -2,12 +2,15 @@ import os
 
 from .base import *  # noqa
 
-DATABASES["default"] = {  # noqa
-    "ENGINE": "django.db.backends.postgresql",
-    "NAME": os.environ.get("RDS_DB_NAME"),
-    "USER": "wcivf",
-    "PASSWORD": os.environ.get("RDS_DB_PASSWORD"),
-    "HOST": os.environ.get("RDS_HOST"),
-    "PORT": os.environ.get("RDS_DB_PORT", "5432"),
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("RDS_DB_NAME"),
+        "USER": "wcivf",
+        "PASSWORD": os.environ.get("RDS_DB_PASSWORD"),
+        "HOST": os.environ.get("RDS_HOST"),
+        "PORT": os.environ.get("RDS_DB_PORT", "5432"),
+    }
 }
+
 EE_BASE = "https://elections.democracyclub.org.uk"


### PR DESCRIPTION
This PR makes it so the lambda only interacts with the principal database. It:
- Makes it so the lambda actually ignore the database router
- Makes sure the that settings.DATABASES only has the principal db connection alias in it. 

Tested by deploying to dev and invoking the local party importer. 