### PR TITLE
Clear emblem_url when a party drops its emblem upstream

### DIFF
--- a/wcivf/apps/parties/models.py
+++ b/wcivf/apps/parties/models.py
@@ -21,8 +21,12 @@ class PartyManager(models.Manager):
             "nations": party["nations"],
         }
 
+        # Always set emblem_url so a party that drops its emblem upstream
+        # doesn't keep showing the old one (see #2295).
         if party["default_emblem"]:
             defaults["emblem_url"] = party["default_emblem"]["image"]
+        else:
+            defaults["emblem_url"] = None
 
         party_obj, _ = self.update_or_create(
             party_id=party["legacy_slug"], defaults=defaults

--- a/wcivf/apps/parties/tests/test_import_parties.py
+++ b/wcivf/apps/parties/tests/test_import_parties.py
@@ -53,3 +53,13 @@ class PartyImporterTests(TmpMediaRootMixin, TestCase):
             party.emblem_url,
             "https://static-candidates.democracyclub.org.uk/media/cache/bf/63/bf63d47b577cfe1c8cf69a469830a847.jpg",
         )
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/test_party_import.yaml")
+    def test_emblem_cleared_when_party_drops_it_upstream(self):
+        party_data = json.loads(SINGLE_PARTY_JSON)
+        Party.objects.update_or_create_from_ynr(party_data)
+        self.assertTrue(Party.objects.first().emblem_url)
+
+        party_data["default_emblem"] = None
+        Party.objects.update_or_create_from_ynr(party_data)
+        self.assertIsNone(Party.objects.first().emblem_url)


### PR DESCRIPTION
Closes #2295.

`update_or_create_from_ynr` only set `emblem_url` when YNR had a `default_emblem` block. When a party loses its emblem on the EC register, the old image kept rendering on the party detail page (as in the @pmk01 screenshot from Birmingham Community Independents). Always assign the field (`None` when there's no emblem) so `update_or_create` actually writes the clear.

Added a regression test that imports a party with an emblem, drops it on a re-import, and asserts the field gets cleared.