### PR TITLE
Strip query strings when extracting Facebook/Instagram usernames

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -275,21 +275,23 @@ class Person(models.Model):
 
     @property
     def facebook_personal_username(self):
-        facebook_personal_url = self.facebook_personal_url
-        facebook_split = list(filter(None, facebook_personal_url.split("/")))
-        return facebook_split[-1]
+        return self._username_from_url(self.facebook_personal_url)
 
     @property
     def facebook_username(self):
-        facebook_page_url = self.facebook_page_url
-        facebook_split = list(filter(None, facebook_page_url.split("/")))
-        return facebook_split[-1]
+        return self._username_from_url(self.facebook_page_url)
 
     @property
     def instagram_username(self):
-        instagram_url = self.instagram_url
-        instagram_split = list(filter(None, instagram_url.split("/")))
-        return instagram_split[-1]
+        return self._username_from_url(self.instagram_url)
+
+    @staticmethod
+    def _username_from_url(url):
+        # Pull the last path segment, ignoring any query string or fragment.
+        # Otherwise a URL like https://m.facebook.com/Tony.Blair/?locale=en_GB
+        # would render as "?locale=en_GB" (see #2356).
+        path_parts = list(filter(None, urlparse(url).path.split("/")))
+        return path_parts[-1] if path_parts else ""
 
     @property
     def linkedin_username(self):

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -49,6 +49,14 @@ class TestPersonModel(TestCase):
         )
         assert self.person.facebook_username == "vicky4chelmsford"
 
+    def test_facebook_username_strips_query_string(self):
+        # Regression for #2356: a URL with a query string used to render as
+        # "?locale=en_GB" because split("/") picked up the query.
+        self.person.facebook_page_url = (
+            "https://m.facebook.com/Tony.Blair/?locale=en_GB"
+        )
+        assert self.person.facebook_username == "Tony.Blair"
+
     def test_instagram_username(self):
         self.person.instagram_url = "https://www.instagram.com/vickyfordmp"
         assert self.person.instagram_username == "vickyfordmp"


### PR DESCRIPTION
Per @edent's #2356. `facebook_username`, `facebook_personal_username`, and `instagram_username` were splitting the raw URL on `/` and taking the last segment, so a URL like `https://m.facebook.com/Tony.Blair/?locale=en_GB` rendered as `?locale=en_GB` instead of `Tony.Blair`.

Pulled the three implementations into a small `_username_from_url` helper that runs the URL through `urlparse(...).path` first (mirroring what `linkedin_username` already does) so query strings and fragments get dropped. Added a regression test using the exact URL from the issue.

Closes #2356.