### PR TITLE
Prioritise our UV over the UV pre-installed in the SAM image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,16 @@ jobs:
 
   sam_build:
     docker:
-      - image: public.ecr.aws/sam/build-python3.12:1.158
+      - image: public.ecr.aws/sam/build-python3.12:latest
     working_directory: ~/repo
     steps:
       - checkout
       - run:
           name: Install UV
           command: deploy/files/scripts/install-uv.sh
+      - run:
+          name: Prioritise our UV over the UV pre-installed in the SAM image
+          command: echo 'export PATH=/var/lang/bin:$PATH' >> "$BASH_ENV"
       - run:
           name: sam build
           command: |
@@ -117,7 +120,7 @@ jobs:
 
   sam_deploy:
     docker:
-      - image: public.ecr.aws/sam/build-python3.12:1.158
+      - image: public.ecr.aws/sam/build-python3.12:latest
     working_directory: ~/repo
     parameters:
       dc-environment:


### PR DESCRIPTION
Here's an explanation of the problem:
https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2399#discussion_r3333562216

In #2399 I fixed this temporarily by just pinning to an old version of the docker image.
In this PR I've gone back to the `:latest` tag but fixed it so that "our" version of UV takes priority over the one that comes pre-installed.

I've tested this deploys cleanly to dev

Assuming we are happy with this, I will apply the same fix on our other projects that use the `public.ecr.aws/sam/build-python3.12` image