### PR TITLE
Don't cache last-updated API endpoint

### DIFF
--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -357,6 +357,16 @@ Resources:
             # AWS Managed: AllViewerExceptHostHeader
             OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
 
+          # Don't cache the last-updated-timestamps endpoint
+          - PathPattern: api/last-updated-timestamps/*
+            AllowedMethods: [ GET, HEAD, OPTIONS ]
+            TargetOriginId: Dynamic
+            ViewerProtocolPolicy: redirect-to-https
+            # AWS Managed: CachingDisabled
+            CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+            # AWS Managed: AllViewerExceptHostHeader
+            OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac
+
           - AllowedMethods: [ GET, HEAD, OPTIONS ]
             PathPattern: static/*
             TargetOriginId: Static


### PR DESCRIPTION
This is a debugging endpoint, but also I'm moving updown to call this. 

Not caching an endpoint opens the risk of a DoS attack against it, but as we have WAF in front of this application limiting to 100 requests a minute, the impact of not caching this is small. 

