### PR TITLE
don't extract username from facebook links like profile.php?id=123

### DIFF
--- a/wcivf/apps/people/models.py
+++ b/wcivf/apps/people/models.py
@@ -275,12 +275,16 @@ class Person(models.Model):
 
     @property
     def facebook_personal_username(self):
+        if "profile.php" in self.facebook_personal_url:
+            return self.facebook_personal_url
         return (
             urlparse(self.facebook_personal_url).path.rstrip("/").split("/")[-1]
         )
 
     @property
     def facebook_username(self):
+        if "profile.php" in self.facebook_page_url:
+            return self.facebook_page_url
         return urlparse(self.facebook_page_url).path.rstrip("/").split("/")[-1]
 
     @property

--- a/wcivf/apps/people/tests/test_person_models.py
+++ b/wcivf/apps/people/tests/test_person_models.py
@@ -59,6 +59,11 @@ class TestPersonModel(TestCase):
                 "https://www.facebook.com/vicky.ford.142#about",
                 "vicky.ford.142",
             ),
+            (
+                "legacy URL style",
+                "https://www.facebook.com/profile.php?id=123",
+                "https://www.facebook.com/profile.php?id=123",
+            ),
         ]
         for label, url, expected in test_cases:
             with self.subTest(msg=label):
@@ -88,6 +93,11 @@ class TestPersonModel(TestCase):
                 "with fragment",
                 "https://www.facebook.com/vicky4chelmsford#about",
                 "vicky4chelmsford",
+            ),
+            (
+                "legacy URL style",
+                "https://www.facebook.com/profile.php?id=123",
+                "https://www.facebook.com/profile.php?id=123",
             ),
         ]
         for label, url, expected in test_cases:


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1216518099220461?focus=true

Examples:
- https://whocanivotefor.co.uk/person/136274/sian-niamh-astley
- https://whocanivotefor.co.uk/person/6223/phil-eckersley

If the URL we hold is like https://www.facebook.com/profile.php?id=100089602928348 we can't extract a username, so just present the raw URL