### PR TITLE
WAF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,11 @@ jobs:
       - run:
           name: deploy
           command: |
+            WEB_ACL_ARN=$(aws cloudformation describe-stacks \
+                --stack-name WCIVFWaf \
+                --region us-east-1 \
+                --query "Stacks[0].Outputs[?OutputKey=='WebACLArn'].OutputValue" \
+                --output text)
             sam deploy \
                 --no-confirm-changeset \
                 --config-file ~/repo/samconfig.toml \
@@ -181,7 +186,8 @@ jobs:
                    SubnetIdsParameter=<<parameters.subnet-ids>> \
                    SSLCertificateArn=<<parameters.ssl-certificate-arn>> \
                    InstanceType='<<parameters.instance-type>>' \
-                   Domain='<<parameters.domain>>'
+                   Domain='<<parameters.domain>>' \
+                   WebACLArn='$WEB_ACL_ARN'
                   "
   post_deploy_tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,19 @@ jobs:
           at: ~/repo/
       - run: echo <<parameters.instance-type>>
       - run:
+          name: deploy CloudFront WAF (us-east-1)
+          # CloudFront-scoped WAFv2 resources MUST live in us-east-1, so the
+          # WAF is a separate stack from the main app (which deploys to
+          # eu-west-2). It is plain CloudFormation - no SAM build artifacts -
+          # so it deploys straight from the checked-out template.
+          command: |
+            aws cloudformation deploy \
+                --template-file ~/repo/waf-template.yaml \
+                --stack-name WCIVFWaf \
+                --region us-east-1 \
+                --no-fail-on-empty-changeset \
+                --tags dc-environment="$DC_ENVIRONMENT" dc-product=wcivf CreatedVia=CloudFormation
+      - run:
           name: deploy
           command: |
             sam deploy \

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -68,6 +68,17 @@ Parameters:
     Description: "API key used to import data from YNR"
     Type: String
 
+  WebACLArn:
+    Description: >
+      ARN of the CloudFront WAF WebACL (from the WebACLArn output of
+      waf-template.yaml, deployed separately in us-east-1). Leave blank to
+      deploy without WAF protection attached.
+    Type: String
+    Default: ""
+
+Conditions:
+  HasWebAcl: !Not [!Equals [!Ref WebACLArn, ""]]
+
 Resources:
   WCIVFControllerFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
@@ -308,6 +319,9 @@ Resources:
                 HeaderValue: https
 
         Enabled: true
+        # CloudFront WAF WebACL (scope CLOUDFRONT, lives in us-east-1).
+        # Defined in waf-template.yaml and passed in via the WebACLArn parameter.
+        WebACLId: !If [HasWebAcl, !Ref WebACLArn, !Ref "AWS::NoValue"]
         HttpVersion: 'http2'
         Aliases:
           - !Ref Domain

--- a/waf-template.yaml
+++ b/waf-template.yaml
@@ -1,0 +1,235 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  WCIVF WAF
+
+  Simple bot-protection Web ACL for the WCIVF CloudFront distribution.
+
+  IMPORTANT: CloudFront-scoped WAFv2 resources MUST be created in us-east-1,
+  regardless of which region the main application stack is deployed to. This
+  template is therefore deployed as a SEPARATE stack in us-east-1, and its
+  output WebACL ARN is passed into the main sam-template.yaml as the
+  `WebACLArn` parameter.
+
+  This is a direct port of the CDK WafStack used by yournextrepresentative
+  (cdk/stack/waf.py) - same rules, same blocks, same managed rule overrides.
+
+  Tagging is applied at the stack level via the deploy command's `--tags`
+  flag (dc-environment / dc-product / CreatedVia) and propagates to every
+  resource here, so the resources themselves carry no Tags blocks.
+
+Resources:
+
+  # WAF regex pattern sets are capped at 10 patterns each, so the list of
+  # known bot user-agent substrings is split across several sets and combined
+  # with an OrStatement in the known-bots rule below.
+  KnownBotsPatternSet0:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet0
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "pcore-http/v0.24.5"
+        - "semrushbot"
+        - "megaindex.ru"
+        - "mj12bot"
+        - "ahrefsbot"
+        - "sogou"
+        - "mauibot"
+        - "gofeed"
+        - "msnbot"
+        - "aspiegelbot"
+
+  KnownBotsPatternSet1:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet1
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "yandex"
+        - "goodbot"
+        - "seekport"
+        - "barkrowler"
+        - "screaming frog"
+        - "petalbot"
+        - "dataforsebot"
+        - "codemantra"
+        - "scrapy"
+        - "dotbot"
+
+  KnownBotsPatternSet2:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet2
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "homeassistant"
+        - "seokicks"
+        - "okhttp"
+        - "blexbot"
+        - "turnitin"
+        - "anthropic-ai"
+        - "bytespider"
+        - "go-http-client"
+        - "gptbot"
+        - "fidget-spinner-bot"
+
+  KnownBotsPatternSet3:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet3
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "thesis-research-bot"
+        - "backgroundshortcutrunner"
+        - "amazonbot"
+        - "claudebot"
+        - "happywing"
+        - "googleother"
+        - "aiohttp"
+        - "imagesiftbot"
+        - "oai-searchbot"
+        - "friendlycrawler"
+
+  KnownBotsPatternSet4:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet4
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "timpibot"
+        - "awariobot"
+        - "meta-externalagent"
+        - "serpstatbot"
+        - "yisoupspider"
+        - "google-cloudvertexbot"
+        - "lanai"
+        - "baiduspider"
+        - "webscanner"
+        - "perplexity"
+
+  KnownBotsPatternSet5:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: KnownBotsPatternSet5
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "findfiles.net"
+        - "headlesschrome"
+        - "amazon-quick"
+        - "sleepbot"
+        - "seamus the search engine"
+
+  SimpleBotProtectionWAF:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: SimpleBotProtectionWAF
+      Scope: CLOUDFRONT
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: SimpleBotProtectionWAF
+        SampledRequestsEnabled: true
+      Rules:
+        # Rate limiting rule: 500 requests per 5 min per IP
+        - Name: RateLimitRule
+          Priority: 1
+          Action:
+            Block: {}
+          Statement:
+            RateBasedStatement:
+              Limit: 500
+              AggregateKeyType: IP
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: RateLimitRule
+            SampledRequestsEnabled: true
+
+        # AWS managed common rule set, run in count (monitor) mode. The
+        # SizeRestrictions_BODY sub-rule is also forced to count.
+        - Name: AWSCommonRuleSet
+          Priority: 100
+          OverrideAction:
+            Count: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              RuleActionOverrides:
+                - Name: SizeRestrictions_BODY
+                  ActionToUse:
+                    Count: {}
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSCommonRuleSet
+            SampledRequestsEnabled: true
+
+        # Block known bots and scrapers by user-agent (returns 418)
+        - Name: known-bots
+          Priority: 101
+          Action:
+            Block:
+              CustomResponse:
+                ResponseCode: 418
+          Statement:
+            OrStatement:
+              Statements:
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet0.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet1.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet2.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet3.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet4.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+                - RegexPatternSetReferenceStatement:
+                    Arn: !GetAtt KnownBotsPatternSet5.Arn
+                    FieldToMatch:
+                      SingleHeader:
+                        Name: user-agent
+                    TextTransformations:
+                      - Priority: 0
+                        Type: LOWERCASE
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: known-bots
+            SampledRequestsEnabled: true
+
+Outputs:
+  WebACLArn:
+    Description: "ARN of the CloudFront WAF WebACL. Pass this as the WebACLArn parameter to sam-template.yaml."
+    Value: !GetAtt SimpleBotProtectionWAF.Arn
+    Export:
+      Name: WCIVFWebAclArn

--- a/waf-template.yaml
+++ b/waf-template.yaml
@@ -131,6 +131,30 @@ Resources:
         MetricName: SimpleBotProtectionWAF
         SampledRequestsEnabled: true
       Rules:
+        # Allow traffic to the candidates-for-ballots API. DemocracyClub's
+        # BallotCacheWriter polls this endpoint every couple of minutes with a
+        # default python-requests user-agent, and the endpoint is CachingDisabled
+        # on CloudFront. Evaluated first (priority 0) so matching requests are
+        # exempt from BOTH the rate-limit and known-bots rules below.
+        # NOTE: this exempts ALL traffic to this path, not only BallotCacheWriter.
+        - Name: allow-candidates-for-ballots
+          Priority: 0
+          Action:
+            Allow: {}
+          Statement:
+            ByteMatchStatement:
+              FieldToMatch:
+                UriPath: {}
+              PositionalConstraint: STARTS_WITH
+              SearchString: /api/candidates_for_ballots/
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: allow-candidates-for-ballots
+            SampledRequestsEnabled: true
+
         # Rate limiting rule: 500 requests per 5 min per IP
         - Name: RateLimitRule
           Priority: 1


### PR DESCRIPTION
Disclosure: I did about 90% of this with Claude Code / Opus 4.8. On a new branch, I prompted:

> This project deploys to AWS using SAM. See @sam-template.yaml. It uses CloudFront, and I want to install Web Application Firewall in front of it to stop bot traffic. Please read @../yournextrepresentative/cdk/stack/waf.py and copy that implementation from CDK into SAM. I want the same rules, features and  blocks as that application uses, but defined here in SAM's YAML. If possible, please make this using a new template YMAL that's included in the main one, but ignore this if that's complex. I just want maintainable code.

After some thinking it came back with:

>  This confirms the architecture. The key finding: YNR deploys the WAF as a completely separate stack in us-east-1 (cdk/app.py:42), and passes the resulting ARN into the CloudFront distribution. This is mandatory — CloudFront-scoped WAFv2 WebACLs must live in us-east-1, but this SAM stack deploys to eu-west-2 (samconfig.toml).
> 
>   That means a nested/included stack won't work — a nested stack inherits the parent's region (eu-west-2), which a CLOUDFRONT scope WAF rejects. So the maintainable equivalent of the CDK setup is: a standalone waf-template.yaml deployed to us-east-1, with its WebACL ARN wired into the main template's CloudFront distribution via a parameter. Let me build that.

I'll not paste the whole chat here, but there was some follow up to get it to change tagging. I then asked it to update CircleCI so that WAF deploys with that. 

I did a dev deploy (manually changing the branch). I needed to update some IAM permissions on the dev account. I've not done this on the other accounts, but I can do before deploying. 

---

## My review of Claude's performance:

I'm sort of over being impressed by this any more, but the whole thing took about 5 minutes from initial prompt to the first two commits here. Faffing about with IAM took a bit longer. This was helped by the fact that the deploys are very similar (in terms of the CloudFront passing on to an ALB, not in terms of YNR's ECS deployment). 

The LLM work was to convert one concept in one language to the same concept in another, and this is something I'd expect them to be fast at. 

I've read the code, and done a deploy. There are more comments than I'd have written, but that's no bad thing. I think it's about as understandable and maintainable as anything I'd have written (everyone loves YAML, afterall).  

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215579151691311