### PR TITLE
run 2 instances in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,9 +346,9 @@ workflows:
       - code_deploy:
           name: code_deploy_production
           dc-environment: production
-          min-size: 1
+          min-size: 2
           max-size: 20
-          desired-capacity: 1
+          desired-capacity: 2
           requires:
           - build_and_test
           - sam_deploy_staging


### PR DESCRIPTION
Turns out WCIVF is still processing a weirdly large amount of traffic.
One of these is too much of a stretch