### PR TITLE
scale up production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,9 +346,9 @@ workflows:
       - code_deploy:
           name: code_deploy_production
           dc-environment: production
-          min-size: 1
+          min-size: 4
           max-size: 20
-          desired-capacity: 3
+          desired-capacity: 4
           requires:
           - build_and_test
           - sam_deploy_staging


### PR DESCRIPTION
- Run a minimum of 4 instances
- We're already using `c6a.large` on this application

This is the configuration we used for polling day last year