### PR TITLE
remove uk-election-timetables library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "dc-logging-utils",
     "djangorestframework-jsonp==1.0.2",
     "feedparser==6.0.10",
-    "uk-election-timetables==5.0.0",
     "uk-election-ids==0.10.1",
     "django-dotenv==1.4.2",
     "akismet==24.5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1350,15 +1350,6 @@ wheels = [
 ]
 
 [[package]]
-name = "uk-election-timetables"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/06/34e1ad5f782b6e72f56d3d950d7f364dfe1554362aff7d218f494218ff7f/uk_election_timetables-5.0.0.tar.gz", hash = "sha256:f6d6db174d9e0fcc9a29a8167047530b6d7b93a27af4958c0195fa293e307fba", size = 20743, upload-time = "2026-07-08T08:14:15.173Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/8a/1220516bc7c3fe46b5dce6d7a8b67bf601e3c5d1757a9e66a2f804b8ba41/uk_election_timetables-5.0.0-py3-none-any.whl", hash = "sha256:3f85d746b7778bb8b901b1cce0dd92b16592d5fe5a3f7ce2c5c6ebd2ceb71d28", size = 23120, upload-time = "2026-07-08T08:14:14.084Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1476,7 +1467,6 @@ dependencies = [
     { name = "requests", marker = "platform_python_implementation == 'CPython'" },
     { name = "slacker2", marker = "platform_python_implementation == 'CPython'" },
     { name = "uk-election-ids", marker = "platform_python_implementation == 'CPython'" },
-    { name = "uk-election-timetables", marker = "platform_python_implementation == 'CPython'" },
 ]
 
 [package.dev-dependencies]
@@ -1531,7 +1521,6 @@ requires-dist = [
     { name = "requests", specifier = "==2.33.0" },
     { name = "slacker2", specifier = ">=22.8.4" },
     { name = "uk-election-ids", specifier = "==0.10.1" },
-    { name = "uk-election-timetables", specifier = "==5.0.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/wcivf/apps/elections/migrations/0054_backfill_postelection_timetable_fields.py
+++ b/wcivf/apps/elections/migrations/0054_backfill_postelection_timetable_fields.py
@@ -1,84 +1,4 @@
 from django.db import migrations
-from uk_election_timetables.calendars import Country
-from uk_election_timetables.election_ids import (
-    InvalidElectionIdError,
-    from_election_id,
-)
-
-country_map = {
-    "ENG": Country.ENGLAND,
-    "SCT": Country.SCOTLAND,
-    "WLS": Country.WALES,
-    "NIR": Country.NORTHERN_IRELAND,
-}
-
-
-def backfill_timetable_fields(apps, schema_editor):
-    PostElection = apps.get_model("elections", "PostElection")
-
-    qs = (
-        PostElection.objects.using(schema_editor.connection.alias)
-        # We don't have logic for computing timetable for
-        # EU Parliament elections but some do exist in the DB
-        # from back in the day
-        .exclude(ballot_paper_id__startswith="europarl.")
-        # There is no nominations or SOPN for referenda
-        # Notice of election deadline is applicable
-        # but not implemented
-        .exclude(ballot_paper_id__startswith="ref.")
-        .select_related("post")
-    )
-
-    ballots_to_update = []
-
-    for ballot in qs.iterator():
-        try:
-            timetable = from_election_id(
-                ballot.ballot_paper_id,
-                country=country_map[ballot.post.territory],
-            )
-        except InvalidElectionIdError:
-            # Some really old elections in WCIVF don't have a EE ballot ID
-            continue
-
-        ballot.notice_of_election_deadline = (
-            timetable.notice_of_election_deadline
-        )
-        ballot.close_of_nominations = timetable.close_of_nominations
-        ballot.sopn_publish_deadline = timetable.sopn_publish_deadline
-        ballot.registration_deadline = timetable.registration_deadline
-        ballot.postal_vote_application_deadline = (
-            timetable.postal_vote_application_deadline
-        )
-        if ballot.requires_voter_id == "EA-2022":
-            ballot.vac_application_deadline = timetable.vac_application_deadline
-        ballots_to_update.append(ballot)
-
-    batch_size = 2000
-    for i in range(0, len(ballots_to_update), batch_size):
-        qs.bulk_update(
-            ballots_to_update[i : i + batch_size],
-            [
-                "notice_of_election_deadline",
-                "close_of_nominations",
-                "sopn_publish_deadline",
-                "registration_deadline",
-                "postal_vote_application_deadline",
-                "vac_application_deadline",
-            ],
-        )
-
-
-def clear_timetable_fields(apps, schema_editor):
-    PostElection = apps.get_model("elections", "PostElection")
-    PostElection.objects.using(schema_editor.connection.alias).update(
-        notice_of_election_deadline=None,
-        close_of_nominations=None,
-        sopn_publish_deadline=None,
-        registration_deadline=None,
-        postal_vote_application_deadline=None,
-        vac_application_deadline=None,
-    )
 
 
 class Migration(migrations.Migration):
@@ -87,5 +7,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(backfill_timetable_fields, clear_timetable_fields)
+        migrations.RunPython(
+            migrations.RunPython.noop, migrations.RunPython.noop
+        )
     ]


### PR DESCRIPTION
~:warning: This PR targets `timetables20260715` not `master` :warning:~

This follow on from https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2414
After we've applied the data backfill in all the environments we care about, we can then remove the timetables lib from this repo