### PR TITLE
fix feedback form notification styling

### DIFF
--- a/wcivf/apps/feedback/templates/feedback/feedback_thanks.html
+++ b/wcivf/apps/feedback/templates/feedback/feedback_thanks.html
@@ -1,25 +1,11 @@
 {% load dc_forms %}
 {% load i18n %}
-<div class="ds-status">
-    <h3>{% trans "Thanks for your feedback!" %}</h3>
 
-    <aside class="ds-status messages" aria-label="Status" style="color: white">
-        <ul class="ds-stack">
-            <li class="ds-status-message">
-                {% if object.found_useful == "YES" %}
-                    <p>
-                        {% trans "The information you see here is gathered publicly, by people like you." %}
-                    </p>
-                {% else %}
-                    <p>
-                        {% trans "We're sorry you didn't find what you were looking for." %}
-                        {% trans "We'll read your feedback and pass it on to our volunteers." %}
-                    </p>
-                    <p>
-                        {% trans "The information you see here is gathered publicly, by people like you." %}
-                    </p>
-                {% endif %}
-            </li>
-        </ul>
-    </aside>
-</div>
+{% trans "Thanks for your feedback!" %}
+{% if object.found_useful == "YES" %}
+    {% trans "The information you see here is gathered publicly, by people like you." %}
+{% else %}
+    {% trans "We're sorry you didn't find what you were looking for." %}
+    {% trans "We'll read your feedback and pass it on to our volunteers." %}
+    {% trans "The information you see here is gathered publicly, by people like you." %}
+{% endif %}


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/WhoCanIVoteFor/issues/2380

The issue here is that we were trying to render all this

https://github.com/DemocracyClub/WhoCanIVoteFor/blob/master/wcivf/apps/feedback/templates/feedback/feedback_thanks.html

inside this

https://github.com/DemocracyClub/WhoCanIVoteFor/blob/404a1836878872aa35d0b78ed236fdb7a6d07d06/wcivf/templates/base.html#L85-L95

which was a mess.

Tbh, this component https://democracyclub.github.io/design-system/components/status/ doesn't really deal with formatting inside it at all, so I've just collapsed both messages down to a single line of text.

Before:

<img width="1080" height="373" alt="585832378-b73ce099-d578-41b1-be8c-a18307c6ed4e" src="https://github.com/user-attachments/assets/9d6311dd-d94f-429e-83ba-e5f9ecdb2a0a" />

After:

<img width="940" height="92" alt="Screenshot at 2026-04-30 09-20-00" src="https://github.com/user-attachments/assets/bda739e7-a6e2-4881-bc5c-3fadc7a81ddf" />

Tbh, I wonder if we should review this text as well but for now I've just fixed the styling.
