### PR TITLE
show_data_on_error: catch Exception, not BaseException

### DIFF
--- a/wcivf/apps/core/helpers.py
+++ b/wcivf/apps/core/helpers.py
@@ -24,7 +24,7 @@ def show_data_on_error(variable_name, data):
 
     try:
         yield
-    except:
+    except Exception:
         message = "An exception was thrown while processing {0}:"
         print(message.format(variable_name))
         print(json.dumps(data, indent=4, sort_keys=True))


### PR DESCRIPTION
The context manager only wants to dump the offending data when the wrapped block raises an error. `Ctrl+C` and `SystemExit` shouldn't trigger the JSON dump on the way out, they should just propagate.