### PR TITLE
Sweep up stale wikipedia_bio rows in the daily import

### DIFF
--- a/wcivf/apps/people/management/commands/import_wikipedia_bios.py
+++ b/wcivf/apps/people/management/commands/import_wikipedia_bios.py
@@ -36,6 +36,14 @@ class Command(BaseCommand):
             except RequestException:
                 pass
 
+        # Clear bios that were imported from a Wikipedia URL that's since been
+        # removed on YNR. New saves already trigger Person.save's url-aware
+        # clear, but rows that haven't been resynced since the URL was dropped
+        # still have stale text hanging around (see #2319).
+        Person.objects.filter(
+            wikipedia_url__isnull=True, wikipedia_bio__isnull=False
+        ).update(wikipedia_bio=None)
+
     def update_ballots(self, current):
         parl_ballots = PostElection.objects.filter(
             ballot_paper_id__startswith="parl."


### PR DESCRIPTION
Refs #2319.

`Person.save` clears `wikipedia_bio` when `wikipedia_url` is blank (added in #2347), so going forward a sync that drops the URL also drops the bio. But anything that hasn't been re-saved since that fix landed still has the old extract in the database, which is what @GeoWill flagged on the issue.

Tacked a small `Person.objects.filter(...).update(wikipedia_bio=None)` onto the end of `update_people` in `import_wikipedia_bios` so the daily Lambda picks them up on its next run.