### PR TITLE
remove duplicate manifestos

### DIFF
--- a/wcivf/apps/people/views.py
+++ b/wcivf/apps/people/views.py
@@ -84,15 +84,21 @@ class PersonView(DetailView, PersonMixin):
         obj.post_country = self.get_post_country(obj)
         if obj.featured_candidacy:
             # We can't show manifestos if they've never stood for a party
-            obj.manifestos = Manifesto.objects.filter(
-                party=obj.featured_candidacy.party,
-                election__in=obj.current_or_future_candidacies.values(
-                    "election"
-                ),
-            ).filter(
-                Q(country="Local")
-                | Q(country="UK")
-                | Q(country=obj.post_country)
+            obj.manifestos = (
+                Manifesto.objects.filter(
+                    party=obj.featured_candidacy.party,
+                    election__in=obj.current_or_future_candidacies.values(
+                        "election"
+                    ),
+                )
+                .filter(
+                    Q(country="Local")
+                    | Q(country="UK")
+                    | Q(country=obj.post_country)
+                )
+                # remove duplicates if person is standing for the same party in multiple elections
+                .order_by("pdf_url", "web_url")
+                .distinct("pdf_url", "web_url")
             )
             obj.manifestos = sorted(
                 obj.manifestos, key=lambda n: n.country != "UK"


### PR DESCRIPTION
This PR fixes duplicated manifesto links for persons standing for the same party in two separate elections, e.g. someone standing in a constituency and a region for the same party. Caused by changes I made in https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2369 to display english + welsh manifestos.

Refs:
https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2365 

Before:
<img width="569" height="823" alt="image" src="https://github.com/user-attachments/assets/e54408e5-7e99-49b7-9d1e-8e4d827e0c92" />
After:
<img width="514" height="709" alt="image" src="https://github.com/user-attachments/assets/05d5373e-7200-474a-b99a-0a56efa70eb0" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214417146416262